### PR TITLE
[REVIEW] fix dangling exec_policy pointer and invalid num_ring argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
-- PR #141 fix invalid pointer bug in rmm::exec_policy(stream)->on(steram) and wrong num_ring for multi-polygons 
+- PR #141 fix invalid pointer bug in 'auto exec_policy=rmm::exec_policy(stream)->on(stream)' and wrong num_ring for multi-polygons 
 
 # cuSpatial 0.13.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #141 fix invalid pointer bug in rmm::exec_policy(stream)->on(steram) and wrong num_ring for multi-polygons 
 
 # cuSpatial 0.13.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
-- PR #141 fix invalid pointer bug in 'auto exec_policy=rmm::exec_policy(stream)->on(stream)' and wrong num_ring for multi-polygons 
+- PR #141 fix dangling exec_policy pointer and invalid num_ring argument.
 
 # cuSpatial 0.13.0 (TBD)
 

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -199,6 +199,7 @@ namespace cuspatial
         if (pm.num_feature <=0) return;
 
         cudaStream_t stream{0};
+        auto exec_policy = rmm::exec_policy(stream);    
 
         int32_t* temp{nullptr};
         RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
@@ -206,7 +207,7 @@ namespace cuspatial
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -215,7 +216,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_ring, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/io/soa/polygon_soa_reader.cu
+++ b/cpp/src/io/soa/polygon_soa_reader.cu
@@ -51,6 +51,7 @@ namespace cuspatial
         if (pm.num_feature <=0) return;
 
         cudaStream_t stream{0};
+        auto exec_policy = rmm::exec_policy(stream);    
 
         int32_t* temp{nullptr};
         RMM_TRY( RMM_ALLOC(&temp, pm.num_feature * sizeof(int32_t), stream) );
@@ -58,7 +59,7 @@ namespace cuspatial
                               pm.num_feature * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
         //prefix-sum: len to pos
-        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_feature, temp);
         gdf_column_view_augmented(ply_fpos, temp, nullptr, pm.num_feature,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "f_pos");
@@ -67,7 +68,7 @@ namespace cuspatial
         CUDA_TRY( cudaMemcpyAsync(temp, pm.ring_length,
                               pm.num_ring * sizeof(int32_t),
                               cudaMemcpyHostToDevice, stream) );
-        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream), temp, temp + pm.num_feature, temp);
+        thrust::inclusive_scan(exec_policy->on(stream), temp, temp + pm.num_ring, temp);
         gdf_column_view_augmented(ply_rpos, temp, nullptr, pm.num_ring,
                               GDF_INT32, 0,
                               gdf_dtype_extra_info{TIME_UNIT_NONE}, "r_pos");

--- a/cpp/src/spatial/hausdorff.cu
+++ b/cpp/src/spatial/hausdorff.cu
@@ -112,6 +112,7 @@ struct Hausdorff_functor {
         int block_sz = num_set*num_set;
 
         cudaStream_t stream{0};
+        auto exec_policy = rmm::exec_policy(stream);    
 
         T *temp_matrix{nullptr};
         RMM_TRY( RMM_ALLOC(&temp_matrix, block_sz * sizeof(T), stream) );
@@ -119,7 +120,7 @@ struct Hausdorff_functor {
         uint32_t *vertex_positions{nullptr};
         RMM_TRY( RMM_ALLOC((void**)&vertex_positions, sizeof(uint32_t)*num_set, stream) );
         uint32_t *vertex_counts_ptr=static_cast<uint32_t*>(vertex_counts.data);
-        thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream),vertex_counts_ptr,vertex_counts_ptr+num_set,vertex_positions);
+        thrust::inclusive_scan(exec_policy->on(stream),vertex_counts_ptr,vertex_counts_ptr+num_set,vertex_positions);
 
         int block_x = block_sz, block_y = 1;
         if (block_sz > 65535)


### PR DESCRIPTION
(1) fix invalid pointer bug in `auto exec_policy=rmm::exec_policy(stream)->on(stream)` by declaring `rmm::exec_policy(stream)` first and then using the variable with `->on(stream)`. 
(2) fix wrong vertex positions in polygon_soa_reader and shapefile_soa_reader. The bug affects multi-polygons with multiple rings only. 
