### PR TITLE
Update all demos with python API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #31 Add Github CODEOWNERS
 - PR #39 Add cython headers to install, python / cmake packaging cleanup
 - PR #41 Python and Cython style cleanup, pre-commit hook
+- PR #44 Update all demos with Python API
 
 ## Bug Fixes
 

--- a/python/cuspatial/demos/hausdorff_clustering_test_toy.py
+++ b/python/cuspatial/demos/hausdorff_clustering_test_toy.py
@@ -13,9 +13,9 @@ conda-forge scipy scikit-learn` under cudf_dev environment
 import numpy as np
 from sklearn.cluster import DBSCAN, AgglomerativeClustering
 
-from cudf.core import column
+from cudf import Series
 
-import cuspatial._lib.spatial as gis
+import cuspatial
 
 in_trajs = []
 in_trajs.append(np.array([[1, 0], [2, 1], [3, 2], [5, 3], [7, 1]]))
@@ -27,10 +27,10 @@ py_y = np.array(out_trajs[:, 1])
 py_cnt = []
 for traj in in_trajs:
     py_cnt.append(len(traj))
-pnt_x = column.as_column(py_x, dtype=np.float64)
-pnt_y = column.as_column(py_y, dtype=np.float64)
-cnt = column.as_column(py_cnt, dtype=np.int32)
-distance = gis.cpp_directed_hausdorff_distance(pnt_x, pnt_y, cnt)
+pnt_x = Series(py_x)
+pnt_y = Series(py_y)
+cnt = Series(py_cnt)
+distance = cuspatial.directed_hausdorff_distance(pnt_x, pnt_y, cnt)
 
 num_set = len(cnt)
 matrix = distance.data.to_array().reshape(num_set, num_set)

--- a/python/cuspatial/demos/hausdorff_distance_verify_locust256.py
+++ b/python/cuspatial/demos/hausdorff_distance_verify_locust256.py
@@ -13,8 +13,7 @@ import time
 import numpy as np
 from scipy.spatial.distance import directed_hausdorff
 
-import cuspatial._lib.soa_readers as readers
-import cuspatial._lib.spatial as gis
+import cuspatial
 
 data_dir = "/home/jianting/trajcode/"
 data_set = "locust256"
@@ -30,18 +29,18 @@ if len(sys.argv) >= 2:
     data_set = sys.argv[1]
 
 # reading poing xy coordinate data (relative to a camera origin)
-pnt_x, pnt_y = readers.cpp_read_pnt_xy_soa(data_dir + data_set + ".coor")
+pnt_x, pnt_y = cuspatial.read_points_xy_km(data_dir + data_set + ".coor")
 # reading numbers of points in trajectories
-cnt = readers.cpp_read_uint_soa(data_dir + data_set + ".objcnt")
+cnt = cuspatial.read_uint(data_dir + data_set + ".objcnt")
 # reading object(vehicle) id
-id = readers.cpp_read_uint_soa(data_dir + data_set + ".objectid")
+id = cuspatial.read_uint(data_dir + data_set + ".objectid")
 
 num_traj = cnt.data.size
-dist0 = gis.cpp_directed_hausdorff_distance(pnt_x, pnt_y, cnt)
+dist0 = cuspatial.directed_hausdorff_distance(pnt_x, pnt_y, cnt)
 cuspatial_dist0 = dist0.data.to_array().reshape((num_traj, num_traj))
 
 start = time.time()
-dist = gis.cpp_directed_hausdorff_distance(pnt_x, pnt_y, cnt)
+dist = cuspatial.directed_hausdorff_distance(pnt_x, pnt_y, cnt)
 print(
     "dis.size={} num_traj*num_traj={}".format(
         dist.data.size, num_traj * num_traj

--- a/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
+++ b/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
@@ -7,9 +7,7 @@ import cuspatial
 start = time.time()
 # data dowloaded from
 # https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2009-01.csv
-df = read_csv(
-    "data/yellow_tripdata_2009-01.csv"
-)
+df = read_csv("data/yellow_tripdata_2009-01.csv")
 end = time.time()
 print("data ingesting time (from SSD) in ms={}".format((end - start) * 1000))
 df.head().to_pandas().columns

--- a/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
+++ b/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
@@ -1,25 +1,25 @@
 import time
 
-import cudf
-from cudf.core import column
+from cudf import Series
+from cudf import read_csv
 
-import cuspatial._lib.spatial as gis
+import cuspatial
 
 start = time.time()
 # data dowloaded from
 # https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2009-01.csv
-df = cudf.read_csv(
-    "/home/jianting/hardbd19/data/nyctaxi/yellow_tripdata_2009-01.csv"
+df = read_csv(
+    "data/yellow_tripdata_2009-01.csv"
 )
 end = time.time()
 print("data ingesting time (from SSD) in ms={}".format((end - start) * 1000))
 df.head().to_pandas().columns
 
 start = time.time()
-x1 = column.as_column(df["Start_Lon"])
-y1 = column.as_column(df["Start_Lat"])
-x2 = column.as_column(df["End_Lon"])
-y2 = column.as_column(df["End_Lat"])
+x1 = Series(df["Start_Lon"])
+y1 = Series(df["Start_Lat"])
+x2 = Series(df["End_Lon"])
+y2 = Series(df["End_Lat"])
 end = time.time()
 print(
     "data frame to gdf column conversion time in ms={}".format(
@@ -28,7 +28,7 @@ print(
 )
 
 start = time.time()
-h_dist = gis.cpp_haversine_distance(x1, y1, x2, y1)
+h_dist = cuspatial.haversine_distance(x1, y1, x2, y2)
 end = time.time()
 print("python computing distance time in ms={}".format((end - start) * 1000))
 # h_dist.data.to_array()

--- a/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
+++ b/python/cuspatial/demos/haversine_distance_test_nyctaxi.py
@@ -1,7 +1,6 @@
 import time
 
-from cudf import Series
-from cudf import read_csv
+from cudf import Series, read_csv
 
 import cuspatial
 

--- a/python/cuspatial/demos/pip_verify_shapely_locust.py
+++ b/python/cuspatial/demos/pip_verify_shapely_locust.py
@@ -10,8 +10,7 @@ import time
 import shapefile
 from shapely.geometry import Point, Polygon
 
-import cuspatial._lib.soa_readers as readers
-import cuspatial._lib.spatial as gis
+import cuspatial
 
 data_dir = "/home/jianting/cuspatial/data/"
 plyreader = shapefile.Reader(data_dir + "its_4326_roi.shp")
@@ -20,13 +19,13 @@ plys = []
 for shape in polygon:
     plys.append(Polygon(shape.points))
 
-pnt_lon, pnt_lat = readers.cpp_read_pnt_lonlat_soa(
-    data_dir + "locust.location"
-)
-fpos, rpos, plyx, plyy = readers.cpp_read_ply_soa(data_dir + "itsroi.ply")
+pnt_lon, pnt_lat = cuspatial.read_points_lonlat(data_dir + "locust.location")
+fpos, rpos, plyx, plyy = cuspatial.read_polygon(data_dir + "itsroi.ply")
 
 start = time.time()
-bm = gis.cpp_pip_bm(pnt_lon, pnt_lat, fpos, rpos, plyx, plyy)
+bm = cuspatial.point_in_polygon_bitmap(
+    pnt_lon, pnt_lat, fpos, rpos, plyx, plyy
+)
 end = time.time()
 print("Python GPU Time in ms (end-to-end)={}".format((end - start) * 1000))
 

--- a/python/cuspatial/demos/stq_test_soa_locust.py
+++ b/python/cuspatial/demos/stq_test_soa_locust.py
@@ -4,22 +4,20 @@ and (x1,x2,y1,y2)=[-180,180,-90,90] as the query window num should be the same
 as x.data.size, both are 1338671
 """
 
-import numpy as np
+import cuspatial
 
-import cuspatial._lib.soa_readers as readers
-import cuspatial._lib.stq as stq
-
-data_dir = "/home/jianting/cuspatial/data/"
-pnt_lon, pnt_lat = readers.cpp_read_pnt_lonlat_soa(
+data_dir = "./data/"
+data = cuspatial.read_points_lonlat(
     data_dir + "locust.location"
 )
-num, nlon, nlat = stq.cpp_sw_xy(
-    np.double(-180),
-    np.double(180),
-    np.double(-90),
-    np.double(90),
-    pnt_lon,
-    pnt_lat,
+
+points_inside = cuspatial.window_points(
+    -180,
+    -90,
+    180,
+    90,
+    data['lon'],
+    data['lat'],
 )
-print(num)
-print(pnt_lon.data.size)
+print(points_inside.shape[0])
+assert points_inside.shape[0] == data.shape[0]

--- a/python/cuspatial/demos/stq_test_soa_locust.py
+++ b/python/cuspatial/demos/stq_test_soa_locust.py
@@ -7,17 +7,10 @@ as x.data.size, both are 1338671
 import cuspatial
 
 data_dir = "./data/"
-data = cuspatial.read_points_lonlat(
-    data_dir + "locust.location"
-)
+data = cuspatial.read_points_lonlat(data_dir + "locust.location")
 
 points_inside = cuspatial.window_points(
-    -180,
-    -90,
-    180,
-    90,
-    data['lon'],
-    data['lat'],
+    -180, -90, 180, 90, data["lon"], data["lat"]
 )
 print(points_inside.shape[0])
 assert points_inside.shape[0] == data.shape[0]

--- a/python/cuspatial/demos/traj_demo_derive_subset_locus.py
+++ b/python/cuspatial/demos/traj_demo_derive_subset_locus.py
@@ -1,0 +1,27 @@
+"""
+demo of chaining three APIs: derive_trajectories+subset_trajectory(by ID)+hausdorff_distance
+also serves as an example to integrate cudf and cuspatial
+"""
+
+import cuspatial
+
+data_dir = "./data/"
+lonlats = cuspatial.read_points_lonlat(data_dir + "locust.location")
+ids = cuspatial.read_uint(data_dir + "locust.objectid")
+ts = cuspatial.read_its_timestamps(data_dir + "locust.time")
+
+num_traj, trajectories = cuspatial.derive(
+    lonlats["lon"], lonlats["lat"], ids, ts
+)
+df = trajectories.query("length>=256")
+query_ids = df["trajectory_id"]
+query_cnts = df["length"]
+new_trajs = cuspatial.subset_trajectory_id(
+    query_ids, lonlats["lon"], lonlats["lat"], ids, ts
+)
+new_lon = new_trajs["x"]
+new_lat = new_trajs["y"]
+num_traj = df.count()[0]
+dist = cuspatial.directed_hausdorff_distance(new_lon, new_lat, query_cnts)
+cuspatial_dist0 = dist.data.to_array().reshape((num_traj, num_traj))
+print(cuspatial_dist0)

--- a/python/cuspatial/demos/traj_demo_derive_subset_locus.py
+++ b/python/cuspatial/demos/traj_demo_derive_subset_locus.py
@@ -1,6 +1,6 @@
 """
-demo of chaining three APIs: derive_trajectories+subset_trajectory(by ID)+hausdorff_distance
-also serves as an example to integrate cudf and cuspatial
+demo of chaining three APIs: derive_trajectories+subset_trajectory(by ID)
++hausdorff_distance also serves as an example to integrate cudf and cuspatial
 """
 
 import cuspatial

--- a/python/cuspatial/demos/traj_test_soa_locust.py
+++ b/python/cuspatial/demos/traj_test_soa_locust.py
@@ -17,9 +17,7 @@ this_cam = df.loc[df["cameraIdString"] == "HWY_20_AND_LOCUST"]
 cam_lon = np.double(this_cam.iloc[0]["originLon"])
 cam_lat = np.double(this_cam.iloc[0]["originLat"])
 
-lonlats = cuspatial.read_points_lonlat(
-    data_dir + "locust.location"
-)
+lonlats = cuspatial.read_points_lonlat(data_dir + "locust.location")
 ids = cuspatial.read_uint(data_dir + "locust.objectid")
 ts = cuspatial.read_its_timestamps(data_dir + "locust.time")
 
@@ -33,17 +31,17 @@ print(out2)
 y, m, d, hh, mm, ss, wd, yd, ms, pid = tools.get_ts_struct(ts_0)
 
 xys = cuspatial.lonlat_to_xy_km_coordinates(
-    cam_lon, cam_lat, lonlats['lon'], lonlats['lat']
+    cam_lon, cam_lat, lonlats["lon"], lonlats["lat"]
 )
-num_traj, trajectories = cuspatial.derive(xys['x'], xys['y'], ids, ts)
+num_traj, trajectories = cuspatial.derive(xys["x"], xys["y"], ids, ts)
 #  = num_traj, tid, len, pos =
 y, m, d, hh, mm, ss, wd, yd, ms, pid = tools.get_ts_struct(ts_0)
 distspeed = cuspatial.distance_and_speed(
-    xys['x'], xys['y'], ts, trajectories["length"], trajectories["position"]
+    xys["x"], xys["y"], ts, trajectories["length"], trajectories["position"]
 )
 print(distspeed)
 
 boxes = cuspatial.spatial_bounds(
-    xys['x'], xys['y'], trajectories["length"], trajectories["position"]
+    xys["x"], xys["y"], trajectories["length"], trajectories["position"]
 )
 print(boxes.head())

--- a/python/cuspatial/demos/traj_test_soa_locust.py
+++ b/python/cuspatial/demos/traj_test_soa_locust.py
@@ -11,7 +11,6 @@ import pandas as pd
 import cuspatial
 import cuspatial.utils.traj_utils as tools
 
-breakpoint()
 data_dir = "./data/"
 df = pd.read_csv(data_dir + "its_camera_2.csv")
 this_cam = df.loc[df["cameraIdString"] == "HWY_20_AND_LOCUST"]

--- a/python/cuspatial/demos/traj_test_soa_locust.py
+++ b/python/cuspatial/demos/traj_test_soa_locust.py
@@ -8,22 +8,21 @@ Note: camera configuration is read from a CSV file using Panda
 import numpy as np
 import pandas as pd
 
-import cuspatial._lib.soa_readers as readers
-import cuspatial._lib.spatial as gis
-import cuspatial._lib.trajectory as traj
+import cuspatial
 import cuspatial.utils.traj_utils as tools
 
-data_dir = "./"
+breakpoint()
+data_dir = "./data/"
 df = pd.read_csv(data_dir + "its_camera_2.csv")
 this_cam = df.loc[df["cameraIdString"] == "HWY_20_AND_LOCUST"]
 cam_lon = np.double(this_cam.iloc[0]["originLon"])
 cam_lat = np.double(this_cam.iloc[0]["originLat"])
 
-pnt_lon, pnt_lat = readers.cpp_read_pnt_lonlat_soa(
+lonlats = cuspatial.read_points_lonlat(
     data_dir + "locust.location"
 )
-id = readers.cpp_read_uint_soa(data_dir + "locust.objectid")
-ts = readers.cpp_read_ts_soa(data_dir + "locust.time")
+ids = cuspatial.read_uint(data_dir + "locust.objectid")
+ts = cuspatial.read_its_timestamps(data_dir + "locust.time")
 
 # examine binary representatons
 ts_0 = ts.data.to_array()[0]
@@ -34,16 +33,18 @@ print(out2)
 
 y, m, d, hh, mm, ss, wd, yd, ms, pid = tools.get_ts_struct(ts_0)
 
-pnt_x, pnt_y = gis.cpp_lonlat2coord(cam_lon, cam_lat, pnt_lon, pnt_lat)
-num_traj, trajectories = traj.cpp_derive_trajectories(pnt_x, pnt_y, id, ts)
+xys = cuspatial.lonlat_to_xy_km_coordinates(
+    cam_lon, cam_lat, lonlats['lon'], lonlats['lat']
+)
+num_traj, trajectories = cuspatial.derive(xys['x'], xys['y'], ids, ts)
 #  = num_traj, tid, len, pos =
 y, m, d, hh, mm, ss, wd, yd, ms, pid = tools.get_ts_struct(ts_0)
-dist, speed = traj.cpp_trajectory_distance_and_speed(
-    pnt_x, pnt_y, ts, trajectories["length"], trajectories["position"]
+distspeed = cuspatial.distance_and_speed(
+    xys['x'], xys['y'], ts, trajectories["length"], trajectories["position"]
 )
-print(dist.data.to_array()[0], speed.data.to_array()[0])
+print(distspeed)
 
-boxes = traj.cpp_trajectory_spatial_bounds(
-    pnt_x, pnt_y, trajectories["length"], trajectories["position"]
+boxes = cuspatial.spatial_bounds(
+    xys['x'], xys['y'], trajectories["length"], trajectories["position"]
 )
 print(boxes.head())


### PR DESCRIPTION
All the demos are updated with the proper API for python usage.

There's a substantial bug in `traj_test_soa_locust.py` because of the timestamps and their custom format being sent in as integers to `cudf::timestamp`. I believe this produces many nonsensical trajectory durations, and puts a lot of bad data into the final output dataframe. I'll have to write a good way to get `its_timestamps` into `cudf::timestamps`. It won't happen this afternoon.