### PR TITLE
FIX Remove unused CUDA conda labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Improvements
 
+- PR #104 Remove unused CUDA conda labels
+
 ## Bug Fixes
 
 - PR #94 Add legacy headers as cudf migrates

--- a/ci/cpu/upload_anaconda.sh
+++ b/ci/cpu/upload_anaconda.sh
@@ -20,7 +20,7 @@ if [ -z "$MY_UPLOAD_KEY" ]; then
 fi
 
 if [ "$UPLOAD_LIBCUSPATIAL" == "1" ]; then
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${LIBCUSPATIAL_FILE}
@@ -30,7 +30,7 @@ if [ "$UPLOAD_LIBCUSPATIAL" == "1" ]; then
 fi
 
 if [ "$UPLOAD_CUSPATIAL" == "1" ]; then
-  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${CUSPATIAL_FILE}


### PR DESCRIPTION
We no longer rely on these labels for version matching and use `cudatoolkit` package to do so.