### PR TITLE
[REVIEW] Update OPS codeowners group name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,13 +8,9 @@ python/            @rapidsai/cuspatial-python-codeowners
 **/CMakeLists.txt  @rapidsai/cuspatial-cmake-codeowners
 **/cmake/          @rapidsai/cuspatial-cmake-codeowners
 
-# java code owners
-java/              @rapidsai/cuspatial-java-codeowners
-
 # build/ops code owners
 .github/           @rapidsai/cuspatial-ops-codeowners 
 ci/                @rapidsai/cuspatial-ops-codeowners
 conda/             @rapidsai/cuspatial-ops-codeowners
 **/Dockerfile      @rapidsai/cuspatial-ops-codeowners
 **/.dockerignore   @rapidsai/cuspatial-ops-codeowners
-docker/            @rapidsai/cuspatial-ops-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@ python/            @rapidsai/cuspatial-python-codeowners
 **/cmake/          @rapidsai/cuspatial-cmake-codeowners
 
 # build/ops code owners
-.github/           @rapidsai/cuspatial-ops-codeowners 
-ci/                @rapidsai/cuspatial-ops-codeowners
-conda/             @rapidsai/cuspatial-ops-codeowners
-**/Dockerfile      @rapidsai/cuspatial-ops-codeowners
-**/.dockerignore   @rapidsai/cuspatial-ops-codeowners
+.github/           @rapidsai/ops-codeowners 
+ci/                @rapidsai/ops-codeowners
+conda/             @rapidsai/ops-codeowners
+**/Dockerfile      @rapidsai/ops-codeowners
+**/.dockerignore   @rapidsai/ops-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #109 Update OPS codeowners group name
+
 ## Bug Fixes
 
 


### PR DESCRIPTION
No java component in cuspatial, so removing that as well.