### PR TITLE
[WIP] Fixing error_utils.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# cuSpatial 0.13.0 (TBD)
+
+## New Features
+
+## Improvements
+
+## Bug Fixes
+
+- PR #123 Update references to error utils after libcudf changes
+
 # cuSpatial 0.12.0 (04 Feb 2020)
 
 ## New Features

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -23,7 +23,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 #include <cuspatial/shapefile_readers.hpp>
 #include <utility/utility.hpp>
 

--- a/cpp/src/io/soa/point_soa_reader.cu
+++ b/cpp/src/io/soa/point_soa_reader.cu
@@ -20,7 +20,7 @@
 #include <cuda_runtime.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 #include <rmm/rmm.h>
 #include <cuspatial/soa_readers.hpp>
 #include <utility/utility.hpp>

--- a/cpp/src/io/soa/polygon_soa_reader.cu
+++ b/cpp/src/io/soa/polygon_soa_reader.cu
@@ -22,7 +22,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 #include <cuspatial/soa_readers.hpp>
 #include <utility/utility.hpp>
 

--- a/cpp/src/io/soa/timestamp_soa_reader.cu
+++ b/cpp/src/io/soa/timestamp_soa_reader.cu
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <math.h>
 #include <cuda_runtime.h>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 #include <rmm/rmm.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>

--- a/cpp/src/io/soa/uint32_soa_reader.cu
+++ b/cpp/src/io/soa/uint32_soa_reader.cu
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <math.h>
 #include <cuda_runtime.h>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 #include <rmm/rmm.h>
 #include <cudf/types.h>
 #include <cudf/legacy/column.hpp>

--- a/cpp/src/utility/utility.hpp
+++ b/cpp/src/utility/utility.hpp
@@ -22,7 +22,7 @@
 #include <map>
 #include <vector>
 #include <cuspatial/types.hpp>
-#include <utilities/legacy/error_utils.hpp>
+#include <cudf/utilities/error.hpp>
 
 namespace cuspatial
 {


### PR DESCRIPTION
libcuspatial is no longer building after recent changed to libcudf, specifically moving `utilities/error_utils.hpp` to `cudf/utilities/error.hpp`.

After these changes, I'm still failing to build with missing `cub/util_type.cuh`, but that could be an issue with my build environment.