### PR TITLE
[WIP] CI failure due to `cudf` `conda` dependency. Build from source?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - PR #94 Add legacy headers as cudf migrates 
 
 
-# cuSpatial 0.10.0 (Date TBD)
+# cuSpatial 0.10.0 (16 Oct 2019)
 
 ## New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@
 - PR #49 Docstring for haversine and argument ordering was backwards
 - PR #66 added missing header in tests
 - PR #70 Require width parameterization of bitmap to binary conversion
+- PR #86 Add Shapefile reader for polygons

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -55,6 +55,7 @@ logger "Clone cudf"
 git clone https://github.com/rapidsai/cudf.git -b branch-$MINOR_VERSION ${CUDF_HOME}
 cd $CUDF_HOME
 git submodule update --init --remote --recursive
+echo conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cdf_dev_${CUDA_REL}.yml
 conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cdf_dev_${CUDA_REL}.yml
 ./build.sh
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -56,7 +56,7 @@ git clone https://github.com/rapidsai/cudf.git -b branch-$MINOR_VERSION ${CUDF_H
 cd $CUDF_HOME
 git submodule update --init --remote --recursive
 conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cudf_dev_cuda${CUDA_REL}.yml
-conda activate cudf_dev
+source activate cudf_dev
 ./build.sh
 
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,6 +59,8 @@ conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cudf_dev_c
 source activate cudf_dev
 ./build.sh
 
+conda install "gdal=2.4.*"
+
 ################################################################################
 # BUILD - Build libcuspatial and cuSpatial from source
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -41,10 +41,6 @@ env
 logger "Check GPU usage..."
 nvidia-smi
 
-logger "Activate conda env..."
-source activate gdf
-conda install "cudf=${MINOR_VERSION}.*" "cudatoolkit=$CUDA_REL"
-
 logger "Check versions..."
 python --version
 $CC --version
@@ -59,6 +55,8 @@ logger "Clone cudf"
 git clone https://github.com/rapidsai/cudf.git -b branch-$MINOR_VERSION ${CUDF_HOME}
 cd $CUDF_HOME
 git submodule update --init --remote --recursive
+conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cdf_dev_${CUDA_REL}.yml
+./build.sh
 
 ################################################################################
 # BUILD - Build libcuspatial and cuSpatial from source

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -55,8 +55,8 @@ logger "Clone cudf"
 git clone https://github.com/rapidsai/cudf.git -b branch-$MINOR_VERSION ${CUDF_HOME}
 cd $CUDF_HOME
 git submodule update --init --remote --recursive
-echo conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cdf_dev_${CUDA_REL}.yml
-conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cdf_dev_${CUDA_REL}.yml
+conda env create --name cudf_dev --file $CUDF_HOME/conda/environments/cudf_dev_cuda${CUDA_REL}.yml
+conda activate cudf_dev
 ./build.sh
 
 ################################################################################

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - cudf {{ minor_version }}.*
     - libcuspatial {{ minor_version}}.*
     - cython >=0.29,<0.30
+    - gdal 2.4.*
 
 test:
   commands:

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   host:
     - libcudf {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
+    - gdal 2.4.*
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     - libcudf {{ minor_version }}.*

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -194,6 +194,18 @@ if (NVSTRINGS_INCLUDE AND NVTEXT_LIBRARY)
     set_target_properties(NVText PROPERTIES IMPORTED_LOCATION ${NVTEXT_LIBRARY})
 endif (NVSTRINGS_INCLUDE AND NVTEXT_LIBRARY)
 
+
+# - find gdal -------------------------------------------------------------------------------------
+
+find_package(GDAL REQUIRED)
+
+message(STATUS "GDAL: GDAL_LIBRARIES set to ${GDAL_LIBRARIES}")
+message(STATUS "GDAL: GDAL_INCLUDE_DIRS set to ${GDAL_INCLUDE_DIRS}")
+
+if(NOT GDAL_FOUND)
+    message(FATAL_ERROR "GDAL not found, please check your settings.")
+endif(NOT GDAL_FOUND)
+
 ###################################################################################################
 # - add gtest -------------------------------------------------------------------------------------
 
@@ -237,7 +249,8 @@ endif(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES)
 include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/src"
-       		        "${CMAKE_SOURCE_DIR}/thirdparty/cub"
+                    "${CMAKE_SOURCE_DIR}/thirdparty/cub"
+                    "${GDAL_INCLUDE_DIR}"
                     "${RMM_INCLUDE}"
                     "${CUDF_SRC_INCLUDE}"
                     "${CUDF_INCLUDE}"
@@ -251,6 +264,8 @@ include_directories("${CMAKE_BINARY_DIR}/include"
 link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
                  "${CMAKE_BINARY_DIR}/lib"
                  "${FLATBUFFERS_LIBRARY_DIR}"
+                 "${GDAL_LIBRARIES}"
+                 "${CONDA_LINK_DIRS}"
                  "${GTEST_LIBRARY_DIR}"
                  "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}")
@@ -259,6 +274,7 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT
 # - library targets -------------------------------------------------------------------------------
 
 add_library(cuspatial SHARED
+            src/io/shp/polygon_shapefile_reader.cu
             src/io/soa/polygon_soa_reader.cu
             src/io/soa/point_soa_reader.cu
             src/io/soa/uint32_soa_reader.cu
@@ -292,7 +308,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cuspatial cudf rmm cudart cuda nvrtc)
+target_link_libraries(cuspatial cudf rmm cudart cuda nvrtc gdal)
 
 
 ###################################################################################################

--- a/cpp/include/cuspatial/shapefile_readers.hpp
+++ b/cpp/include/cuspatial/shapefile_readers.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+typedef struct gdf_column_ gdf_column; // forward declaration
+
+namespace cuspatial {
+
+/**
+ * @brief read polygon data from an ESRI Shapefile.
+ *
+ * data type of vertices is fixed to double (GDF_FLOAT64)
+ *
+ * @param[in] filename: polygon data filename in ESRI Shapefile format
+ * @param[out] ply_fpos: index polygons: prefix sum of number of rings of all
+ *             polygons
+ * @param[out] ply_rpos: index rings: prefix sum of number of vertices of all
+ *             rings
+ * @param[out] ply_x: x coordinates of concatenated polygons
+ * @param[out] ply_y: y coordinates of concatenated polygons
+ *
+ * @note: x/y can be lon/lat.
+**/
+void read_polygon_shapefile(const char *filename,
+                      gdf_column* ply_fpos, gdf_column* ply_rpos,
+                      gdf_column* ply_x, gdf_column* ply_y);
+
+}// namespace cuspatial

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <algorithm>
+#include <cuda_runtime.h>
+#include <thrust/device_vector.h>
+#include <rmm/thrust_rmm_allocator.h>
+#include <cudf/types.h>
+#include <cudf/legacy/column.hpp>
+#include <utilities/legacy/error_utils.hpp>
+#include <cuspatial/shapefile_readers.hpp>
+#include <utility/utility.hpp>
+
+#include <ogrsf_frmts.h>
+
+namespace
+{
+ 
+    /*
+     * Read a LinearRing into x/y/size vectors
+    */
+ 
+    void VertexFromLinearRing(OGRLinearRing const& poRing, std::vector<double> &aPointX, 
+        std::vector<double> &aPointY,std::vector<int> &aPartSize )
+    {
+        int nCount = poRing.getNumPoints();
+        int nNewCount = aPointX.size() + nCount;
+ 
+        aPointX.reserve( nNewCount );
+        aPointY.reserve( nNewCount );
+        for (int i = nCount - 1; i >= 0; i-- )
+        {
+            aPointX.push_back( poRing.getX(i));
+            aPointY.push_back( poRing.getY(i));
+        }
+        aPartSize.push_back( nCount );	
+    }
+ 
+     /*
+      * Read a Polygon (could be with multiple rings) into x/y/size vectors
+     */
+
+    void LinearRingFromPolygon(OGRPolygon const & poPolygon, std::vector<double> &aPointX, 
+        std::vector<double> &aPointY,std::vector<int> &aPartSize )
+    {
+        
+        VertexFromLinearRing( *(poPolygon.getExteriorRing()),
+                                        aPointX, aPointY, aPartSize );
+
+        for(int i = 0; i < poPolygon.getNumInteriorRings(); i++ )
+            VertexFromLinearRing( *(poPolygon.getInteriorRing(i)),
+                                            aPointX, aPointY, aPartSize );
+    }
+
+     /*
+      * Read a Geometry (could be MultiPolygon/GeometryCollection) into x/y/size vectors
+     */
+
+    void PolygonFromGeometry(OGRGeometry const *poShape, std::vector<double> &aPointX, 
+        std::vector<double> &aPointY,std::vector<int> &aPartSize )
+    {
+        OGRwkbGeometryType eFlatType = wkbFlatten(poShape->getGeometryType());
+
+        if (eFlatType == wkbMultiPolygon || eFlatType == wkbGeometryCollection )             
+        {      
+            OGRGeometryCollection *poGC = (OGRGeometryCollection *) poShape;
+            for(int i = 0; i < poGC->getNumGeometries(); i++ )
+            {
+                OGRGeometry *poGeom=poGC->getGeometryRef(i);
+                PolygonFromGeometry(poGeom,aPointX, aPointY, aPartSize );
+            }
+        }
+        else if (eFlatType == wkbPolygon)
+            LinearRingFromPolygon(*((OGRPolygon *) poShape),aPointX, aPointY, aPartSize );
+        else
+           CUDF_EXPECTS(0, "must be polygonal geometry." );    
+    }
+
+     /*
+     * Read a GDALDataset layer (corresponding to a shapefile) into five vectors
+     *
+     * layer: OGRLayer layer holding polygon data
+     * g_len_v: vector of group lengths, i.e., numbers of features/polygons (should be 1 for a single layer/g_len_v)
+     * f_len_v: vector of feature lengths, i.e., numbers of rings in features/polygons
+     * r_len_v: vector of ring lengths, i.e., numbers of vertices in rings
+     * x_v: vector of x coordiantes of vertices
+     * y_v: vector of y coordiantes of vertices
+     * returns number of features/polygons
+     
+    */
+    
+    int ReadLayer(const OGRLayerH layer,std::vector<int>& g_len_v,std::vector<int>&f_len_v,
+         std::vector<int>& r_len_v,std::vector<double>& x_v, std::vector<double>& y_v)         
+    {
+        int num_feature=0;
+        OGR_L_ResetReading(layer );
+        OGRFeatureH hFeat;
+        while( (hFeat = OGR_L_GetNextFeature( layer )) != NULL )
+        {
+            OGRGeometry *poShape=(OGRGeometry *)OGR_F_GetGeometryRef( hFeat );
+            CUDF_EXPECTS(poShape!=NULL,"Invalid Shape");
+            
+            std::vector<double> aPointX;
+            std::vector<double> aPointY;
+            std::vector<int> aPartSize;
+            PolygonFromGeometry( poShape, aPointX, aPointY, aPartSize );
+
+            x_v.insert(x_v.end(),aPointX.begin(),aPointX.end());
+            y_v.insert(y_v.end(),aPointY.begin(),aPointY.end());
+            r_len_v.insert(r_len_v.end(),aPartSize.begin(),aPartSize.end());
+            f_len_v.push_back(aPartSize.size());
+            OGR_F_Destroy( hFeat );
+            num_feature++;
+        }
+        g_len_v.push_back(num_feature);
+        return num_feature;
+    }
+}
+
+namespace cuspatial
+{
+    /*
+    * Read a polygon shapefile and fill in a polygons structure
+    * ToDo: read associated relational data into a CUDF Table 
+    *
+    * filename: ESRI shapefile name (wtih .shp extension
+    * pm: structure polygons (fixed to double type) to hold polygon data
+    
+    * Note: only the first layer is read - shapefiles have only one layer in GDALDataset model    
+    */
+
+    void polygon_from_shapefile(const char *filename, polygons<double>& pm)
+    {
+        std::vector<int> g_len_v,f_len_v,r_len_v;
+        std::vector<double> x_v, y_v;
+        GDALAllRegister();
+
+        GDALDatasetH hDS = GDALOpenEx( filename, GDAL_OF_VECTOR, NULL, NULL, NULL );
+        CUDF_EXPECTS(hDS!=NULL,"Failed to open ESRI Shapefile dataset");		    
+        OGRLayerH hLayer = GDALDatasetGetLayer( hDS,0 );
+        CUDF_EXPECTS(hLayer!=NULL,"Failed to open the first layer");
+        int num_f=ReadLayer(hLayer,g_len_v,f_len_v,r_len_v,x_v,y_v);
+        CUDF_EXPECTS(num_f>0,"Shapefile must have at lest one polygon");
+        
+        pm.num_group=g_len_v.size();
+        pm.num_feature=f_len_v.size();
+        pm.num_ring=r_len_v.size();
+        pm.num_vertex=x_v.size();
+        pm.group_length=new uint32_t[ pm.num_group];
+        pm.feature_length=new uint32_t[ pm.num_feature];
+        pm.ring_length=new uint32_t[ pm.num_ring];
+        pm.x=new double [pm.num_vertex];
+        pm.y=new double [pm.num_vertex];
+        CUDF_EXPECTS(pm.group_length !=nullptr, "NULL group_length pointer");
+        CUDF_EXPECTS(pm.feature_length != nullptr, "NULL feature_length pointer");
+        CUDF_EXPECTS(pm.ring_length != nullptr, "NULL ring_length pointer");
+        CUDF_EXPECTS(pm.x != nullptr && pm.y != nullptr, "NULL polygon x/y data pointer");
+
+        std::copy_n(g_len_v.begin(),pm.num_group,pm.group_length);
+        std::copy_n(f_len_v.begin(),pm.num_feature,pm.feature_length);
+        std::copy_n(r_len_v.begin(),pm.num_ring,pm.ring_length);
+        std::copy_n(x_v.begin(),pm.num_vertex,pm.x);
+        std::copy_n(y_v.begin(),pm.num_vertex,pm.y);
+    }
+
+    /*
+    * read polygon data from file in ESRI Shapefile format; data type of vertices is fixed to double (GDF_FLOAT64)
+    * see shp_readers.hpp
+    */
+
+    void read_polygon_shapefile(const char *filename,
+                      gdf_column* ply_fpos, gdf_column* ply_rpos,
+                      gdf_column* ply_x, gdf_column* ply_y)
+    {
+        memset(ply_fpos,0,sizeof(gdf_column));
+        memset(ply_rpos,0,sizeof(gdf_column));
+        memset(ply_x,0,sizeof(gdf_column));
+        memset(ply_y,0,sizeof(gdf_column));
+
+        polygons<double> pm;
+        memset(&pm,0,sizeof(pm));
+        polygon_from_shapefile(filename,pm);
+        if (pm.num_feature <=0) return;
+
+        cudaStream_t stream{0};
+        auto exec_policy = rmm::exec_policy(stream)->on(stream);
+
+        int32_t* temp{nullptr};
+        RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
+        CUDA_TRY( cudaMemcpyAsync(temp, pm.feature_length,
+                              pm.num_feature * sizeof(int32_t),
+                              cudaMemcpyHostToDevice, stream) );
+        //prefix-sum: len to pos
+        thrust::inclusive_scan(exec_policy, temp, temp + pm.num_feature, temp);
+        gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
+                              GDF_INT32, 0,
+                              gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
+
+        RMM_TRY( RMM_ALLOC(&temp, pm.num_ring * sizeof(int32_t), stream) );
+        CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
+                              pm.num_ring * sizeof(int32_t),
+                              cudaMemcpyHostToDevice, stream) );
+        thrust::inclusive_scan(exec_policy, temp, temp + pm.num_feature, temp);
+        gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
+                              GDF_INT32, 0,
+                              gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");
+
+        RMM_TRY( RMM_ALLOC(&temp, pm.num_vertex * sizeof(double), stream) );
+        CUDA_TRY( cudaMemcpyAsync(temp, pm.x,
+                              pm.num_vertex * sizeof(double),
+                              cudaMemcpyHostToDevice, stream) );
+        gdf_column_view_augmented(ply_x, temp, nullptr, pm.num_vertex,
+                              GDF_FLOAT64, 0,
+                              gdf_dtype_extra_info{TIME_UNIT_NONE}, "x");
+
+        RMM_TRY( RMM_ALLOC(&temp, pm.num_vertex * sizeof(double), stream) );
+        CUDA_TRY( cudaMemcpyAsync(temp, pm.y,
+                              pm.num_vertex * sizeof(double),
+                              cudaMemcpyHostToDevice, stream) );
+        gdf_column_view_augmented(ply_y, temp, nullptr, pm.num_vertex,
+                              GDF_FLOAT64, 0,
+                              gdf_dtype_extra_info{TIME_UNIT_NONE}, "y");
+
+        delete[] pm.feature_length;
+        delete[] pm.ring_length;
+        delete[] pm.x;
+        delete[] pm.y;
+        delete[] pm.group_length;
+    }
+
+}// namespace cuspatial

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cuspatial cudf
                           cudftestutil rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES} NVCategory
-                          NVStrings nvrtc)
+                          NVStrings nvrtc gdal)
     if(USE_NVTX)
         target_link_libraries(${CMAKE_TEST_NAME} ${NVTX_LIBRARY})
     endif(USE_NVTX)
@@ -79,6 +79,8 @@ include_directories("${CMAKE_BINARY_DIR}/include"
 
 link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
                  "${CMAKE_BINARY_DIR}/lib"
+                 "${GDAL_LIBRARIES}"
+                 "${CONDA_LINK_DIRS}"
                  "${GTEST_LIBRARY_DIR}"
                  "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}"
@@ -103,6 +105,10 @@ set(POINT_IN_POLYGON_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/spatial/pip_test.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/spatial/pip_compare.cu")
 ConfigureTest(POINT_IN_POLYGON_TEST "${POINT_IN_POLYGON_TEST_SRC}")
+
+set(SHAPEFILE_POYGON_READER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/io/read_shapefile_polygon_test.cu")
+ConfigureTest(SHAPEFILE_POLYGON_READER_TEST "${SHAPEFILE_POYGON_READER_TEST_SRC}")
 
 set(SPATIAL_WINDOW_POINT_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/query/spatial_window_test_toy.cu")

--- a/cpp/tests/io/read_shapefile_polygon_test.cu
+++ b/cpp/tests/io/read_shapefile_polygon_test.cu
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <time.h>
+#include <sys/time.h>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <utilities/legacy/error_utils.hpp>
+#include <tests/utilities/legacy/cudf_test_utils.cuh>
+#include <tests/utilities/legacy/cudf_test_fixtures.h>
+#include <cuspatial/shapefile_readers.hpp>
+#include <utility/utility.hpp> 
+
+struct ReadShapefilePolygonTest : public GdfTest 
+{
+};   
+
+#if  0 // disable until data files are checked in
+TEST_F(ReadShapefilePolygonTest, readshapefilepolygontest)
+{
+    gdf_column f_pos,r_pos,poly_x,poly_y;
+    std::string shape_filename=std::string("its_4326_roi.shp"); 
+    struct timeval t0,t1;
+    gettimeofday(&t0, nullptr);
+    cuspatial::read_polygon_shapefile(shape_filename.c_str(),&f_pos,&r_pos,&poly_x,&poly_y);
+    std::cout<<"# of polygons= "<<f_pos.size<<std::endl;
+    std::cout<<"# of rings= "<<r_pos.size<<std::endl;
+    std::cout<<"# of vertices= "<<poly_x.size<<std::endl;
+    
+    gettimeofday(&t1, nullptr);
+    float gpu_pip_time1=cuspatial::calc_time("read shapefile time......",t0,t1);
+}
+#endif

--- a/python/cuspatial/demos/hausdorff_clustering_test_toy.py
+++ b/python/cuspatial/demos/hausdorff_clustering_test_toy.py
@@ -32,8 +32,7 @@ pnt_y = Series(py_y)
 cnt = Series(py_cnt)
 distance = cuspatial.directed_hausdorff_distance(pnt_x, pnt_y, cnt)
 
-num_set = len(cnt)
-matrix = distance.data.to_array().reshape(num_set, num_set)
+matrix = distance.as_matrix()
 
 # clustering using AgglomerativeClustering
 agg1 = AgglomerativeClustering(


### PR DESCRIPTION
This PR builds gpu CI `cudf` from source entirely, preventing some issues we've been having with the `conda` build of `cudf` that prevent `cuspatial` from building.