### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# cpp code owners
+cpp/               @rapidsai/cuspatial-cpp-codeowners
+
+# python code owners
+python/            @rapidsai/cuspatial-python-codeowners
+
+# cmake code owners
+**/CMakeLists.txt  @rapidsai/cuspatial-cmake-codeowners
+**/cmake/          @rapidsai/cuspatial-cmake-codeowners
+
+# java code owners
+java/              @rapidsai/cuspatial-java-codeowners
+
+# build/ops code owners
+.github/           @rapidsai/cuspatial-ops-codeowners 
+ci/                @rapidsai/cuspatial-ops-codeowners
+conda/             @rapidsai/cuspatial-ops-codeowners
+**/Dockerfile      @rapidsai/cuspatial-ops-codeowners
+**/.dockerignore   @rapidsai/cuspatial-ops-codeowners
+docker/            @rapidsai/cuspatial-ops-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Improvements
 
+- #31 Add Github CODEOWNERS
+
 ## Bug Fixes
 
 - PR #16 `cuspatial::subset_trajectory_id()` test improvements and bug fixes


### PR DESCRIPTION
Adds a GitHub CODEOWNERS file. 

@dillon-cullinan please create the following initial groups in the rapidsai Org (can expand as needed)

`@rapidsai/cuspatial-cpp-codeowners`: @harrism @jrhemstad 
`@rapidsai/cuspatial-python-codeowners`: @thomcom @kkraus14 
`@rapidsai/cuspatial-cmake-codeowners`: @harrism @thomcom @kkraus14 
`@rapidsai/cuspatial-java-codeowners`: @revans2 @jlowe 
`@rapidsai/cuspatial-ops-codeowners`: Same as `@rapidsai/cudf-ops-codeowners` or what you think is appropriate.