### PR TITLE
Ordering should be lon/lat to reflect x/y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - PR #17 Update issue / PR templates
 - PR #23 Fix cudf Cython imports
 - PR #24 `cuspatial::derive_trajectories()` test improvements and bug fixes
+- PR #49 Docstring for haversine and argument ordering was backwards

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -30,15 +30,15 @@ def directed_hausdorff_distance(x, y, count):
     return cpp_directed_hausdorff_distance(x, y, count)
 
 
-def haversine_distance(p1_lat, p1_lon, p2_lat, p2_lon):
-    """ Compute the haversine distances between an arbitrary list of lat/lon
+def haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat):
+    """ Compute the haversine distances between an arbitrary list of lon/lat
     pairs
 
     params
-    p1_lat: latitude of first set of coords
     p1_lon: longitude of first set of coords
-    p2_lat: latitude of second set of coords
+    p1_lat: latitude of first set of coords
     p2_lon: longitude of second set of coords
+    p2_lat: latitude of second set of coords
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def haversine_distance(p1_lat, p1_lon, p2_lat, p2_lon):
     returns
     Series: distance between all pairs of lat/lon coords
     """
-    return cpp_haversine_distance(p1_lat, p1_lon, p2_lat, p2_lon)
+    return cpp_haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat)
 
 
 def lonlat_to_xy_km_coordinates(


### PR DESCRIPTION
We learned lat/lon in school, that's silly. Lon is change in the x coordinate, lat in change in the y coordinate. Fix the ordering for haversine. 