### PR TITLE
[BUG] Added flag to not treat deprecation warnings as errors, for now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Bug Fixes
 
 - PR #123 Update references to error utils after libcudf changes
+- PR #136 Remove build erroring for deprecation warnings
 
 # cuSpatial 0.12.0 (04 Feb 2020)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -249,7 +249,7 @@ endif(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES)
 include_directories("${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/src"
-                    "${CMAKE_SOURCE_DIR}/thirdparty/cub"
+                    "${CMAKE_SOURCE_DIR}/../thirdparty/cub"
                     "${GDAL_INCLUDE_DIR}"
                     "${RMM_INCLUDE}"
                     "${CUDF_SRC_INCLUDE}"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 
     option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
     if(CMAKE_CXX11_ABI)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -69,7 +69,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-
 
 # set warnings as errors
 # TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -206,7 +206,7 @@ namespace cuspatial
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -215,7 +215,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -198,16 +198,13 @@ namespace cuspatial
         polygon_from_shapefile(filename,pm);
         if (pm.num_feature <=0) return;
 
-        cudaStream_t stream{0};
-        auto exec_policy = rmm::exec_policy(stream);
-
         int32_t* temp{nullptr};
         RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
         CUDA_TRY( cudaMemcpyAsync(temp, pm.feature_length,
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -216,7 +213,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -198,13 +198,15 @@ namespace cuspatial
         polygon_from_shapefile(filename,pm);
         if (pm.num_feature <=0) return;
 
+        cudaStream_t stream{0};
+
         int32_t* temp{nullptr};
         RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
         CUDA_TRY( cudaMemcpyAsync(temp, pm.feature_length,
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -213,7 +215,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/io/soa/polygon_soa_reader.cu
+++ b/cpp/src/io/soa/polygon_soa_reader.cu
@@ -58,7 +58,7 @@ namespace cuspatial
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -67,7 +67,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(rmm::exec_policy(stream)->(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/io/soa/polygon_soa_reader.cu
+++ b/cpp/src/io/soa/polygon_soa_reader.cu
@@ -50,16 +50,13 @@ namespace cuspatial
         read_polygon_soa<double>(filename, &pm);
         if (pm.num_feature <=0) return;
 
-        cudaStream_t stream{0};
-        auto exec_policy = rmm::exec_policy(stream)->on(stream);
-
         int32_t* temp{nullptr};
         RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
         CUDA_TRY( cudaMemcpyAsync(temp, pm.feature_length,
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(exec_policy, temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -68,7 +65,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(exec_policy, temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(rmm::exec_policy(0)->on(0), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/query/spatial_window_points.cu
+++ b/cpp/src/query/spatial_window_points.cu
@@ -83,14 +83,12 @@ struct sw_point_functor
         CUDF_EXPECTS(q_bottom < q_top,
                      "bottom must be less than top in a spatial window query");
 
-        cudaStream_t stream{0};
-        auto exec_policy = rmm::exec_policy(stream)->on(stream);
-
+        
         auto in_it = thrust::make_zip_iterator(thrust::make_tuple(
             static_cast<T*>(x.data), static_cast<T*>(y.data)));
 
         int num_hits =
-            thrust::count_if(exec_policy, in_it, in_it + x.size,
+            thrust::count_if(rmm::exec_policy(0)->on(0), in_it, in_it + x.size,
                              spatial_window_functor_xy<T>(q_left, q_bottom,
                                                           q_right, q_top));
 
@@ -101,7 +99,7 @@ struct sw_point_functor
 
         auto out_it =
             thrust::make_zip_iterator(thrust::make_tuple(temp_x, temp_y));
-        thrust::copy_if(exec_policy, in_it, in_it + x.size, out_it,
+        thrust::copy_if(rmm::exec_policy(0)->on(0), in_it, in_it + x.size, out_it,
                         spatial_window_functor_xy<T>(q_left, q_bottom,
                                                      q_right, q_top));
 

--- a/cpp/src/spatial/hausdorff.cu
+++ b/cpp/src/spatial/hausdorff.cu
@@ -111,6 +111,8 @@ struct Hausdorff_functor {
         int num_set=vertex_counts.size;
         int block_sz = num_set*num_set;
 
+        cudaStream_t stream{0};
+
         T *temp_matrix{nullptr};
         RMM_TRY( RMM_ALLOC(&temp_matrix, block_sz * sizeof(T), stream) );
 

--- a/cpp/src/spatial/hausdorff.cu
+++ b/cpp/src/spatial/hausdorff.cu
@@ -111,16 +111,13 @@ struct Hausdorff_functor {
         int num_set=vertex_counts.size;
         int block_sz = num_set*num_set;
 
-        cudaStream_t stream{0};
-        auto exec_policy = rmm::exec_policy(stream)->on(stream);
-
         T *temp_matrix{nullptr};
         RMM_TRY( RMM_ALLOC(&temp_matrix, block_sz * sizeof(T), stream) );
 
         uint32_t *vertex_positions{nullptr};
         RMM_TRY( RMM_ALLOC((void**)&vertex_positions, sizeof(uint32_t)*num_set, stream) );
         uint32_t *vertex_counts_ptr=static_cast<uint32_t*>(vertex_counts.data);
-        thrust::inclusive_scan(exec_policy,vertex_counts_ptr,vertex_counts_ptr+num_set,vertex_positions);
+        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream),vertex_counts_ptr,vertex_counts_ptr+num_set,vertex_positions);
 
         int block_x = block_sz, block_y = 1;
         if (block_sz > 65535)

--- a/cpp/src/trajectory/subset_trajectories.cu
+++ b/cpp/src/trajectory/subset_trajectories.cu
@@ -63,16 +63,13 @@ struct subset_functor {
             int32_t* in_id_ptr = static_cast<int32_t*>(in_id.data);
             int32_t* id_ptr = static_cast<int32_t*>(id.data);
 
-            cudaStream_t stream{0};
-            auto exec_policy = rmm::exec_policy(stream)->on(stream);
-
             rmm::device_vector<int32_t> temp_id(id_ptr, id_ptr + num_id);
-            thrust::sort(exec_policy, temp_id.begin(), temp_id.end());
+            thrust::sort(rmm::exec_policy(0)->on(0), temp_id.begin(), temp_id.end());
             thrust::device_vector<bool> hit_vec(num_rec);
-            thrust::binary_search(exec_policy, temp_id.cbegin(), temp_id.cend(),
+            thrust::binary_search(rmm::exec_policy(0)->on(0), temp_id.cbegin(), temp_id.cend(),
                                 in_id_ptr, in_id_ptr + num_rec, hit_vec.begin());
 
-            num_hit = thrust::count(exec_policy, hit_vec.begin(),
+            num_hit = thrust::count(rmm::exec_policy(0)->on(0), hit_vec.begin(),
                                     hit_vec.end(), true);
 
             if (num_hit > 0) {
@@ -90,7 +87,7 @@ struct subset_functor {
                     static_cast<int32_t*>(out_id.data),
                     static_cast<cudf::timestamp*>(out_timestamp.data)));
 
-                auto end = thrust::copy_if(exec_policy, in_itr, in_itr + num_rec,
+                auto end = thrust::copy_if(rmm::exec_policy(0)->on(0), in_itr, in_itr + num_rec,
                                            hit_vec.begin(), out_itr, is_true());
                 gdf_size_type num_keep = end - out_itr;
 

--- a/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
@@ -8,7 +8,7 @@ from cudf.tests.utils import assert_eq
 
 import cuspatial
 
-
+""" These tests and possibly others are creating a segfault
 def test_zeros():
     distance = cuspatial.directed_hausdorff_distance(
         cudf.Series([0.0]), cudf.Series([0.0]), cudf.Series([1])
@@ -35,7 +35,7 @@ def test_empty_counts():
         distance = cuspatial.directed_hausdorff_distance(  # noqa: F841
             cudf.Series([0]), cudf.Series([0]), cudf.Series()
         )
-
+"""
 
 def test_large():
     in_trajs = []

--- a/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
@@ -8,7 +8,7 @@ from cudf.tests.utils import assert_eq
 
 import cuspatial
 
-""" These tests and possibly others are creating a segfault
+
 def test_zeros():
     distance = cuspatial.directed_hausdorff_distance(
         cudf.Series([0.0]), cudf.Series([0.0]), cudf.Series([1])
@@ -35,7 +35,7 @@ def test_empty_counts():
         distance = cuspatial.directed_hausdorff_distance(  # noqa: F841
             cudf.Series([0]), cudf.Series([0]), cudf.Series()
         )
-"""
+
 
 def test_large():
     in_trajs = []


### PR DESCRIPTION
Added flag to not treat deprecation warnings as errors, for now. This will likely be removed when the RMM API calls have been updated for 0.14.