### PR TITLE
[REVIEW] Fix legacy migrations so cuspatial builds again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes
 
-- PR #94 Add legacy headers as cudf migrates
+- PR #94 Add legacy headers as cudf migrates 
 
 
 # cuSpatial 0.10.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- PR #94 Add legacy headers as cudf migrates
+
 
 # cuSpatial 0.10.0 (Date TBD)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,8 +87,7 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
 
-option(BUILD_TESTS "Configure CMake to build tests"
-       ON)
+option(BUILD_TESTS "Configure CMake to build tests" OFF)
 
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -88,7 +88,7 @@ set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
 
 option(BUILD_TESTS "Configure CMake to build tests"
-       OFF)
+       ON)
 
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 

--- a/cpp/src/io/soa/point_soa_reader.cu
+++ b/cpp/src/io/soa/point_soa_reader.cu
@@ -20,7 +20,7 @@
 #include <cuda_runtime.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <rmm/rmm.h>
 #include <cuspatial/soa_readers.hpp>
 #include <utility/utility.hpp>

--- a/cpp/src/io/soa/polygon_soa_reader.cu
+++ b/cpp/src/io/soa/polygon_soa_reader.cu
@@ -22,7 +22,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/soa_readers.hpp>
 #include <utility/utility.hpp>
 

--- a/cpp/src/io/soa/timestamp_soa_reader.cu
+++ b/cpp/src/io/soa/timestamp_soa_reader.cu
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <math.h>
 #include <cuda_runtime.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <rmm/rmm.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>

--- a/cpp/src/io/soa/uint32_soa_reader.cu
+++ b/cpp/src/io/soa/uint32_soa_reader.cu
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <math.h>
 #include <cuda_runtime.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <rmm/rmm.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>

--- a/cpp/src/trajectory/subset_trajectories.cu
+++ b/cpp/src/trajectory/subset_trajectories.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/utilities/legacy/type_dispatcher.hpp>
+#include <cudf/cudf.h>
 #include <cudf/legacy/copying.hpp>
 #include <utilities/cuda_utils.hpp>
 #include <type_traits>

--- a/cpp/src/trajectory/subset_trajectories.cu
+++ b/cpp/src/trajectory/subset_trajectories.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cudf/utilities/legacy/type_dispatcher.hpp>
-#include <cudf/copying.hpp>
+#include <cudf/legacy/copying.hpp>
 #include <utilities/cuda_utils.hpp>
 #include <type_traits>
 #include <thrust/device_vector.h>

--- a/cpp/src/utility/utility.hpp
+++ b/cpp/src/utility/utility.hpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <vector>
 #include <cuspatial/types.hpp>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 
 namespace cuspatial
 {

--- a/cpp/tests/query/spatial_window_test_toy.cu
+++ b/cpp/tests/query/spatial_window_test_toy.cu
@@ -26,9 +26,9 @@
 #include <cuspatial/query.hpp>
 #include <utility/utility.hpp>
 
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct TrajectoryDeriveToy : public GdfTest 
 {

--- a/cpp/tests/query/spatial_window_test_toy.cu
+++ b/cpp/tests/query/spatial_window_test_toy.cu
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/query.hpp>
 #include <utility/utility.hpp>
 

--- a/cpp/tests/spatial/coordinate_transform_toy.cu
+++ b/cpp/tests/spatial/coordinate_transform_toy.cu
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/coordinate_transform.hpp>
 #include <utility/utility.hpp>
 

--- a/cpp/tests/spatial/coordinate_transform_toy.cu
+++ b/cpp/tests/spatial/coordinate_transform_toy.cu
@@ -26,9 +26,9 @@
 #include <cuspatial/coordinate_transform.hpp>
 #include <utility/utility.hpp>
 
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct CoordinateTransToy : public GdfTest 
 {

--- a/cpp/tests/spatial/hausdorff_compare.cu
+++ b/cpp/tests/spatial/hausdorff_compare.cu
@@ -28,8 +28,8 @@
 #include <utility/utility.hpp> 
 #include "hausdorff_util.h" 
 
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct HausdorffCompare : public GdfTest 
 {

--- a/cpp/tests/spatial/hausdorff_compare.cu
+++ b/cpp/tests/spatial/hausdorff_compare.cu
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #include <gtest/gtest.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 
 #include <cuspatial/soa_readers.hpp> 
 #include <cuspatial/hausdorff.hpp> 

--- a/cpp/tests/spatial/hausdorff_test.cu
+++ b/cpp/tests/spatial/hausdorff_test.cu
@@ -18,7 +18,7 @@
 #include <sys/time.h>
 
 #include <gtest/gtest.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 
 #include <cuspatial/soa_readers.hpp> 
 #include <cuspatial/hausdorff.hpp> 

--- a/cpp/tests/spatial/hausdorff_test.cu
+++ b/cpp/tests/spatial/hausdorff_test.cu
@@ -25,8 +25,8 @@
 #include <utility/utility.hpp> 
 #include "hausdorff_util.h" 
 
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct is_true
 {

--- a/cpp/tests/spatial/hausdorff_toy.cu
+++ b/cpp/tests/spatial/hausdorff_toy.cu
@@ -24,9 +24,9 @@
 #include <utilities/error_utils.hpp>
 #include <cuspatial/hausdorff.hpp> 
 
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct HausdorffToy : public GdfTest 
 {

--- a/cpp/tests/spatial/hausdorff_toy.cu
+++ b/cpp/tests/spatial/hausdorff_toy.cu
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #include <gtest/gtest.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/hausdorff.hpp> 
 
 #include <tests/utilities/legacy/column_wrapper.cuh>

--- a/cpp/tests/spatial/haversine_toy.cu
+++ b/cpp/tests/spatial/haversine_toy.cu
@@ -18,9 +18,9 @@
 #include <cuspatial/haversine.hpp> 
 #include <utilities/error_utils.hpp>
 
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct HaversineToy : public GdfTest 
 {

--- a/cpp/tests/spatial/haversine_toy.cu
+++ b/cpp/tests/spatial/haversine_toy.cu
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <cuspatial/haversine.hpp> 
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 
 #include <tests/utilities/legacy/cudf_test_utils.cuh>
 #include <tests/utilities/legacy/column_wrapper.cuh>

--- a/cpp/tests/spatial/pip_compare.cu
+++ b/cpp/tests/spatial/pip_compare.cu
@@ -18,7 +18,7 @@
 #include <sys/time.h>
 
 #include <gtest/gtest.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/point_in_polygon.hpp>
 #include "pip_util.h"
 

--- a/cpp/tests/spatial/pip_compare.cu
+++ b/cpp/tests/spatial/pip_compare.cu
@@ -22,8 +22,8 @@
 #include <cuspatial/point_in_polygon.hpp>
 #include "pip_util.h"
 
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 template <typename T>
 struct PIPCompare : public GdfTest 

--- a/cpp/tests/spatial/pip_test.cu
+++ b/cpp/tests/spatial/pip_test.cu
@@ -23,8 +23,8 @@
 #include <cuspatial/point_in_polygon.hpp>
 #include "pip_util.h"
 
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 template <typename T>
 struct PIPTest : public GdfTest 

--- a/cpp/tests/spatial/pip_test.cu
+++ b/cpp/tests/spatial/pip_test.cu
@@ -18,7 +18,7 @@
 #include <sys/time.h>
 
 #include <gtest/gtest.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/soa_readers.hpp>
 #include <cuspatial/point_in_polygon.hpp>
 #include "pip_util.h"

--- a/cpp/tests/spatial/pip_toy.cu
+++ b/cpp/tests/spatial/pip_toy.cu
@@ -20,9 +20,9 @@
 #include <cuspatial/point_in_polygon.hpp>
 #include "pip_util.h"
 
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct PIPToy : public GdfTest 
 {

--- a/cpp/tests/trajectory/test_trajectory_derive.cu
+++ b/cpp/tests/trajectory/test_trajectory_derive.cu
@@ -17,8 +17,8 @@
 #include <vector>
 #include <gtest/gtest.h>
 #include <random>
-#include <tests/utilities/cudf_test_fixtures.h>
-#include <tests/utilities/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
 
 #include <cuspatial/trajectory.hpp> 
 
@@ -54,13 +54,13 @@ TEST_F(TrajectoryDerive, DeriveThree)
     std::shuffle(sequence.begin(), sequence.end(), g);
 
     wrapper<double> in_x(column_size,
-        [&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<double> in_y(column_size,
-        [&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<int32_t> in_id(column_size,
-        [&](gdf_index_type i) { return id_vector[sequence[i]]; });
+        [&](cudf::size_type i) { return id_vector[sequence[i]]; });
     wrapper<cudf::timestamp> in_ts(column_size,
-        [&](gdf_index_type i) { 
+        [&](cudf::size_type i) { 
             return static_cast<cudf::timestamp>(ms_vector[sequence[i]]); 
         });
 

--- a/cpp/tests/trajectory/test_trajectory_distance_speed.cu
+++ b/cpp/tests/trajectory/test_trajectory_distance_speed.cu
@@ -17,8 +17,8 @@
 #include <vector>
 #include <gtest/gtest.h>
 
-#include <tests/utilities/cudf_test_fixtures.h>
-#include <tests/utilities/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
 
 #include <cuspatial/trajectory.hpp> 
 
@@ -55,11 +55,11 @@ TEST_F(TrajectoryDistanceSpeed, DistanceAndSpeedThree)
 
     std::vector<double> x(sequence.begin(), sequence.end());
     wrapper<double> in_x{x};
-        //[&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        //[&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<double> in_y(column_size,
-        [&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<cudf::timestamp> in_ts(column_size,
-        [&](gdf_index_type i) {
+        [&](cudf::size_type i) {
             return static_cast<cudf::timestamp>(ms_vector[sequence[i]]);
         });
 

--- a/cpp/tests/trajectory/test_trajectory_subset.cu
+++ b/cpp/tests/trajectory/test_trajectory_subset.cu
@@ -19,8 +19,8 @@
 
 #include <gtest/gtest.h>
 
-#include <tests/utilities/cudf_test_fixtures.h>
-#include <tests/utilities/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
 
 #include <cuspatial/trajectory.hpp>
 
@@ -56,13 +56,13 @@ void test_subset(std::vector<int32_t> ids_to_keep)
     std::shuffle(sequence.begin(), sequence.end(), g);
 
     wrapper<double> in_x(column_size,
-        [&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<double> in_y(column_size,
-        [&](gdf_index_type i) { return static_cast<double>(sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(sequence[i]); });
     wrapper<int32_t> in_id(column_size,
-        [&](gdf_index_type i) { return id_vector[sequence[i]]; });
+        [&](cudf::size_type i) { return id_vector[sequence[i]]; });
     wrapper<cudf::timestamp> in_ts(column_size,
-        [&](gdf_index_type i) { 
+        [&](cudf::size_type i) { 
             return static_cast<cudf::timestamp>(ms_vector[sequence[i]]); 
         });
     wrapper<int32_t> ids{ids_to_keep};
@@ -84,13 +84,13 @@ void test_subset(std::vector<int32_t> ids_to_keep)
     gdf_size_type expected_size = end - expected_sequence.begin();
 
     wrapper<double> expected_x(expected_size,
-        [&](gdf_index_type i) { return static_cast<double>(expected_sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(expected_sequence[i]); });
     wrapper<double> expected_y(expected_size,
-        [&](gdf_index_type i) { return static_cast<double>(expected_sequence[i]); });
+        [&](cudf::size_type i) { return static_cast<double>(expected_sequence[i]); });
     wrapper<int32_t> expected_id(expected_size,
-        [&](gdf_index_type i) { return id_vector[expected_sequence[i]]; });
+        [&](cudf::size_type i) { return id_vector[expected_sequence[i]]; });
     wrapper<cudf::timestamp> expected_ts(expected_size,
-        [&](gdf_index_type i) {
+        [&](cudf::size_type i) {
             return static_cast<cudf::timestamp>(ms_vector[expected_sequence[i]]);
         });
 

--- a/cpp/tests/trajectory/trajectory_spatial_bounds_toy.cu
+++ b/cpp/tests/trajectory/trajectory_spatial_bounds_toy.cu
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
-#include <utilities/error_utils.hpp>
+#include <utilities/legacy/error_utils.hpp>
 #include <cuspatial/types.hpp> 
 #include <cuspatial/trajectory.hpp> 
 #include <utility/utility.hpp>

--- a/cpp/tests/trajectory/trajectory_spatial_bounds_toy.cu
+++ b/cpp/tests/trajectory/trajectory_spatial_bounds_toy.cu
@@ -28,9 +28,9 @@
 #include <utility/utility.hpp>
 #include <utility/trajectory_thrust.cuh>
 
-#include <tests/utilities/column_wrapper.cuh>
-#include <tests/utilities/cudf_test_utils.cuh>
-#include <tests/utilities/cudf_test_fixtures.h>
+#include <tests/utilities/legacy/column_wrapper.cuh>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
 
 struct TrajectoryDeriveToy : public GdfTest 
 {

--- a/python/cuspatial/cuspatial/_lib/trajectory.pxd
+++ b/python/cuspatial/cuspatial/_lib/trajectory.pxd
@@ -10,7 +10,7 @@ from libcpp.pair cimport pair
 
 cdef extern from "trajectory.hpp" namespace "cuspatial" nogil:
 
-    cdef gdf_size_type derive_trajectories(
+    cdef size_type derive_trajectories(
         const gdf_column& coor_x,
         const gdf_column& coor_y,
         const gdf_column& pid,
@@ -39,7 +39,7 @@ cdef extern from "trajectory.hpp" namespace "cuspatial" nogil:
         gdf_column& bbox_y2
     ) except +
 
-    cdef gdf_size_type subset_trajectory_id(
+    cdef size_type subset_trajectory_id(
         const gdf_column& id,
         const gdf_column& in_x,
         const gdf_column& in_y,

--- a/python/cuspatial/cuspatial/tests/test_haversine_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_haversine_distance.py
@@ -54,7 +54,7 @@ def test_triple():
             "Sydney": [151.2093, -33.8688],
         }
     )
-    cities = cities.set_index(["lat", "lon"])
+    cities.index = ["lat", "lon"]
     pnt_x1 = []
     pnt_y1 = []
     pnt_x2 = []


### PR DESCRIPTION
Modify headers with various `legacy` paths.