### PR TITLE
[REVIEW] Add python methods to api.rst, fix formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #205 Port hausdorff.hpp cython to libcudf++
 - PR #206 Remove legacy code.
 - PR #214 Install gdal>=3.0.2 in build.sh
+- PR #221 Add python methods to api.rst, fix formatting
 
 ## Bug Fixes
 

--- a/cpp/include/cuspatial/trajectory.hpp
+++ b/cpp/include/cuspatial/trajectory.hpp
@@ -95,6 +95,7 @@ std::unique_ptr<cudf::table> trajectory_distances_and_speeds(
  *
  * @note Assumes object_id, timestamp, x, y presorted by (object_id, timestamp).
  *
+ * @param num_trajectories number of trajectories (unique object ids)
  * @param object_id column of object (e.g., vehicle) ids
  * @param x coordinates (in kilometers)
  * @param y coordinates (in kilometers)

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -63,13 +63,14 @@ __global__ void point_in_polygon_kernel(cudf::size_type num_test_points,
       auto ring_idx_next = ring_idx + 1;
       auto ring_begin    = poly_ring_offsets[ring_idx];
       auto ring_end = (ring_idx_next < num_rings) ? poly_ring_offsets[ring_idx_next] : num_points;
+      auto ring_len = ring_end - ring_begin;
 
       // for each line segment
-      for (auto point_idx = ring_begin; point_idx < ring_end - 1; point_idx++) {
-        T ax = poly_points_x[point_idx];
-        T ay = poly_points_y[point_idx];
-        T bx = poly_points_x[point_idx + 1];
-        T by = poly_points_y[point_idx + 1];
+      for (auto point_idx = 0; point_idx < ring_len; point_idx++) {
+        T ax = poly_points_x[ring_begin + ((point_idx + 0) % ring_len)];
+        T ay = poly_points_y[ring_begin + ((point_idx + 0) % ring_len)];
+        T bx = poly_points_x[ring_begin + ((point_idx + 1) % ring_len)];
+        T by = poly_points_y[ring_begin + ((point_idx + 1) % ring_len)];
 
         bool y_between_ay_by = ay <= y && y < by;  // is y in range [ay, by) when ay < by?
         bool y_between_by_ay = by <= y && y < ay;  // is y in range [by, ay) when by < ay?

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -324,3 +324,35 @@ TEST_F(PointInPolygonErrorTest, MismatchPointTypes)
       test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys),
     cuspatial::logic_error);
 }
+
+TYPED_TEST(PointInPolygonTest, SelfClosingLoopLeftEdgeMissing)
+{
+  using T                = TypeParam;
+  auto test_point_xs     = wrapper<T>({-2.0, 0.0, 2.0});
+  auto test_point_ys     = wrapper<T>({0.0, 0.0, 0.0});
+  auto poly_offsets      = wrapper<cudf::size_type>({0});
+  auto poly_ring_offsets = wrapper<cudf::size_type>({0});
+  // "left" edge missing
+  auto poly_point_xs = wrapper<T>({-1, 1, 1, -1});
+  auto poly_point_ys = wrapper<T>({1, 1, -1, -1});
+  auto expected      = wrapper<int32_t>({0b0, 0b1, 0b0});
+  auto actual        = cuspatial::point_in_polygon(
+    test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
+  expect_columns_equal(expected, actual->view(), true);
+}
+
+TYPED_TEST(PointInPolygonTest, SelfClosingLoopRightEdgeMissing)
+{
+  using T                = TypeParam;
+  auto test_point_xs     = wrapper<T>({-2.0, 0.0, 2.0});
+  auto test_point_ys     = wrapper<T>({0.0, 0.0, 0.0});
+  auto poly_offsets      = wrapper<cudf::size_type>({0});
+  auto poly_ring_offsets = wrapper<cudf::size_type>({0});
+  // "right" edge missing
+  auto poly_point_xs = wrapper<T>({1, -1, -1, 1});
+  auto poly_point_ys = wrapper<T>({-1, -1, 1, 1});
+  auto expected      = wrapper<int32_t>({0b0, 0b1, 0b0});
+  auto actual        = cuspatial::point_in_polygon(
+    test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
+  expect_columns_equal(expected, actual->view(), true);
+}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,18 +3,50 @@ cuSpatial API Reference
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 
+GIS
+---
+.. currentmodule:: cuspatial.core.gis
+
+.. automethod:: cuspatial.core.gis.directed_hausdorff_distance
+.. automethod:: cuspatial.core.gis.haversine_distance
+.. automethod:: cuspatial.core.gis.lonlat_to_cartesian
+.. automethod:: cuspatial.core.gis.point_in_polygon
+
+
+Indexing
+--------
+.. currentmodule:: cuspatial.core.indexing
+
+.. automethod:: cuspatial.core.indexing.quadtree_on_points
+
+
+Interpolation
+-------------
+.. currentmodule:: cuspatial.core.interpolate
+
+.. autoclass:: CubicSpline
+.. automethod:: CubicSpline.__init__
+.. automethod:: CubicSpline.__call__
+
+
+Spatial Querying
+----------------
+.. currentmodule:: cuspatial.core.spatial_window
+
+.. automethod:: cuspatial.core.spatial_window.points_in_spatial_window
+
+
 Trajectory
 ----------
 .. currentmodule:: cuspatial.core.trajectory
 
-.. automethod:: cuspatial.core.trajectory.subset_trajectory_id
-.. automethod:: cuspatial.core.trajectory.spatial_bounds
-.. automethod:: cuspatial.core.trajectory.derive
-.. automethod:: cuspatial.core.trajectory.distance_and_speed   
+.. automethod:: cuspatial.core.trajectory.derive_trajectories
+.. automethod:: cuspatial.core.trajectory.trajectory_bounding_boxes
+.. automethod:: cuspatial.core.trajectory.trajectory_distances_and_speeds
 
-GIS
----
-.. automethod:: cuspatial.core.gis.directed_hausdorff_distance 
-.. automethod:: cuspatial.core.gis.haversine_distance
-.. automethod:: cuspatial.core.gis.lonlat_to_cartesian
-.. automethod:: cuspatial.core.gis.window_points
+
+IO
+--
+.. currentmodule:: cuspatial.io.shapefile
+
+.. automethod:: cuspatial.io.shapefile.read_polygon_shapefile

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -21,53 +21,61 @@ def directed_hausdorff_distance(xs, ys, points_per_space):
     """Compute the directed Hausdorff distances between all pairs of
     spaces.
 
-    params
-    xs: x-coordinates
-    ys: y-coordinates
-    points_per_space: number of points in each space
-
     Parameters
     ----------
-    {params}
+    xs
+        column of x-coordinates
+    ys
+        column of y-coordinates
+    points_per_space
+        number of points in each space
 
-    Example
+    Returns
     -------
+    result : cudf.DataFrame
+        The pairwise directed distance matrix with one row and one
+        column per input space; the value at row i, column j represents the
+        hausdorff distance from space i to space j.
+
+    Examples
+    --------
     The directed Hausdorff distance from one space to another is the greatest
     of all the distances between any point in the first space to the closest
     point in the second.
 
-    [Wikipedia](https://en.wikipedia.org/wiki/Hausdorff_distance)
+    `Wikipedia <https://en.wikipedia.org/wiki/Hausdorff_distance>`_
 
-    Consider a pair of lines on a grid.
+    Consider a pair of lines on a grid::
 
-     |
-     o
-    -oxx-
-     |
-    o = [[0, 0], [0, 1]]
-    x = [[1, 0], [2, 0]]
+             :
+             x
+        -----xyy---
+             :
+             :
 
-    o[0] is the closest point in o to x. The distance from o[0] to the farthest
-    point in x = 2.
-    x[0] is the closest point in x to o. The distance from x[0] to the farthest
-    point in o = 1.414.
+    x\\ :sub:`0` = (0, 0), x\\ :sub:`1` = (0, 1)
 
-        result = cuspatial.directed_hausdorff_distance(
-            cudf.Series([0, 1, 0, 0]),
-            cudf.Series([0, 0, 1, 2]),
-            cudf.Series([2, 2,]),
+    y\\ :sub:`0` = (1, 0), y\\ :sub:`1` = (2, 0)
+
+    x\\ :sub:`0` is the closest point in ``x`` to ``y``. The distance from
+    x\\ :sub:`0` to the farthest point in ``y`` is 2.
+
+    y\\ :sub:`0` is the closest point in ``y`` to ``x``. The distance from
+    y\\ :sub:`0` to the farthest point in ``x`` is 1.414.
+
+    Compute the directed hausdorff distances between a set of spaces
+
+    >>> result = cuspatial.directed_hausdorff_distance(
+            [0, 1, 0, 0], # xs
+            [0, 0, 1, 2], # ys
+            [2,    2],    # points_per_space
         )
-        print(result)
+    >>> print(result)
              0         1
         0  0.0  1.414214
         1  2.0  0.000000
-
-    Returns
-    -------
-    DataFrame: The pairwise directed distance matrix with one row and one
-    column per input space; the value at row i, column j represents the
-    hausdorff distance from space i to space j.
     """
+
     num_spaces = len(points_per_space)
     if num_spaces == 0:
         return DataFrame()
@@ -84,19 +92,23 @@ def haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat):
     """ Compute the haversine distances between an arbitrary list of lon/lat
     pairs
 
-    params
-    p1_lon: longitude of first set of coords
-    p1_lat: latitude of first set of coords
-    p2_lon: longitude of second set of coords
-    p2_lat: latitude of second set of coords
-
     Parameters
     ----------
-    {params}
+    p1_lon
+        longitude of first set of coords
+    p1_lat
+        latitude of first set of coords
+    p2_lon
+        longitude of second set of coords
+    p2_lat
+        latitude of second set of coords
 
-    returns
-    Series: distance between all pairs of lat/lon coords
+    Returns
+    -------
+    result : cudf.Series
+        The distance between all pairs of lat/lon coordinates
     """
+
     p1_lon, p1_lat, p2_lon, p2_lat = normalize_point_columns(
         as_column(p1_lon),
         as_column(p1_lat),
@@ -107,21 +119,28 @@ def haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat):
 
 
 def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
-    """ Convert lonlat coordinates to km x,y coordinates based on some camera
-    origin.
-
-    params
-    origin_lon: float64 - longitude camera
-    origin_lat: float64 - latitude camera
-    input_lon: Series of longitude coords to convert to x
-    input_lat: Series of latitude coords to convert to y
+    """
+    Convert lon/lat coordinates to kilometer x,y coordinates with respect to
+    an origin camera position.
 
     Parameters
     ----------
-    {params}
+    origin_lon : ``number``
+        camera longitude
+    origin_lat : ``number``
+        camera latitude
+    input_lon : ``Series`` or ``list``
+        longitude coordinates to convert to x
+    input_lat : ``Series`` or ``list``
+        latitude coordinates to convert to y
 
-    returns
-    DataFrame: 'x', 'y' columns for new km positions of coords
+    Returns
+    -------
+    result : cudf.DataFrame
+        x : cudf.Series
+            x-coordinate of the new positions in kilometers
+        y : cudf.Series
+            y-coordinate of the new positions in kilometers
     """
     result = cpp_lonlat_to_cartesian(
         origin_lon, origin_lat, input_lon._column, input_lat._column
@@ -142,51 +161,55 @@ def point_in_polygon(
     closed polygons: the first and last coordinate of each polygon must be
     the same.
 
-    params
-    test_points_x: x-coordinate of test points
-    test_points_y: y-coordinate of test points
-    poly_offsets: beginning index of the first ring in each polygon
-    poly_ring_offsets: beginning index of the first point in each ring
-    poly_points_x: x closed-coordinate of polygon points
-    poly_points_y: y closed-coordinate of polygon points
-
     Parameters
     ----------
-    {params}
+    test_points_x
+        x-coordinate of test points
+    test_points_y
+        y-coordinate of test points
+    poly_offsets
+        beginning index of the first ring in each polygon
+    poly_ring_offsets
+        beginning index of the first point in each ring
+    poly_points_x
+        x closed-coordinate of polygon points
+    poly_points_y
+        y closed-coordinate of polygon points
 
     Examples
     --------
-        result = cuspatial.point_in_polygon(
-            cudf.Series([0, -8, 6.0]]), # x coordinates of 3 query points
-            cudf.Series([0, -8, 6.0]), # y coordinates of 3 query points
-            cudf.Series([1, 2], index=['nyc', 'dc']), # ring positions of
-                    # two polygons each with one ring
-            cudf.Series([4, 8]), # positions of last vertex in each ring
-            # polygon coordinates, x and y. Note [-10, -10] and [0, 0] repeat
-            # the start/end coordinate of the two polygons.
-            cudf.Series([-10, 5, 5, -10, -10, 0, 10, 10, 0, 0]),
-            cudf.Series([-10, -10, 5, 5, -10, 0, 0, 10, 10, 0]),
-        )
-        # The result of point_in_polygon is a DataFrame of Boolean
-        # values indicating whether each point (rows) falls within
-        # each polygon (columns).
-        print(result)
-                    nyc            dc
-        0          True          True
-        1          True         False
-        2         False          True
 
-        # Point 0: (0, 0) falls in both polygons
-        # Point 1: (-8, -8) falls in the first polygon
-        # Point 2: (6.0, 6.0) falls in the second polygon
+    Test whether 3 points fall within either of two polygons
+
+    >>> result = cuspatial.point_in_polygon(
+        [0, -8, 6.0],                             # test_points_x
+        [0, -8, 6.0],                             # test_points_y
+        cudf.Series([0, 1], index=['nyc', 'dc']), # poly_offsets
+        [0, 3],                                   # ring_offsets
+        [-10, 5, 5, -10, 0, 10, 10, 0],           # poly_points_x
+        [-10, -10, 5, 5, 0, 0, 10, 10],           # poly_points_y
+    )
+    # The result of point_in_polygon is a DataFrame of Boolean
+    # values indicating whether each point (rows) falls within
+    # each polygon (columns).
+    >>> print(result)
+                nyc            dc
+    0          True          True
+    1          True         False
+    2         False          True
+    # Point 0: (0, 0) falls in both polygons
+    # Point 1: (-8, -8) falls in the first polygon
+    # Point 2: (6.0, 6.0) falls in the second polygon
 
     note
     input Series x and y will not be index aligned, but computed as
     sequential arrays.
 
-    returns
-    DataFrame: a DataFrame of Boolean values indicating whether each point
-    falls within each polygon.
+    Returns
+    -------
+    result : cudf.DataFrame
+        A DataFrame of boolean values indicating whether each point falls
+        within each polygon.
     """
 
     if len(poly_offsets) == 0:

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -106,7 +106,7 @@ def haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat):
     Returns
     -------
     result : cudf.Series
-        The distance between all pairs of lat/lon coordinates
+        The distance between all pairs of lon/lat coordinates
     """
 
     p1_lon, p1_lat, p2_lon, p2_lat = normalize_point_columns(

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -126,9 +126,11 @@ def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     Parameters
     ----------
     origin_lon : ``number``
-        longitude offset  (this is subtracted from each input before converting to x,y)
+        longitude offset  (this is subtracted from each input before
+        converting to x,y)
     origin_lat : ``number``
-        latitude offset (this is subtracted from each input before converting to x,y)
+        latitude offset (this is subtracted from each input before
+        converting to x,y)
     input_lon : ``Series`` or ``list``
         longitude coordinates to convert to x
     input_lat : ``Series`` or ``list``
@@ -138,9 +140,11 @@ def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     -------
     result : cudf.DataFrame
         x : cudf.Series
-            x-coordinates of the input relative to the size of Earth in kilometers.
+            x-coordinate of the input relative to the size of Earth in
+            kilometers.
         y : cudf.Series
-            y-coordinate of the input relative to the size of Earth in kilometers
+            y-coordinate of the input relative to the size of Earth in
+            kilometers.
     """
     result = cpp_lonlat_to_cartesian(
         origin_lon, origin_lat, input_lon._column, input_lat._column

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -120,8 +120,8 @@ def haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat):
 
 def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     """
-    Convert lon/lat coordinates to kilometer x,y coordinates with respect to
-    an origin camera position.
+    Convert lon/lat to ``x,y`` coordinates with respect to an origin lon/lat
+    point. Results are scaled relative to the size of the Earth in kilometers.
 
     Parameters
     ----------
@@ -140,10 +140,10 @@ def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     -------
     result : cudf.DataFrame
         x : cudf.Series
-            x-coordinate of the input relative to the size of Earth in
+            x-coordinate of the input relative to the size of the Earth in
             kilometers.
         y : cudf.Series
-            y-coordinate of the input relative to the size of Earth in
+            y-coordinate of the input relative to the size of the Earth in
             kilometers.
     """
     result = cpp_lonlat_to_cartesian(

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -126,9 +126,9 @@ def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     Parameters
     ----------
     origin_lon : ``number``
-        camera longitude
+        longitude offset  (this is subtracted from each input before converting to x,y)
     origin_lat : ``number``
-        camera latitude
+        latitude offset (this is subtracted from each input before converting to x,y)
     input_lon : ``Series`` or ``list``
         longitude coordinates to convert to x
     input_lat : ``Series`` or ``list``
@@ -138,9 +138,9 @@ def lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat):
     -------
     result : cudf.DataFrame
         x : cudf.Series
-            x-coordinate of the new positions in kilometers
+            x-coordinates of the input relative to the size of Earth in kilometers.
         y : cudf.Series
-            y-coordinate of the new positions in kilometers
+            y-coordinate of the input relative to the size of Earth in kilometers
     """
     result = cpp_lonlat_to_cartesian(
         origin_lon, origin_lat, input_lon._column, input_lat._column
@@ -184,7 +184,7 @@ def point_in_polygon(
     >>> result = cuspatial.point_in_polygon(
         [0, -8, 6.0],                             # test_points_x
         [0, -8, 6.0],                             # test_points_y
-        cudf.Series([0, 1], index=['nyc', 'dc']), # poly_offsets
+        cudf.Series([0, 1], index=['nyc', 'hudson river']), # poly_offsets
         [0, 3],                                   # ring_offsets
         [-10, 5, 5, -10, 0, 10, 10, 0],           # poly_points_x
         [-10, -10, 5, 5, 0, 0, 10, 10],           # poly_points_y
@@ -193,7 +193,7 @@ def point_in_polygon(
     # values indicating whether each point (rows) falls within
     # each polygon (columns).
     >>> print(result)
-                nyc            dc
+                nyc            hudson river
     0          True          True
     1          True         False
     2         False          True

--- a/python/cuspatial/cuspatial/core/indexing.py
+++ b/python/cuspatial/cuspatial/core/indexing.py
@@ -17,13 +17,138 @@ def quadtree_on_points(
 
     Parameters
     ----------
-    {params}
-    quadtree  : DataFrame of key, level, is_node, length, and offset columns
+    xs
+        Column of x-coordinates for each point
+    ys
+        Column of y-coordinates for each point
+    x_min
+        The lower-left x-coordinate of the area of interest bounding box
+    x_max
+        The upper-right x-coordinate of the area of interest bounding box
+    y_min
+        The lower-left y-coordinate of the area of interest bounding box
+    y_max
+        The upper-right y-coordinate of the area of interest bounding box
+    scale
+        Scale to apply to each point's distance from ``(x_min, y_min)``
+    max_depth
+        Maximum quadtree depth
+    min_size
+        Minimum number of points for a non-leaf quadtree node
+
+    Returns
+    -------
+    result : tuple (cudf.Series, cudf.DataFrame)
+        keys_to_points  : cudf.Series(dtype=np.int32)
+            A column of sorted keys to original point indices
+        quadtree        : cudf.DataFrame
+            A complete quadtree for the set of input points
+
+            key         : cudf.Series(dtype=np.int32)
+                An int32 column of quadrant keys
+            level       : cudf.Series(dtype=np.int8)
+                An int8 column of quadtree levels
+            is_node     : cudf.Series(dtype=np.bool_)
+                A boolean column indicating whether the node is a leaf or not
+            length      : cudf.Series(dtype=np.int32)
+                If this is a non-leaf quadrant (i.e. ``is_node`` is ``True``),
+                this column's value is the number of children in the non-leaf
+                quadrant.
+
+                Otherwise this column's value is the number of points
+                contained in the leaf quadrant.
+            offset      : cudf.Series(dtype=np.int32)
+                If this is a non-leaf quadrant (i.e. ``is_node`` is ``True``),
+                this column's value is the position of the non-leaf quadrant's
+                first child.
+
+                Otherwise this column's value is the position of the leaf
+                quadrant's first point.
+
+    Notes
+    -----
+    * Swaps ``min_x`` and ``max_x`` if ``min_x > max_x``
+    * Swaps ``min_y`` and ``max_y`` if ``min_y > max_y``
+
+    Examples
+    --------
+
+    An example of selecting the ``min_size`` and ``scale`` based on input::
+
+        >>> np.random.seed(0)
+        >>> points = cudf.DataFrame({
+                "x": cudf.Series(np.random.normal(size=120)) * 500,
+                "y": cudf.Series(np.random.normal(size=120)) * 500,
+            })
+
+        >>> max_depth = 3
+        >>> min_size = 50
+        >>> min_x, min_y, max_x, max_y = (points["x"].min(),
+                                          points["y"].min(),
+                                          points["x"].max(),
+                                          points["y"].max())
+        >>> scale = max(abs(max_x - min_x),
+                        abs(max_y - min_y)) // (1 << max_depth)
+        >>> print(
+                "min_size:   " + str(min_size) + "\\n"
+                "num_points: " + str(len(points)) + "\\n"
+                "min_x:      " + str(min_x - scale) + "\\n"
+                "min_y:      " + str(min_y - scale) + "\\n"
+                "max_x:      " + str(max_x + scale) + "\\n"
+                "max_y:      " + str(max_y + scale) + "\\n"
+                "scale:      " + str(scale) + "\\n"
+            )
+        min_size:   50
+        num_points: 120
+        min_x:      -1577.4949079170394
+        min_y:      -1412.7015761122134
+        max_x:      1435.877311993804
+        max_y:      1492.572387431971
+        scale:      301.0
+
+        >>> key_to_point, quadtree = cuspatial.quadtree_on_points(
+                points["x"],    # x
+                points["y"],    # y
+                min_x - scale,  # min_x
+                max_x + scale,  # max_x
+                min_y - scale,  # min_y
+                max_y + scale,  # max_y
+                scale, max_depth, min_size
+            )
+
+        >>> print(quadtree)
+            key  level  is_node  length  offset
+        0     0      0    False      15       0
+        1     1      0    False      27      15
+        2     2      0    False      12      42
+        3     3      0     True       4       8
+        4     4      0    False       5     106
+        5     6      0    False       6     111
+        6     9      0    False       2     117
+        7    12      0    False       1     119
+        8    12      1    False      22      54
+        9    13      1    False      18      76
+        10   14      1    False       9      94
+        11   15      1    False       3     103
+
+        >>> print(key_to_point)
+        0       63
+        1       20
+        2       33
+        3       66
+        4       19
+            ...
+        115    113
+        116      3
+        117     78
+        118     98
+        119     24
+        Length: 120, dtype: int32
     """
 
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))
 
-    points_order, quadtree = cpp_quadtree_on_points(
+    key_to_point, quadtree = cpp_quadtree_on_points(
         xs,
         ys,
         min(x_min, x_max),
@@ -34,4 +159,4 @@ def quadtree_on_points(
         max_depth,
         min_size,
     )
-    return Series(points_order), DataFrame._from_table(quadtree)
+    return Series(key_to_point), DataFrame._from_table(quadtree)

--- a/python/cuspatial/cuspatial/core/interpolate.py
+++ b/python/cuspatial/cuspatial/core/interpolate.py
@@ -36,8 +36,8 @@ class CubicSpline:
     """
     Fits each column of the input Series `y` to a hermetic cubic spline.
 
-    cuspatial.CubicSpline supports two usage patterns: The first is
-    identical to scipy.interpolate.CubicSpline:
+    ``cuspatial.CubicSpline`` supports two usage patterns: The first is
+    identical to scipy.interpolate.CubicSpline::
 
         curve = cuspatial.CubicSpline(t, y)
         new_points = curve(np.linspace(t.min, t.max, 50))
@@ -46,16 +46,16 @@ class CubicSpline:
     host based interpolation performance is likely to exceed GPU performance
     for a single curve.
 
-    cuspatial massively outperforms scipy however when many
-    splines are fit simultaneously. Data must be arranged in a SoA format,
-    and the inclusive/exclusive prefix_sum of the separate curves must also
-    be passed to the function.
+    However, cuSpatial massively outperforms scipy when many splines are fit
+    simultaneously. Data must be arranged in a SoA format, and the exclusive
+    `prefix_sum` of the separate curves must also be passed to the function.::
 
         t = cudf.Series(np.repeat(cp.arange(100), 1000)).astype('float32')
         y = cudf.Series(np.random.random(100*1000)).astype('float32')
         prefix_sum = cudf.Series(cp.arange(1000)*100).astype('int32')
-        new_samples = cudf.Series(np.repeat(np.linspace(0, 100, 1000), 1000)
-            .astype('float32'))
+        new_samples = cudf.Series(
+            np.repeat(np.linspace(0, 100, 1000), 1000)
+        ).astype('float32')
 
         curve = cuspatial.CubicSpline(t, y, prefixes=prefix_sum)
         new_points = curve(new_samples, prefix_sum*10)
@@ -65,8 +65,8 @@ class CubicSpline:
     def __init__(self, t, y, ids=None, size=None, prefixes=None):
         """
         Computes various error preconditions on the input data, then
-        calls C++/Thrust code to compute cubic splines for each set of input
-        coordinates in parallel.
+        uses CUDA to compute cubic splines for each set of input
+        coordinates on the GPU in parallel.
 
         Parameters
         ----------
@@ -84,10 +84,10 @@ class CubicSpline:
 
         Returns
         -------
-        CubicSpline object `o`. `o.c` contains the coefficients that can be
-        used to compute new points along the spline fitting the original `t`
-        data. `o(n)` interpolates the spline coordinates along new input
-        values `n`.
+        CubicSpline : callable `o`
+            ``o.c`` contains the coefficients that can be used to compute new
+            points along the spline fitting the original ``t`` data. ``o(n)``
+            interpolates the spline coordinates along new input values ``n``.
         """
 
         # error protections:

--- a/python/cuspatial/cuspatial/core/spatial_window.py
+++ b/python/cuspatial/cuspatial/core/spatial_window.py
@@ -11,31 +11,36 @@ def points_in_spatial_window(min_x, max_x, min_y, max_y, xs, ys):
     """ Return only the subset of coordinates that fall within a
     rectangular window.
 
-    A point (x, y) is inside the query window if and only if
-    min_x < x < max_x AND min_y < y < max_y
+    A point `(x, y)` is inside the query window if and only if
+    ``min_x < x < max_x AND min_y < y < max_y``
 
     The window is specified by minimum and maximum x and y
     coordinates.
 
-    Swaps min_x and max_x if min_x > max_x.
-    Swaps min_y and max_y if min_y > max_y.
-
-    params
-    min_x: lower x-coordinate of the query window
-    max_x: upper x-coordinate of the query window
-    min_y: lower y-coordinate of the query window
-    max_y: upper y-coordinate of the query window
-
-    xs: Series of x-coordinates that may fall within the window
-    ys: Series of y-coordinates that may fall within the window
-
     Parameters
     ----------
-    {params}
+    min_x
+        lower x-coordinate of the query window
+    max_x
+        upper x-coordinate of the query window
+    min_y
+        lower y-coordinate of the query window
+    max_y
+        upper y-coordinate of the query window
+    xs
+        column of x-coordinates that may fall within the window
+    ys
+        column of y-coordinates that may fall within the window
 
     Returns
     -------
-    DataFrame: subset of x, y pairs above that fall within the window
+    result : cudf.DataFrame
+        subset of `(x, y)` pairs above that fall within the window
+
+    Notes
+    -----
+    * Swaps ``min_x`` and ``max_x`` if ``min_x > max_x``
+    * Swaps ``min_y`` and ``max_y`` if ``min_y > max_y``
     """
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))
     result = spatial_window.points_in_spatial_window(

--- a/python/cuspatial/cuspatial/io/shapefile.py
+++ b/python/cuspatial/cuspatial/io/shapefile.py
@@ -9,7 +9,7 @@ from cuspatial._lib.shapefile_reader import (
 
 def read_polygon_shapefile(filename):
     """
-    Reads an ESRI shapefile into GPU memory.
+    Reads polygon geometry from an ESRI shapefile into GPU memory.
 
     Parameters
     ----------

--- a/python/cuspatial/cuspatial/io/shapefile.py
+++ b/python/cuspatial/cuspatial/io/shapefile.py
@@ -8,7 +8,28 @@ from cuspatial._lib.shapefile_reader import (
 
 
 def read_polygon_shapefile(filename):
-    """Reads a shapefile into GPU memory."""
+    """
+    Reads an ESRI shapefile into GPU memory.
+
+    Parameters
+    ----------
+    filename : str, pathlike
+        ESRI Shapefile file path (usually ends in ``.shp``)
+
+    Returns
+    -------
+    result  : tuple (cudf.Series, cudf.Series, cudf.DataFrame)
+    poly_offsets   : cudf.Series(dtype=np.int32)
+        Offsets of the first ring in each polygon
+    ring_offsets   : cudf.Series(dtype=np.int32)
+        Offsets of the first point in each ring
+    points  : cudf.DataFrame
+        DataFrame of all points in the shapefile
+            x : cudf.Series(dtype=np.float64)
+                x-components of each polygon's points
+            y : cudf.Series(dtype=np.float64)
+                y-components of each polygon's points
+    """
     result = cpp_read_polygon_shapefile(filename)
     f_pos = Series(result[0], name="f_pos")
     r_pos = Series(result[1], name="r_pos")

--- a/python/cuspatial/cuspatial/tests/test_pip.py
+++ b/python/cuspatial/cuspatial/tests/test_pip.py
@@ -135,14 +135,14 @@ def test_one_point_in_two_rings():
     assert_eq(expected, result)
 
 
-def xxxtest_one_point_in_two_rings():
+def test_one_point_in_two_rings_no_repeat():
     result = cuspatial.point_in_polygon(
         cudf.Series([0]),
         cudf.Series([0]),
         cudf.Series([0]),
         cudf.Series([0, 3]),
-        cudf.Series([-1, 0, 1, -1, -1, 0, 1, -1]),
-        cudf.Series([-1, 1, -1, -1, 3, 5, 3, 3]),
+        cudf.Series([-1, 0, 1, -1, 0, 1]),
+        cudf.Series([-1, 1, -1, 3, 5, 3]),
     )
     expected = cudf.DataFrame({0: True})
     assert_eq(expected, result)
@@ -161,14 +161,14 @@ def test_one_point_out_two_rings():
     assert_eq(expected, result)
 
 
-def xxxtest_one_point_out_two_rings():
+def test_one_point_out_two_rings_no_repeat():
     result = cuspatial.point_in_polygon(
         cudf.Series([1]),
         cudf.Series([1]),
         cudf.Series([0]),
         cudf.Series([0, 3]),
-        cudf.Series([-1, 0, 1, -1, -1, 0, 1, -1]),
-        cudf.Series([-1, 1, -1, -1, 3, 5, 3, 3]),
+        cudf.Series([-1, 0, 1, -1, 0, 1]),
+        cudf.Series([-1, 1, -1, 3, 5, 3]),
     )
     expected = cudf.DataFrame({0: False})
     assert_eq(expected, result)


### PR DESCRIPTION
This PR fixes a few formatting issues in our Python docs and adds all the new methods to the Sphinx `api.rst` manifest.

If you're using `rapids-compose`, here's an easy way to build the python docs:
```shell
make html -C $CUSPATIAL_HOME/docs
```

Or if you're doing a lot of docs editing and want to auto-rebuild the docs on save, you can do this:
```shell
# Install `entr` to watch files (https://systutorials.com/docs/linux/man/1-entr/)
echo "rapids" | sudo -S apt update && echo "rapids" | sudo -S apt install entr

# Launch `entr` to re-run `make html` any time the source or config files change
find $CUSPATIAL_HOME/python $CUSPATIAL_HOME/docs/source \
  | entr sh -c "make html -C $CUSPATIAL_HOME/docs"
```

<details><summary>Expand this to see a screenshot of the rendered docs</summary>
<img src="https://user-images.githubusercontent.com/178183/82729418-468a5400-9cac-11ea-9a1f-29080b438cb3.png"/>
</details>