### PR TITLE
[REVIEW] Remove use of RMM libraries and use cudf test utils correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 - PR #141 Fix dangling exec_policy pointer and invalid num_ring argument.
 - PR #169 Fix shapefile reader compilation with GCC 7.x / CUDA 10.2
-- PR #175 Address RMM API change requiring rmmInitialize(nullptr)
+- PR #178 Fix broken haversine tests introduced by upstream CUDF PRs.
+- PR #175 Address RMM API changes by eliminating the use of the RMM_API
 
 
 # cuSpatial 0.13.0 (31 Mar 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - PR #141 Fix dangling exec_policy pointer and invalid num_ring argument.
 - PR #169 Fix shapefile reader compilation with GCC 7.x / CUDA 10.2
+- PR #175 Address RMM API change requiring rmmInitialize(nullptr)
 
 
 # cuSpatial 0.13.0 (31 Mar 2020)

--- a/cpp/tests/interpolate/cubic_spline_test.cpp
+++ b/cpp/tests/interpolate/cubic_spline_test.cpp
@@ -14,204 +14,105 @@
  * limitations under the License.
  */
 
-#include <time.h>
 #include <sys/time.h>
-#include <string>
+#include <time.h>
 
-#include <tests/utilities/base_fixture.hpp>
-#include <tests/utilities/column_utilities.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/table/table_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 #include <cuspatial/cubic_spline.hpp>
 #include <cuspatial/error.hpp>
+#include <string>
+#include <tests/utilities/base_fixture.hpp>
+#include <tests/utilities/column_utilities.hpp>
+#include <tests/utilities/column_wrapper.hpp>
 
 struct CubicSplineTest : public cudf::test::BaseFixture {};
 
-template<typename T>
-auto make_device_column(T* const points, int length) {
-    T *d_p = nullptr;
-    RMM_TRY( RMM_ALLOC( &d_p, length * sizeof(T), 0));
-    assert(d_p != nullptr);    
-    CUDA_TRY( cudaMemcpy( d_p, points, length * sizeof(T), cudaMemcpyHostToDevice ) );
-    cudf::column_view col(cudf::data_type{cudf::experimental::type_to_id<T>()}, length, d_p);
-    cudf::column result(col);
-    RMM_FREE(d_p, 0);
-    return result;
-}
-
 auto get_d_expect() {
-  std::array<float, 4> d3_expect{{0.5, -0.5, -0.5, 0.5}};
-  std::array<float, 4> d2_expect{{0, 3, 3, -6}};
-  std::array<float, 4> d1_expect{{-1.5, -4.5, -4.5, 22.5}};
-  std::array<float, 4> d0_expect{{3, 4, 4, -23}};
-  std::vector<std::array<float, 4>> d_expect;
-  d_expect.push_back(d3_expect);
-  d_expect.push_back(d2_expect);
-  d_expect.push_back(d1_expect);
-  d_expect.push_back(d0_expect);
-  return d_expect;
+  std::vector<float> d3_expect{{0.5, -0.5, -0.5, 0.5}};
+  std::vector<float> d2_expect{{0, 3, 3, -6}};
+  std::vector<float> d1_expect{{-1.5, -4.5, -4.5, 22.5}};
+  std::vector<float> d0_expect{{3, 4, 4, -23}};
+  return std::vector<std::vector<float>>{
+      {d3_expect, d2_expect, d1_expect, d0_expect}};
 }
 
-TEST_F(CubicSplineTest, test_coefficients_single)
-{
-    int point_len = 5;
-    float t[point_len] = {0, 1, 2, 3, 4};
-    float y[point_len] = {3, 2, 3, 4, 3};
-    int ids_len = 2;
-    int ids[ids_len] = {0, 0};
-    int prefix[ids_len] = {0, 5};
+TEST_F(CubicSplineTest, test_coefficients_single) {
+  cudf::test::fixed_width_column_wrapper<float> t_column{{0, 1, 2, 3, 4}};
+  cudf::test::fixed_width_column_wrapper<float> y_column{{3, 2, 3, 4, 3}};
+  cudf::test::fixed_width_column_wrapper<int> ids_column{{0, 0}};
+  cudf::test::fixed_width_column_wrapper<int> prefix_column{{0, 5}};
 
-    rmmInitialize(nullptr);
+  auto splines = cuspatial::cubicspline_coefficients(t_column, y_column,
+                                                     ids_column, prefix_column);
 
-    cudf::column t_column = make_device_column<float>(t, point_len);
-    cudf::column y_column = make_device_column<float>(y, point_len);
-    cudf::column ids_column = make_device_column<int>(ids, ids_len);
-    cudf::column prefix_column = make_device_column<int>(prefix, ids_len);
+  auto d_expect = get_d_expect();
+  for (unsigned int i = 0; i < d_expect.size(); ++i) {
+    cudf::test::expect_columns_equivalent(
+        splines->get_column(i), cudf::test::fixed_width_column_wrapper<float>(
+                                    d_expect[i].begin(), d_expect[i].end()));
+  }
+}
 
-    std::unique_ptr<cudf::experimental::table> splines =
-        cuspatial::cubicspline_coefficients(
-            t_column, y_column, ids_column, prefix_column
-        );
+TEST_F(CubicSplineTest, test_coefficients_full) {
+  cudf::test::fixed_width_column_wrapper<float> t_column{
+      {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4}};
+  cudf::test::fixed_width_column_wrapper<float> y_column{
+      {3, 2, 3, 4, 3, 3, 2, 3, 4, 3, 3, 2, 3, 4, 3}};
+  cudf::test::fixed_width_column_wrapper<int> ids_column{{0, 0, 1, 2}};
+  cudf::test::fixed_width_column_wrapper<int> prefix_column{{0, 5, 10, 15}};
 
-    auto d_expect = get_d_expect();
-    for(unsigned int i = 0 ; i < d_expect.size() ; ++i){
-      cudf::column_view device_column = splines->view().column(i);
-      std::vector<float> host_data;
-      host_data.resize(device_column.size());
-      cudaMemcpy(host_data.data(), device_column.data<float>(),
-            device_column.size() * sizeof(float),
-            cudaMemcpyDeviceToHost);
-      for(unsigned int j = 0 ; j < host_data.size() ; ++j ){
-        EXPECT_EQ(d_expect[i][j], host_data[j]);
-      }
+  auto splines = cuspatial::cubicspline_coefficients(t_column, y_column,
+                                                     ids_column, prefix_column);
+
+  auto d_expect = get_d_expect();
+  for (unsigned int i = 0; i < d_expect.size(); ++i) {
+    auto h_expected_col = d_expect[i];
+    auto h_actual_col =
+        cudf::test::to_host<float>(splines->get_column(i)).first;
+    for (unsigned int j = 0; j < h_actual_col.size(); ++j) {
+      EXPECT_EQ(h_expected_col[j % h_expected_col.size()], h_actual_col[j]);
     }
+  }
 }
 
-TEST_F(CubicSplineTest, test_coefficients_full)
-{
-    int point_len = 15;
-    float t[point_len] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
-    float y[point_len] = {3, 2, 3, 4, 3, 3, 2, 3, 4, 3, 3, 2, 3, 4, 3};
-    int ids_len = 4;
-    int ids[ids_len] = {0, 0, 1, 2};
-    int prefix[ids_len] = {0, 5, 10, 15};
- 
-    cudf::column t_column = make_device_column<float>(t, point_len);
-    cudf::column y_column = make_device_column<float>(y, point_len);
-    cudf::column ids_column = make_device_column<int>(ids, ids_len);
-    cudf::column prefix_column = make_device_column<int>(prefix, ids_len);
+TEST_F(CubicSplineTest, test_interpolate_single) {
+  cudf::test::fixed_width_column_wrapper<float> t_column{{0, 1, 2, 3, 4}};
+  cudf::test::fixed_width_column_wrapper<float> x_column{{3, 2, 3, 4, 3}};
+  cudf::test::fixed_width_column_wrapper<int> ids_column{{0, 0}};
+  cudf::test::fixed_width_column_wrapper<int> prefix_column{{0, 5}};
+  cudf::test::fixed_width_column_wrapper<int> point_ids_column{{0, 0, 0, 0, 0}};
 
-    std::unique_ptr<cudf::experimental::table> splines =
-        cuspatial::cubicspline_coefficients(
-            t_column,
-            y_column,
-            ids_column,
-            prefix_column
-        );
+  auto splines = cuspatial::cubicspline_coefficients(t_column, x_column,
+                                                     ids_column, prefix_column);
 
-    auto d_expect = get_d_expect();
-    for(unsigned int i = 0 ; i < d_expect.size() ; ++i){
-      cudf::column_view device_column = splines->view().column(i);
-      std::vector<float> host_data;
-      host_data.resize(device_column.size());
-      cudaMemcpy(host_data.data(), device_column.data<float>(),
-            device_column.size() * sizeof(float),
-            cudaMemcpyDeviceToHost);
-      for(unsigned int j = 0 ; j < host_data.size() ; ++j ){
-        EXPECT_EQ(d_expect[i][j%d_expect[i].size()], host_data[j]);
-      }
-    }
+  auto interpolates = cuspatial::cubicspline_interpolate(
+      t_column, point_ids_column, prefix_column, t_column, splines->view());
+
+  cudf::test::expect_columns_equivalent(
+      *interpolates,
+      cudf::test::fixed_width_column_wrapper<float>{{3, 2, 3, 4, 3}});
 }
 
-TEST_F(CubicSplineTest, test_interpolate_single)
-{ 
-    int point_len = 5;
-    float t[point_len] = {0, 1, 2, 3, 4};
-    float x[point_len] = {3, 2, 3, 4, 3};
-    int ids_len = 2;
-    int ids[ids_len] = {0, 0};
-    int prefix[ids_len] = {0, 5};
-    int point_ids[point_len] = {0, 0, 0, 0, 0};
+TEST_F(CubicSplineTest, test_interpolate_full) {
+  cudf::test::fixed_width_column_wrapper<float> t_column{
+      {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4}};
+  cudf::test::fixed_width_column_wrapper<float> x_column{
+      {3, 2, 3, 4, 3, 3, 2, 3, 4, 3, 3, 2, 3, 4, 3}};
+  cudf::test::fixed_width_column_wrapper<int> ids_column{{0, 0, 1, 2}};
+  cudf::test::fixed_width_column_wrapper<int> prefix_column{{0, 5, 10, 15}};
+  cudf::test::fixed_width_column_wrapper<int> point_ids_column{
+      {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2}};
 
-    cudf::column t_column = make_device_column<float>(t, point_len);
-    cudf::column x_column = make_device_column<float>(x, point_len);
-    cudf::column ids_column = make_device_column<int>(ids, ids_len);
-    cudf::column prefix_column = make_device_column<int>(prefix, ids_len);
-    cudf::column point_ids_column = make_device_column<int>(point_ids, point_len);
+  auto splines = cuspatial::cubicspline_coefficients(t_column, x_column,
+                                                     ids_column, prefix_column);
 
-    std::unique_ptr<cudf::experimental::table> splines = 
-        cuspatial::cubicspline_coefficients(
-            t_column,
-            x_column,
-            ids_column,
-            prefix_column
-        );
+  auto interpolates = cuspatial::cubicspline_interpolate(
+      t_column, point_ids_column, prefix_column, t_column, splines->view());
 
-    std::unique_ptr<cudf::column> interpolates = 
-        cuspatial::cubicspline_interpolate(
-            t_column,
-            point_ids_column,
-            prefix_column,
-            t_column,
-            splines->view()
-        );
-    
-    cudf::column_view device_column = interpolates->view();
-    std::vector<float> host_data;
-    host_data.resize(device_column.size());
-    cudaMemcpy(host_data.data(), device_column.data<float>(),
-          device_column.size() * sizeof(float),
-          cudaMemcpyDeviceToHost);
-
-    for(int i = 0 ; i < device_column.size() ; ++i){
-      EXPECT_EQ(x[i], host_data[i]);
-    }
+  cudf::test::expect_columns_equivalent(
+      *interpolates, cudf::test::fixed_width_column_wrapper<float>{
+                         {3, 2, 3, 4, 3, 3, 2, 3, 4, 3, 3, 2, 3, 4, 3}});
 }
-
-TEST_F(CubicSplineTest, test_interpolate_full)
-{
-    int point_len = 15;
-    float t[point_len] = {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4};
-    float x[point_len] = {3, 2, 3, 4, 3, 3, 2, 3, 4, 3, 3, 2, 3, 4, 3};
-    int ids_len = 4;
-    int ids[ids_len] = {0, 0, 1, 2};
-    int prefix[ids_len] = {0, 5, 10, 15};
-    int point_ids[point_len] = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2};
-
-    cudf::column t_column = make_device_column<float>(t, point_len);
-    cudf::column x_column = make_device_column<float>(x, point_len);
-    cudf::column ids_column = make_device_column<int>(ids, ids_len);
-    cudf::column prefix_column = make_device_column<int>(prefix, ids_len);
-    cudf::column point_ids_column = make_device_column<int>(point_ids, point_len);
-
-    std::unique_ptr<cudf::experimental::table> splines = 
-        cuspatial::cubicspline_coefficients(
-            t_column,
-            x_column,
-            ids_column,
-            prefix_column
-        );
-
-    std::unique_ptr<cudf::column> interpolates =
-        cuspatial::cubicspline_interpolate(
-            t_column,
-            point_ids_column.view(),
-            prefix_column,
-            t_column,
-            splines->view()
-        );
-    
-    cudf::column_view device_column = interpolates->view();
-    std::vector<float> host_data;
-    host_data.resize(device_column.size());
-    cudaMemcpy(host_data.data(), device_column.data<float>(),
-          device_column.size() * sizeof(float),
-          cudaMemcpyDeviceToHost);
-
-    for(int i = 0 ; i < device_column.size() ; ++i){
-      EXPECT_EQ(x[i], host_data[i]);
-    }
-}
-

--- a/cpp/tests/interpolate/cubic_spline_test.cpp
+++ b/cpp/tests/interpolate/cubic_spline_test.cpp
@@ -63,6 +63,8 @@ TEST_F(CubicSplineTest, test_coefficients_single)
     int ids[ids_len] = {0, 0};
     int prefix[ids_len] = {0, 5};
 
+    rmmInitialize(nullptr);
+
     cudf::column t_column = make_device_column<float>(t, point_len);
     cudf::column y_column = make_device_column<float>(y, point_len);
     cudf::column ids_column = make_device_column<int>(ids, ids_len);

--- a/python/cuspatial/cuspatial/tests/test_haversine_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_haversine_distance.py
@@ -61,10 +61,10 @@ def test_triple():
     pnt_y2 = []
     for i in cities:
         for j in cities:
-            pnt_x1.append(cities[i][0])
-            pnt_y1.append(cities[i][1])
-            pnt_x2.append(cities[j][0])
-            pnt_y2.append(cities[j][1])
+            pnt_x1.append(cities[i].iloc[0])
+            pnt_y1.append(cities[i].iloc[1])
+            pnt_x2.append(cities[j].iloc[0])
+            pnt_y2.append(cities[j].iloc[1])
     distance = cuspatial.haversine_distance(
         cudf.Series(pnt_x1),
         cudf.Series(pnt_y1),


### PR DESCRIPTION
Something in the RMM API changed such that `rmmIntialize(nullptr)` needs to be called before `RMM_TRY`. This is now handled in `cubic_spline_test.cpp`.