### PR TITLE
[REVIEW] Fix potential thrust launch failure in quadtree building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PR #205 Port hausdorff.hpp cython to libcudf++
 - PR #206 Remove legacy code.
 - PR #214 Install gdal>=3.0.2 in build.sh
+- PR #222 Fix potential thrust launch failure in quadtree building
 
 ## Bug Fixes
 

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -292,16 +292,16 @@ inline auto make_full_levels(cudf::column_view const &x,
   // This allows us to avoid building the "full" quads for each level only to turn around and
   // remove them for having no children. This scenario causes the `thrust::transform` call in
   // `construct_non_leaf_indicator()` to launch on zero elements.
-  if (num_top_quads >= static_cast<cudf::size_type>(quad_keys.size())) {
-    return std::make_tuple(std::move(point_indices),
-                           std::move(quad_keys),
-                           std::move(quad_point_count),
-                           std::move(rmm::device_vector<uint32_t>(0)),
-                           std::move(rmm::device_vector<int8_t>(0)),
-                           num_top_quads,
-                           0,
-                           0);
-  }
+  // if (num_top_quads >= static_cast<cudf::size_type>(quad_keys.size())) {
+  //   return std::make_tuple(std::move(point_indices),
+  //                          std::move(quad_keys),
+  //                          std::move(quad_point_count),
+  //                          std::move(rmm::device_vector<uint32_t>(0)),
+  //                          std::move(rmm::device_vector<int8_t>(0)),
+  //                          num_top_quads,
+  //                          0,
+  //                          0);
+  // }
 
   // Repurpose the `point_keys` vector now the points have been grouped into the
   // leaf quadrants

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -263,7 +263,7 @@ inline auto make_full_levels(cudf::column_view const &x,
                              rmm::mr::device_memory_resource *mr,
                              cudaStream_t stream)
 {
-  // Compute point keys and sort into top-level quadrants
+  // Compute point keys and sort into bottom-level quadrants
   // (i.e. quads at level `max_depth - 1`)
 
   // Compute Morton code (z-order) keys for each point
@@ -279,21 +279,21 @@ inline auto make_full_levels(cudf::column_view const &x,
   // Construct quadrants at the finest level of detail, i.e. the quadrants
   // furthest from the root. Reduces points with common z-order codes into
   // the same quadrant.
-  auto const num_top_quads = build_tree_level(point_keys.begin(),
-                                              point_keys.end(),
-                                              thrust::make_constant_iterator<uint32_t>(1),
-                                              quad_keys.begin(),
-                                              quad_point_count.begin(),
-                                              thrust::plus<uint32_t>(),
-                                              stream);
+  auto const num_bottom_quads = build_tree_level(point_keys.begin(),
+                                                 point_keys.end(),
+                                                 thrust::make_constant_iterator<uint32_t>(1),
+                                                 quad_keys.begin(),
+                                                 quad_point_count.begin(),
+                                                 thrust::plus<uint32_t>(),
+                                                 stream);
 
   // Repurpose the `point_keys` vector now the points have been grouped into the
   // leaf quadrants
   auto &quad_child_count = point_keys;
 
-  quad_keys.resize(num_top_quads * (max_depth + 1));
-  quad_point_count.resize(num_top_quads * (max_depth + 1));
-  quad_child_count.resize(num_top_quads * (max_depth + 1));
+  quad_keys.resize(num_bottom_quads * (max_depth + 1));
+  quad_point_count.resize(num_bottom_quads * (max_depth + 1));
+  quad_child_count.resize(num_bottom_quads * (max_depth + 1));
 
   //
   // Compute "full" quads for the tree at each level. Starting from the quadrant
@@ -327,7 +327,7 @@ inline auto make_full_levels(cudf::column_view const &x,
   //                                                           (root)  |
   //
   auto quads = build_tree_levels(max_depth,
-                                 num_top_quads,
+                                 num_bottom_quads,
                                  quad_keys.begin(),
                                  quad_point_count.begin(),
                                  quad_child_count.begin(),
@@ -353,7 +353,7 @@ inline auto make_full_levels(cudf::column_view const &x,
                            std::move(quad_point_count),
                            std::move(quad_child_count),
                            std::move(rmm::device_vector<int8_t>(quad_keys.size())),
-                           num_top_quads,
+                           num_bottom_quads,
                            num_parent_nodes,
                            0);
   }
@@ -375,7 +375,7 @@ inline auto make_full_levels(cudf::column_view const &x,
                          std::move(std::get<1>(reversed)),
                          std::move(std::get<2>(reversed)),
                          std::move(std::get<3>(reversed)),
-                         num_top_quads,
+                         num_bottom_quads,
                          num_parent_nodes,
                          end_pos[0] - begin_pos[0]);
 }

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -307,6 +307,10 @@ inline auto make_full_levels(cudf::column_view const &x,
   // leaf quadrants
   auto &quad_child_count = point_keys;
 
+  quad_keys.resize(num_top_quads * (max_depth + 1));
+  quad_point_count.resize(num_top_quads * (max_depth + 1));
+  quad_child_count.resize(num_top_quads * (max_depth + 1));
+
   //
   // Compute "full" quads for the tree at each level. Starting from the quadrant
   // at the bottom (at the finest level of detail), aggregates the number of

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -287,22 +287,6 @@ inline auto make_full_levels(cudf::column_view const &x,
                                               thrust::plus<uint32_t>(),
                                               stream);
 
-  // Optimization: return early if all the nodes are top-level leaf children of the root.
-  //
-  // This allows us to avoid building the "full" quads for each level only to turn around and
-  // remove them for having no children. This scenario causes the `thrust::transform` call in
-  // `construct_non_leaf_indicator()` to launch on zero elements.
-  // if (num_top_quads >= static_cast<cudf::size_type>(quad_keys.size())) {
-  //   return std::make_tuple(std::move(point_indices),
-  //                          std::move(quad_keys),
-  //                          std::move(quad_point_count),
-  //                          std::move(rmm::device_vector<uint32_t>(0)),
-  //                          std::move(rmm::device_vector<int8_t>(0)),
-  //                          num_top_quads,
-  //                          0,
-  //                          0);
-  // }
-
   // Repurpose the `point_keys` vector now the points have been grouped into the
   // leaf quadrants
   auto &quad_child_count = point_keys;

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -287,6 +287,22 @@ inline auto make_full_levels(cudf::column_view const &x,
                                               thrust::plus<uint32_t>(),
                                               stream);
 
+  // Optimization: return early if all the nodes are top-level leaf children of the root.
+  //
+  // This allows us to avoid building the "full" quads for each level only to turn around and
+  // remove them for having no children. This scenario causes the `thrust::transform` call in
+  // `construct_non_leaf_indicator()` to launch on zero elements.
+  if (num_top_quads >= static_cast<cudf::size_type>(quad_keys.size())) {
+    return std::make_tuple(std::move(point_indices),
+                           std::move(quad_keys),
+                           std::move(quad_point_count),
+                           std::move(rmm::device_vector<uint32_t>(0)),
+                           std::move(rmm::device_vector<int8_t>(0)),
+                           num_top_quads,
+                           0,
+                           0);
+  }
+
   // Repurpose the `point_keys` vector now the points have been grouped into the
   // leaf quadrants
   auto &quad_child_count = point_keys;

--- a/cpp/src/indexing/construction/detail/phase_2.cuh
+++ b/cpp/src/indexing/construction/detail/phase_2.cuh
@@ -235,12 +235,6 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
   cudf::size_type level_1_size,
   cudaStream_t stream)
 {
-  std::cerr << "min_size: " << min_size << std::endl;
-  std::cerr << "level_1_size: " << level_1_size << std::endl;
-  std::cerr << "quadtree_size: " << quad_keys.size() << std::endl;
-  std::cerr << "num_child_nodes: " << num_child_nodes << std::endl;
-  std::cerr << "num_parent_nodes: " << num_parent_nodes << std::endl;
-
   // compute parent node start positions
   auto parent_positions =
     compute_parent_positions(quad_child_count, num_parent_nodes, num_child_nodes, stream);
@@ -256,8 +250,6 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
                      parent_point_counts + (num_parent_nodes - level_1_size),
                      // i.e. quad_point_count[parent_pos] <= min_size
                      [min_size] __device__(auto const n) { return n <= min_size; });
-
-  std::cerr << "num_invalid_parent_nodes: " << num_invalid_parent_nodes << std::endl;
 
   // line 4 of algorithm in Fig. 5 in ref.
   // revision to line 4: copy unnecessary if using permutation_iterator stencil
@@ -281,8 +273,6 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
 
   // add the number of level 1 nodes back in to num_valid_nodes
   auto num_valid_nodes = thrust::distance(tree, last_valid) + level_1_size;
-
-  std::cerr << "num_valid_nodes: " << num_valid_nodes << std::endl;
 
   quad_keys.resize(num_valid_nodes);
   quad_keys.shrink_to_fit();

--- a/cpp/src/indexing/construction/detail/phase_2.cuh
+++ b/cpp/src/indexing/construction/detail/phase_2.cuh
@@ -235,6 +235,12 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
   cudf::size_type level_1_size,
   cudaStream_t stream)
 {
+  std::cerr << "min_size: " << min_size << std::endl;
+  std::cerr << "level_1_size: " << level_1_size << std::endl;
+  std::cerr << "quadtree_size: " << quad_keys.size() << std::endl;
+  std::cerr << "num_child_nodes: " << num_child_nodes << std::endl;
+  std::cerr << "num_parent_nodes: " << num_parent_nodes << std::endl;
+
   // compute parent node start positions
   auto parent_positions =
     compute_parent_positions(quad_child_count, num_parent_nodes, num_child_nodes, stream);
@@ -250,6 +256,8 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
                      parent_point_counts + (num_parent_nodes - level_1_size),
                      // i.e. quad_point_count[parent_pos] <= min_size
                      [min_size] __device__(auto const n) { return n <= min_size; });
+
+  std::cerr << "num_invalid_parent_nodes: " << num_invalid_parent_nodes << std::endl;
 
   // line 4 of algorithm in Fig. 5 in ref.
   // revision to line 4: copy unnecessary if using permutation_iterator stencil
@@ -273,6 +281,8 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
 
   // add the number of level 1 nodes back in to num_valid_nodes
   auto num_valid_nodes = thrust::distance(tree, last_valid) + level_1_size;
+
+  std::cerr << "num_valid_nodes: " << num_valid_nodes << std::endl;
 
   quad_keys.resize(num_valid_nodes);
   quad_keys.shrink_to_fit();

--- a/cpp/src/indexing/construction/detail/utilities.cuh
+++ b/cpp/src/indexing/construction/detail/utilities.cuh
@@ -39,8 +39,8 @@ inline auto make_zip_iterator(Ts... its)
 
 template <typename T>
 struct tuple_sum {
-  inline __device__ thrust::tuple<T, T> operator()(thrust::tuple<T, T> const &a,
-                                                   thrust::tuple<T, T> const &b)
+  inline __device__ thrust::tuple<T, T> operator()(thrust::tuple<T, T> const& a,
+                                                   thrust::tuple<T, T> const& b)
   {
     return thrust::make_tuple(thrust::get<0>(a) + thrust::get<0>(b),
                               thrust::get<1>(a) + thrust::get<1>(b));
@@ -54,7 +54,7 @@ template <typename T>
 inline std::unique_ptr<cudf::column> make_fixed_width_column(
   cudf::size_type size,
   cudaStream_t stream                 = 0,
-  rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
 {
   return cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_to_id<T>()}, size, cudf::mask_state::UNALLOCATED, stream, mr);

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -86,8 +86,6 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
     auto quad_point_pos = compute_flattened_first_point_positions(
       quad_keys, quad_levels, quad_point_count, *is_node, num_valid_nodes, max_depth, stream);
 
-    // rmm::device_vector<uint32_t> quad_child_pos(num_valid_nodes);
-
     auto quad_child_pos = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
     // line 9 of algorithm in Fig. 5 in ref.
     thrust::replace_if(rmm::exec_policy(stream)->on(stream),

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -312,8 +312,6 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   rmm::mr::device_memory_resource *mr,
   cudaStream_t stream)
 {
-  auto min_scale = std::max(std::abs(x_max - x_min), std::abs(y_max - y_min)) /
-                   static_cast<double>((1 << max_depth) + 2);
   return cudf::type_dispatcher(x.type(),
                                dispatch_construct_quadtree{},
                                x,
@@ -322,7 +320,7 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
                                x_max,
                                y_min,
                                y_max,
-                               std::max(min_scale, scale),
+                               scale,
                                max_depth,
                                min_size,
                                mr,

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -312,6 +312,8 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   rmm::mr::device_memory_resource *mr,
   cudaStream_t stream)
 {
+  auto min_scale = std::max(std::abs(x_max - x_min), std::abs(y_max - y_min)) /
+                   static_cast<double>((1 << max_depth) + 2);
   return cudf::type_dispatcher(x.type(),
                                dispatch_construct_quadtree{},
                                x,
@@ -320,7 +322,7 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
                                x_max,
                                y_min,
                                y_max,
-                               scale,
+                               std::max(min_scale, scale),
                                max_depth,
                                min_size,
                                mr,

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -74,7 +74,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
 
   // Construct the indicator output column.
   // line 6 and 7 of algorithm in Fig. 5 in ref.
-  auto is_node = construct_non_leaf_indicator(
+  auto is_quad = construct_non_leaf_indicator(
     quad_point_count, num_parent_nodes, num_valid_nodes, min_size, mr, stream);
 
   // Construct the offsets output column
@@ -84,14 +84,14 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
     // revision to line 8: adjust quad_point_pos based on last-level z-order
     // code
     auto quad_point_pos = compute_flattened_first_point_positions(
-      quad_keys, quad_levels, quad_point_count, *is_node, num_valid_nodes, max_depth, stream);
+      quad_keys, quad_levels, quad_point_count, *is_quad, num_valid_nodes, max_depth, stream);
 
     auto quad_child_pos = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
     // line 9 of algorithm in Fig. 5 in ref.
     thrust::replace_if(rmm::exec_policy(stream)->on(stream),
                        quad_child_count.begin(),
                        quad_child_count.begin() + num_valid_nodes,
-                       is_node->view().begin<int8_t>(),
+                       is_quad->view().begin<int8_t>(),
                        !thrust::placeholders::_1,
                        0);
 
@@ -103,11 +103,11 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
                            level_1_size);
 
     auto &offsets     = quad_child_pos;
-    auto offsets_iter = make_zip_iterator(is_node->view().begin<bool>(),
+    auto offsets_iter = make_zip_iterator(is_quad->view().begin<bool>(),
                                           quad_child_pos->view().template begin<uint32_t>(),
                                           quad_point_pos.begin());
 
-    // for each value in `is_node` copy from `quad_child_pos` if true, else
+    // for each value in `is_quad` copy from `quad_child_pos` if true, else
     // `quad_point_pos`
     thrust::transform(rmm::exec_policy(stream)->on(stream),
                       offsets_iter,
@@ -123,9 +123,9 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
 
   // Construct the lengths output column
   auto lengths = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
-  // for each value in `is_node` copy from `quad_child_count` if true, else
+  // for each value in `is_quad` copy from `quad_child_count` if true, else
   // `quad_point_count`
-  auto lengths_iter = make_zip_iterator(is_node->view().begin<bool>(),  //
+  auto lengths_iter = make_zip_iterator(is_quad->view().begin<bool>(),  //
                                         quad_child_count.begin(),
                                         quad_point_count.begin());
   thrust::transform(rmm::exec_policy(stream)->on(stream),
@@ -159,7 +159,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
   cols.reserve(5);
   cols.push_back(std::move(keys));
   cols.push_back(std::move(levels));
-  cols.push_back(std::move(is_node));
+  cols.push_back(std::move(is_quad));
   cols.push_back(std::move(lengths));
   cols.push_back(std::move(offsets));
   return std::make_unique<cudf::table>(std::move(cols));
@@ -177,7 +177,7 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
 {
   auto keys    = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
   auto levels  = make_fixed_width_column<int8_t>(num_top_quads, stream, mr);
-  auto is_node = make_fixed_width_column<bool>(num_top_quads, stream, mr);
+  auto is_quad = make_fixed_width_column<bool>(num_top_quads, stream, mr);
   auto lengths = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
   auto offsets = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
 
@@ -201,8 +201,8 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
 
   // Quad node indicators are false for leaf nodes
   thrust::fill(rmm::exec_policy(stream)->on(stream),
-               is_node->mutable_view().begin<bool>(),
-               is_node->mutable_view().end<bool>(),
+               is_quad->mutable_view().begin<bool>(),
+               is_quad->mutable_view().end<bool>(),
                false);
 
   // compute offsets from lengths
@@ -215,7 +215,7 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
   cols.reserve(5);
   cols.push_back(std::move(keys));
   cols.push_back(std::move(levels));
-  cols.push_back(std::move(is_node));
+  cols.push_back(std::move(is_quad));
   cols.push_back(std::move(lengths));
   cols.push_back(std::move(offsets));
   return std::make_unique<cudf::table>(std::move(cols));

--- a/cpp/tests/indexing/point_quadtree_test.cu
+++ b/cpp/tests/indexing/point_quadtree_test.cu
@@ -190,7 +190,7 @@ TEST_F(QuadtreeOnPointIndexingTest, test_all_top_level_quads)
 {
   using namespace cudf::test;
 
-  const uint32_t max_depth = 1;
+  const uint32_t max_depth = 2;
   uint32_t min_size        = 1;
 
   double scale = 1.0;

--- a/cpp/tests/indexing/point_quadtree_test.cu
+++ b/cpp/tests/indexing/point_quadtree_test.cu
@@ -185,3 +185,39 @@ TEST_F(QuadtreeOnPointIndexingTest, test_small)
        fixed_width_column_wrapper<int32_t>({3, 2, 11, 7, 2, 2, 9, 2, 9, 7, 5, 8, 8, 7}),
        fixed_width_column_wrapper<int32_t>({3, 6, 60, 0, 8, 10, 36, 12, 7, 16, 23, 28, 45, 53})}});
 }
+
+TEST_F(QuadtreeOnPointIndexingTest, test_all_top_level_quads)
+{
+  using namespace cudf::test;
+
+  const uint32_t max_depth = 1;
+  uint32_t min_size        = 1;
+
+  double scale = 1.0;
+  double x_min = -1000.0;
+  double x_max = 1000.0;
+  double y_min = -1000.0;
+  double y_max = 1000.0;
+
+  fixed_width_column_wrapper<double> x({-100.0, 100.0});
+  fixed_width_column_wrapper<double> y({-100.0, 100.0});
+
+  auto pair =
+    cuspatial::quadtree_on_points(x, y, x_min, x_max, y_min, y_max, scale, max_depth, min_size);
+  auto &quadtree = std::get<1>(pair);
+
+  CUSPATIAL_EXPECTS(
+    quadtree->num_columns() == 5,
+    "a quadtree table must have 5 columns (keys, levels, is_node, lengths, offsets)");
+
+  CUSPATIAL_EXPECTS(quadtree->num_rows() == 2, "the resulting quadtree must have 2 quadrants");
+
+  // the top level quadtree node is expected to have a value of
+  // ([1032240, 3158256], [0, 0], [0, 0], [1, 1], [0, 1])
+  expect_tables_equal(*quadtree,
+                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({1032240, 3158256}),
+                                        fixed_width_column_wrapper<int8_t>({0, 0}),
+                                        fixed_width_column_wrapper<bool>({0, 0}),
+                                        fixed_width_column_wrapper<int32_t>({1, 1}),
+                                        fixed_width_column_wrapper<int32_t>({0, 1})}});
+}

--- a/cpp/tests/indexing/point_quadtree_test.cu
+++ b/cpp/tests/indexing/point_quadtree_test.cu
@@ -193,11 +193,11 @@ TEST_F(QuadtreeOnPointIndexingTest, test_all_top_level_quads)
   const uint32_t max_depth = 2;
   uint32_t min_size        = 1;
 
-  double scale = 1.0;
   double x_min = -1000.0;
   double x_max = 1000.0;
   double y_min = -1000.0;
   double y_max = 1000.0;
+  double scale = std::max(x_max - x_min, y_max - y_min) / static_cast<double>((1 << max_depth) + 2);
 
   fixed_width_column_wrapper<double> x({-100.0, 100.0});
   fixed_width_column_wrapper<double> y({-100.0, 100.0});
@@ -210,14 +210,14 @@ TEST_F(QuadtreeOnPointIndexingTest, test_all_top_level_quads)
     quadtree->num_columns() == 5,
     "a quadtree table must have 5 columns (keys, levels, is_node, lengths, offsets)");
 
-  CUSPATIAL_EXPECTS(quadtree->num_rows() == 2, "the resulting quadtree must have 2 quadrants");
+  CUSPATIAL_EXPECTS(quadtree->num_rows() == 3, "the resulting quadtree must have 3 quadrants");
 
   // the top level quadtree node is expected to have a value of
-  // ([1032240, 3158256], [0, 0], [0, 0], [1, 1], [0, 1])
+  // ([3, 12, 15], [0, 1, 1], [1, 0, 0], [2, 1, 1], [1, 0, 1])
   expect_tables_equal(*quadtree,
-                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({1032240, 3158256}),
-                                        fixed_width_column_wrapper<int8_t>({0, 0}),
-                                        fixed_width_column_wrapper<bool>({0, 0}),
-                                        fixed_width_column_wrapper<int32_t>({1, 1}),
-                                        fixed_width_column_wrapper<int32_t>({0, 1})}});
+                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({3, 12, 15}),
+                                        fixed_width_column_wrapper<int8_t>({0, 1, 1}),
+                                        fixed_width_column_wrapper<bool>({1, 0, 0}),
+                                        fixed_width_column_wrapper<int32_t>({2, 1, 1}),
+                                        fixed_width_column_wrapper<int32_t>({1, 0, 1})}});
 }

--- a/cpp/tests/indexing/point_quadtree_test.cu
+++ b/cpp/tests/indexing/point_quadtree_test.cu
@@ -186,7 +186,7 @@ TEST_F(QuadtreeOnPointIndexingTest, test_small)
        fixed_width_column_wrapper<int32_t>({3, 6, 60, 0, 8, 10, 36, 12, 7, 16, 23, 28, 45, 53})}});
 }
 
-TEST_F(QuadtreeOnPointIndexingTest, test_all_top_level_quads)
+TEST_F(QuadtreeOnPointIndexingTest, test_all_lowest_level_quads)
 {
   using namespace cudf::test;
 

--- a/python/cuspatial/cuspatial/_lib/quadtree.pyx
+++ b/python/cuspatial/cuspatial/_lib/quadtree.pyx
@@ -33,6 +33,6 @@ cpdef quadtree_on_points(Column x, Column y,
         Column.from_unique_ptr(move(result.first)),
         Table.from_unique_ptr(
             move(result.second),
-            column_names=["key", "level", "is_node", "length", "offset"]
+            column_names=["key", "level", "is_quad", "length", "offset"]
         )
     )

--- a/python/cuspatial/cuspatial/core/indexing.py
+++ b/python/cuspatial/cuspatial/core/indexing.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+import warnings
+
 from cudf.core import DataFrame, Series
 from cudf.core.column import as_column
 
@@ -22,15 +24,28 @@ def quadtree_on_points(
     """
 
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))
-
-    points_order, quadtree = cpp_quadtree_on_points(
-        xs,
-        ys,
+    x_min, x_max, y_min, y_max = (
         min(x_min, x_max),
         max(x_min, x_max),
         min(y_min, y_max),
         max(y_min, y_max),
-        scale,
+    )
+
+    min_scale = max(x_max - x_min, y_max - y_min) / ((1 << max_depth) + 2)
+    if scale < min_scale:
+        warnings.warn(
+            "scale {} is less than required minimum ".format(scale)
+            + "scale {}. Clamping to minimum scale".format(min_scale)
+        )
+
+    points_order, quadtree = cpp_quadtree_on_points(
+        xs,
+        ys,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        max(scale, min_scale),
         max_depth,
         min_size,
     )

--- a/python/cuspatial/cuspatial/core/indexing.py
+++ b/python/cuspatial/cuspatial/core/indexing.py
@@ -20,7 +20,7 @@ def quadtree_on_points(
     Parameters
     ----------
     {params}
-    quadtree  : DataFrame of key, level, is_node, length, and offset columns
+    quadtree  : DataFrame of key, level, is_quad, length, and offset columns
     """
 
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))

--- a/python/cuspatial/cuspatial/tests/test_indexing.py
+++ b/python/cuspatial/cuspatial/tests/test_indexing.py
@@ -28,7 +28,7 @@ def test_empty():
             {
                 "key": cudf.Series([], dtype=np.int32),
                 "level": cudf.Series([], dtype=np.int8),
-                "is_node": cudf.Series([], dtype=np.bool_),
+                "is_quad": cudf.Series([], dtype=np.bool_),
                 "length": cudf.Series([], dtype=np.int32),
                 "offset": cudf.Series([], dtype=np.int32),
             }
@@ -52,7 +52,7 @@ def test_one_point(dtype):
             {
                 "key": cudf.Series([0], dtype=np.int32),
                 "level": cudf.Series([0], dtype=np.int8),
-                "is_node": cudf.Series([0], dtype=np.bool_),
+                "is_quad": cudf.Series([0], dtype=np.bool_),
                 "length": cudf.Series([1], dtype=np.int32),
                 "offset": cudf.Series([0], dtype=np.int32),
             }
@@ -76,7 +76,7 @@ def test_two_points(dtype):
             {
                 "key": cudf.Series([0, 3], dtype=np.int32),
                 "level": cudf.Series([0, 0], dtype=np.int8),
-                "is_node": cudf.Series([0, 0], dtype=np.bool_),
+                "is_quad": cudf.Series([0, 0], dtype=np.bool_),
                 "length": cudf.Series([1, 1], dtype=np.int32),
                 "offset": cudf.Series([0, 1], dtype=np.int32),
             }
@@ -260,7 +260,7 @@ def test_small_number_of_points(dtype):
                 "level": cudf.Series(
                     [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2], dtype=np.int8
                 ),
-                "is_node": cudf.Series(
+                "is_quad": cudf.Series(
                     [1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0], dtype=np.bool_
                 ),
                 "length": cudf.Series(


### PR DESCRIPTION
This PR fixes a potential thrust launch failure in the case there are no valid non-leaf quadrants. This is easy to trigger if the user-provided `scale` value doesn't lead to computing any common Morton code keys, and all points are grouped into separate top-level leaf quadrants.