### PR TITLE
[REVIEW] Fix broken haversine tests caused by cudf migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - PR #141 Fix dangling exec_policy pointer and invalid num_ring argument.
 - PR #169 Fix shapefile reader compilation with GCC 7.x / CUDA 10.2
+- PR #178 Fix broken haversine tests introduced by upstream CUDF PRs.
 
 
 # cuSpatial 0.13.0 (31 Mar 2020)

--- a/python/cuspatial/cuspatial/tests/test_haversine_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_haversine_distance.py
@@ -61,10 +61,10 @@ def test_triple():
     pnt_y2 = []
     for i in cities:
         for j in cities:
-            pnt_x1.append(cities[i][0])
-            pnt_y1.append(cities[i][1])
-            pnt_x2.append(cities[j][0])
-            pnt_y2.append(cities[j][1])
+            pnt_x1.append(cities[i].iloc[0])
+            pnt_y1.append(cities[i].iloc[1])
+            pnt_x2.append(cities[j].iloc[0])
+            pnt_y2.append(cities[j].iloc[1])
     distance = cuspatial.haversine_distance(
         cudf.Series(pnt_x1),
         cudf.Series(pnt_y1),


### PR DESCRIPTION
Cudf changed series indexing rules to require `.iloc` for writing. This PR adds that to haversine tests, which are breaking other PRs.