### PR TITLE
[REVIEW] remove test_benchmark.cpp from cmakelists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PR #175 Address RMM API changes by eliminating the use of the RMM_API
 - PR #199 Fix coordinate transform tests
 - PR #215 Replace legacy RMM calls
+- PR #218 Fix benchmark build by removing test_benchmark.cpp
 
 
 # cuSpatial 0.13.0 (31 Mar 2020)

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -69,11 +69,3 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT
                  "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}"
                  "${CUSPATIAL_LIBRARY}")
-
-###################################################################################################
-# - test benchmark --------------------------------------------------------------------------------
-
-set(TEST_BENCH_SRC
-  "${CMAKE_CURRENT_SOURCE_DIR}/test/test_benchmark.cpp")
-
-ConfigureBench(TEST_BENCH "${TEST_BENCH_SRC}")


### PR DESCRIPTION
Fixes benchmark build by removing `test_benchmark.cpp` from cmakelists, as it was removed in #215.