### PR TITLE
[REVIEW] Require width parameterization of bitmap to binary conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 - PR #33 `cuspatial::trajectory_distance_and_speed()` test improvements and bug fixes
 - PR #49 Docstring for haversine and argument ordering was backwards
 - PR #66 added missing header in tests
+- PR #70 Require width parameterization of bitmap to binary conversion

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -135,7 +135,9 @@ def point_in_polygon_bitmap(
         polygons_y,
     )
 
-    result_binary = gis_utils.pip_bitmap_column_to_binary_array(bitmap_result)
+    result_binary = gis_utils.pip_bitmap_column_to_binary_array(
+        polygon_bitmap_column=bitmap_result, width=len(polygon_ids)
+    )
     result_bools = DataFrame.from_gpu_matrix(
         result_binary
     )._apply_support_method("astype", dtype="bool")

--- a/python/cuspatial/cuspatial/tests/test_pip.py
+++ b/python/cuspatial/cuspatial/tests/test_pip.py
@@ -138,24 +138,24 @@ def test_dataset():
 
 def test_pip_bitmap_column_to_binary_array():
     col = cudf.Series([0, 13, 3, 9])._column
-    got = gis_utils.pip_bitmap_column_to_binary_array(col)
+    got = gis_utils.pip_bitmap_column_to_binary_array(col, width=4)
     expected = np.array(
         [[0, 0, 0, 0], [1, 1, 0, 1], [0, 0, 1, 1], [1, 0, 0, 1]], dtype="int8"
     )
     np.testing.assert_array_equal(got.copy_to_host(), expected)
 
     col = cudf.Series([])._column
-    got = gis_utils.pip_bitmap_column_to_binary_array(col)
+    got = gis_utils.pip_bitmap_column_to_binary_array(col, width=0)
     expected = np.array([], dtype="int8").reshape(0, 0)
     np.testing.assert_array_equal(got.copy_to_host(), expected)
 
     col = cudf.Series([None, None])._column
-    got = gis_utils.pip_bitmap_column_to_binary_array(col)
+    got = gis_utils.pip_bitmap_column_to_binary_array(col, width=0)
     expected = np.array([], dtype="int8").reshape(2, 0)
     np.testing.assert_array_equal(got.copy_to_host(), expected)
 
     col = cudf.Series([238, 13, 29594])._column
-    got = gis_utils.pip_bitmap_column_to_binary_array(col)
+    got = gis_utils.pip_bitmap_column_to_binary_array(col, width=15)
     expected = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0],
@@ -164,4 +164,9 @@ def test_pip_bitmap_column_to_binary_array():
         ],
         dtype="int8",
     )
+    np.testing.assert_array_equal(got.copy_to_host(), expected)
+
+    col = cudf.Series([0, 0, 0])._column
+    got = gis_utils.pip_bitmap_column_to_binary_array(col, width=3)
+    expected = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]], dtype="int8")
     np.testing.assert_array_equal(got.copy_to_host(), expected)

--- a/python/cuspatial/cuspatial/utils/gis_utils.py
+++ b/python/cuspatial/cuspatial/utils/gis_utils.py
@@ -32,21 +32,9 @@ def apply_binarize(in_col, width):
     return out
 
 
-def _find_min_bits(val):
-    if val == 0:
-        return 1
-
-    minbits = 0
-    while val > 0:
-        val = operator.rshift(val, 1)
-        minbits += 1
-    return minbits
-
-
-def pip_bitmap_column_to_binary_array(polygon_bitmap_column):
+def pip_bitmap_column_to_binary_array(polygon_bitmap_column, width):
     """Convert the bitmap output of cpp_point_in_polygon_bitmap
     to an array of 0s and 1s.
     """
-    minbits = _find_min_bits(polygon_bitmap_column.max())
-    binary_maps = apply_binarize(polygon_bitmap_column.data.mem, minbits)
+    binary_maps = apply_binarize(polygon_bitmap_column.data.mem, width)
     return binary_maps


### PR DESCRIPTION
Summary of Changes
- Requires and makes explicit the need for a width parameter in the bitmap to binary conversion utility. This is necessary for downstream usage in `point_in_polygon_bitmap`, ensuring that the dataframe will have the same number of columns as the number of polygon IDs.
- Updates tests accordingly