### PR TITLE
[BUGFIX] added missing header in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 - PR #23 Fix cudf Cython imports
 - PR #24 `cuspatial::derive_trajectories()` test improvements and bug fixes
 - PR #49 Docstring for haversine and argument ordering was backwards
+- PR #66 added missing header in tests

--- a/cpp/tests/trajectory/test_trajectory_derive.cu
+++ b/cpp/tests/trajectory/test_trajectory_derive.cu
@@ -16,7 +16,7 @@
 
 #include <vector>
 #include <gtest/gtest.h>
-
+#include <random>
 #include <tests/utilities/cudf_test_fixtures.h>
 #include <tests/utilities/column_wrapper.cuh>
 


### PR DESCRIPTION
Missing <random> header fixing compilation error for tests

One of the tests had a missing header causing compilation issue in cpp tests


