### PR TITLE
[REVIEW] Fix polygon and polyline docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #214 Install gdal>=3.0.2 in build.sh
 - PR #222 Fix potential thrust launch failure in quadtree building
 - PR #221 Add python methods to api.rst, fix formatting
+- PR #228 Fix polygon and polyline docstrings
 
 ## Bug Fixes
 

--- a/cpp/include/cuspatial/polygon_bounding_box.hpp
+++ b/cpp/include/cuspatial/polygon_bounding_box.hpp
@@ -31,10 +31,10 @@ namespace cuspatial {
  * @param y Polygon point y-coordinates
  *
  * @return a cudf table of bounding boxes as four columns of the same type as `x` and `y`:
- * x1 - the minimum x-coordinate of each bounding box
- * y1 - the minimum y-coordinate of each bounding box
- * x2 - the maximum x-coordinate of each bounding box
- * y2 - the maximum y-coordinate of each bounding box
+ * x_min - the minimum x-coordinate of each bounding box
+ * y_min - the minimum y-coordinate of each bounding box
+ * x_max - the maximum x-coordinate of each bounding box
+ * y_max - the maximum y-coordinate of each bounding box
  */
 
 std::unique_ptr<cudf::table> polygon_bounding_boxes(

--- a/cpp/include/cuspatial/polyline_bounding_box.hpp
+++ b/cpp/include/cuspatial/polyline_bounding_box.hpp
@@ -28,20 +28,20 @@ namespace cuspatial {
  * @param poly_offsets Begin indices of the first ring in each polyline (i.e. prefix-sum)
  * @param x Polyline point x-coordinates
  * @param y Polyline point y-coordinates
- * @param R Expansion radius
+ * @param expansion_radius Radius of each polyline point
  *
  * @return a cudf table of bounding boxes as four columns of the same type as `x` and `y`:
- * x1 - the lower-left x-coordinate of each bounding box
- * y1 - the lower-left y-coordinate of each bounding box
- * x2 - the upper-right x-coordinate of each bounding box
- * y2 - the upper-right y-coordinate of each bounding box
+ * x1 - the minimum x-coordinate of each bounding box
+ * y1 - the minimum y-coordinate of each bounding box
+ * x2 - the maximum x-coordinate of each bounding box
+ * y2 - the maximum y-coordinate of each bounding box
  */
 
 std::unique_ptr<cudf::table> polyline_bounding_boxes(
   cudf::column_view const& poly_offsets,
   cudf::column_view const& x,
   cudf::column_view const& y,
-  double R,
+  double expansion_radius,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/polyline_bounding_box.hpp
+++ b/cpp/include/cuspatial/polyline_bounding_box.hpp
@@ -31,10 +31,10 @@ namespace cuspatial {
  * @param expansion_radius Radius of each polyline point
  *
  * @return a cudf table of bounding boxes as four columns of the same type as `x` and `y`:
- * x1 - the minimum x-coordinate of each bounding box
- * y1 - the minimum y-coordinate of each bounding box
- * x2 - the maximum x-coordinate of each bounding box
- * y2 - the maximum y-coordinate of each bounding box
+ * x_min - the minimum x-coordinate of each bounding box
+ * y_min - the minimum y-coordinate of each bounding box
+ * x_max - the maximum x-coordinate of each bounding box
+ * y_max - the maximum y-coordinate of each bounding box
  */
 
 std::unique_ptr<cudf::table> polyline_bounding_boxes(

--- a/cpp/include/cuspatial/trajectory.hpp
+++ b/cpp/include/cuspatial/trajectory.hpp
@@ -107,10 +107,10 @@ std::unique_ptr<cudf::table> trajectory_distances_and_speeds(
  *
  * @return a cudf table of bounding boxes with length `num_trajectories` and
  * four columns:
- *   * x1 - the lower-left x-coordinate of each bounding box in kilometers
- *   * y1 - the lower-left y-coordinate of each bounding box in kilometers
- *   * x2 - the upper-right x-coordinate of each bounding box in kilometers
- *   * y2 - the upper-right y-coordinate of each bounding box in kilometers
+ * x_min - the minimum x-coordinate of each bounding box in kilometers
+ * y_min - the minimum y-coordinate of each bounding box in kilometers
+ * x_max - the maximum x-coordinate of each bounding box in kilometers
+ * y_max - the maximum y-coordinate of each bounding box in kilometers
  */
 std::unique_ptr<cudf::table> trajectory_bounding_boxes(
   cudf::size_type num_trajectories,

--- a/cpp/tests/spatial/polyline_bbox_test.cu
+++ b/cpp/tests/spatial/polyline_bbox_test.cu
@@ -40,12 +40,13 @@ TYPED_TEST(BoundingBoxTest, test_empty)
   using T = TypeParam;
   using namespace cudf::test;
 
-  double const R{0};
+  double const expansion_radius{0};
   fixed_width_column_wrapper<int32_t> poly_offsets({});
   fixed_width_column_wrapper<T> x({});
   fixed_width_column_wrapper<T> y({});
 
-  auto bboxes = cuspatial::polyline_bounding_boxes(poly_offsets, x, y, R, this->mr());
+  auto bboxes =
+    cuspatial::polyline_bounding_boxes(poly_offsets, x, y, expansion_radius, this->mr());
 
   CUSPATIAL_EXPECTS(bboxes->num_rows() == 0, "must return 0 bounding boxes on empty input");
 }
@@ -55,22 +56,24 @@ TYPED_TEST(BoundingBoxTest, test_one)
   using T = TypeParam;
   using namespace cudf::test;
 
-  double const R{0};
+  double const expansion_radius{0};
   fixed_width_column_wrapper<int32_t> poly_offsets({0});
   fixed_width_column_wrapper<T> x({2.488450, 1.333584, 3.460720});
   fixed_width_column_wrapper<T> y({5.856625, 5.008840, 4.586599});
 
-  auto bboxes = cuspatial::polyline_bounding_boxes(poly_offsets, x, y, R, this->mr());
+  auto bboxes =
+    cuspatial::polyline_bounding_boxes(poly_offsets, x, y, expansion_radius, this->mr());
 
   CUSPATIAL_EXPECTS(bboxes->view().num_columns() == 4, "bbox table must have 4 columns");
   CUSPATIAL_EXPECTS(bboxes->num_rows() == 1,
                     "resutling #of bounding boxes must be the same as # of polygons");
 
-  expect_tables_equivalent(*bboxes,
-                           cudf::table_view{{fixed_width_column_wrapper<T>({1.333584 - R}),
-                                             fixed_width_column_wrapper<T>({4.586599 - R}),
-                                             fixed_width_column_wrapper<T>({3.460720 + R}),
-                                             fixed_width_column_wrapper<T>({5.856625 + R})}});
+  expect_tables_equivalent(
+    *bboxes,
+    cudf::table_view{{fixed_width_column_wrapper<T>({1.333584 - expansion_radius}),
+                      fixed_width_column_wrapper<T>({4.586599 - expansion_radius}),
+                      fixed_width_column_wrapper<T>({3.460720 + expansion_radius}),
+                      fixed_width_column_wrapper<T>({5.856625 + expansion_radius})}});
 }
 
 TYPED_TEST(BoundingBoxTest, test_small)
@@ -78,7 +81,7 @@ TYPED_TEST(BoundingBoxTest, test_small)
   using T = TypeParam;
   using namespace cudf::test;
 
-  double const R{0.5};
+  double const expansion_radius{0.5};
   fixed_width_column_wrapper<int32_t> poly_offsets({0, 3, 8, 12});
   fixed_width_column_wrapper<T> x({// ring 1
                                    2.488450,
@@ -123,7 +126,8 @@ TYPED_TEST(BoundingBoxTest, test_small)
                                    3.745936,
                                    4.541529});
 
-  auto bboxes = cuspatial::polyline_bounding_boxes(poly_offsets, x, y, R, this->mr());
+  auto bboxes =
+    cuspatial::polyline_bounding_boxes(poly_offsets, x, y, expansion_radius, this->mr());
 
   CUSPATIAL_EXPECTS(bboxes->view().num_columns() == 4, "bbox table must have 4 columns");
   CUSPATIAL_EXPECTS(bboxes->num_rows() == 4,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,8 @@ GIS
 .. automethod:: cuspatial.core.gis.haversine_distance
 .. automethod:: cuspatial.core.gis.lonlat_to_cartesian
 .. automethod:: cuspatial.core.gis.point_in_polygon
+.. automethod:: cuspatial.core.gis.polygon_bounding_boxes
+.. automethod:: cuspatial.core.gis.polyline_bounding_boxes
 
 
 Indexing

--- a/python/cuspatial/cuspatial/_lib/polygon_bounding_boxes.pyx
+++ b/python/cuspatial/cuspatial/_lib/polygon_bounding_boxes.pyx
@@ -30,5 +30,5 @@ cpdef polygon_bounding_boxes(Column poly_offsets,
         ))
     return Table.from_unique_ptr(
         move(result),
-        column_names=["x1", "y1", "x2", "y2"]
+        column_names=["x_min", "y_min", "x_max", "y_max"]
     )

--- a/python/cuspatial/cuspatial/_lib/polyline_bounding_boxes.pyx
+++ b/python/cuspatial/cuspatial/_lib/polyline_bounding_boxes.pyx
@@ -29,5 +29,5 @@ cpdef polyline_bounding_boxes(Column poly_offsets,
         ))
     return Table.from_unique_ptr(
         move(result),
-        column_names=["x1", "y1", "x2", "y2"]
+        column_names=["x_min", "y_min", "x_max", "y_max"]
     )

--- a/python/cuspatial/cuspatial/_lib/trajectory.pyx
+++ b/python/cuspatial/cuspatial/_lib/trajectory.pyx
@@ -51,7 +51,7 @@ cpdef trajectory_bounding_boxes(size_type num_trajectories,
         ))
     return Table.from_unique_ptr(
         move(result),
-        column_names=["x1", "y1", "x2", "y2"]
+        column_names=["x_min", "y_min", "x_max", "y_max"]
     )
 
 

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -280,14 +280,14 @@ def polygon_bounding_boxes(poly_offsets, ring_offsets, xs, ys):
     )
 
 
-def polyline_bounding_boxes(poly_offsets, xs, ys, R):
+def polyline_bounding_boxes(poly_offsets, xs, ys, expansion_radius):
     """Compute the minimum bounding-boxes for a set of polylines.
 
     params
     poly_offsets: beginning index of the first ring in each polyline
     xs: x-coordinates
     ys: y-coordinates
-    R: Expansion radius
+    expansion_radius: radius of each polyline point
 
     Parameters
     ----------
@@ -299,5 +299,5 @@ def polyline_bounding_boxes(poly_offsets, xs, ys, R):
     poly_offsets = as_column(poly_offsets, dtype="int32")
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))
     return DataFrame._from_table(
-        cpp_polyline_bounding_boxes(poly_offsets, xs, ys, R)
+        cpp_polyline_bounding_boxes(poly_offsets, xs, ys, expansion_radius)
     )

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -275,13 +275,13 @@ def polygon_bounding_boxes(poly_offsets, ring_offsets, xs, ys):
     result : cudf.DataFrame
         minimum bounding boxes for each polygon
 
-        x1 : cudf.Series
+        x_min : cudf.Series
             the minimum x-coordinate of each bounding box
-        y1 : cudf.Series
+        y_min : cudf.Series
             the minimum y-coordinate of each bounding box
-        x2 : cudf.Series
+        x_max : cudf.Series
             the maximum x-coordinate of each bounding box
-        y2 : cudf.Series
+        y_max : cudf.Series
             the maximum y-coordinate of each bounding box
     """
     poly_offsets = as_column(poly_offsets, dtype="int32")
@@ -311,13 +311,13 @@ def polyline_bounding_boxes(poly_offsets, xs, ys, expansion_radius):
     result : cudf.DataFrame
         minimum bounding boxes for each polyline
 
-        x1 : cudf.Series
+        x_min : cudf.Series
             the minimum x-coordinate of each bounding box
-        y1 : cudf.Series
+        y_min : cudf.Series
             the minimum y-coordinate of each bounding box
-        x2 : cudf.Series
+        x_max : cudf.Series
             the maximum x-coordinate of each bounding box
-        y2 : cudf.Series
+        y_max : cudf.Series
             the maximum y-coordinate of each bounding box
     """
     poly_offsets = as_column(poly_offsets, dtype="int32")

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -259,18 +259,30 @@ def point_in_polygon(
 def polygon_bounding_boxes(poly_offsets, ring_offsets, xs, ys):
     """Compute the minimum bounding-boxes for a set of polygons.
 
-    params
-    poly_offsets: beginning index of the first ring in each polygon
-    ring_offsets: beginning index of the first point in each ring
-    xs: x-coordinates
-    ys: y-coordinates
-
     Parameters
     ----------
-    {params}
+    poly_offsets
+        Begin indices of the first ring in each polygon (i.e. prefix-sum)
+    ring_offsets
+        Begin indices of the first point in each ring (i.e. prefix-sum)
+    xs
+        Polygon point x-coordinates
+    ys
+        Polygon point y-coordinates
 
-    returns
-    DataFrame of x1, y1, x2, y2 as minimum bounding boxes for each polygon
+    Returns
+    -------
+    result : cudf.DataFrame
+        minimum bounding boxes for each polygon
+
+        x1 : cudf.Series
+            the minimum x-coordinate of each bounding box
+        y1 : cudf.Series
+            the minimum y-coordinate of each bounding box
+        x2 : cudf.Series
+            the maximum x-coordinate of each bounding box
+        y2 : cudf.Series
+            the maximum y-coordinate of each bounding box
     """
     poly_offsets = as_column(poly_offsets, dtype="int32")
     ring_offsets = as_column(ring_offsets, dtype="int32")
@@ -283,18 +295,30 @@ def polygon_bounding_boxes(poly_offsets, ring_offsets, xs, ys):
 def polyline_bounding_boxes(poly_offsets, xs, ys, expansion_radius):
     """Compute the minimum bounding-boxes for a set of polylines.
 
-    params
-    poly_offsets: beginning index of the first ring in each polyline
-    xs: x-coordinates
-    ys: y-coordinates
-    expansion_radius: radius of each polyline point
-
     Parameters
     ----------
-    {params}
+    poly_offsets
+        Begin indices of the first ring in each polyline (i.e. prefix-sum)
+    xs
+        Polyline point x-coordinates
+    ys
+        Polyline point y-coordinates
+    expansion_radius
+        radius of each polyline point
 
-    returns
-    DataFrame of x1, y1, x2, y2 as minimum bounding boxes for each polyline
+    Returns
+    -------
+    result : cudf.DataFrame
+        minimum bounding boxes for each polyline
+
+        x1 : cudf.Series
+            the minimum x-coordinate of each bounding box
+        y1 : cudf.Series
+            the minimum y-coordinate of each bounding box
+        x2 : cudf.Series
+            the maximum x-coordinate of each bounding box
+        y2 : cudf.Series
+            the maximum y-coordinate of each bounding box
     """
     poly_offsets = as_column(poly_offsets, dtype="int32")
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))

--- a/python/cuspatial/cuspatial/core/trajectory.py
+++ b/python/cuspatial/cuspatial/core/trajectory.py
@@ -90,14 +90,14 @@ def trajectory_bounding_boxes(num_trajectories, object_ids, xs, ys):
     result : cudf.DataFrame
         minimum bounding boxes (in kilometers) for each trajectory
 
-        x1 : cudf.Series
-            the lower-left x-coordinate of each bounding box
-        y1 : cudf.Series
-            the lower-left y-coordinate of each bounding box
-        x2 : cudf.Series
-            the upper-right x-coordinate of each bounding box
-        y2 : cudf.Series
-            the upper-right y-coordinate of each bounding box
+        x_min : cudf.Series
+            the minimum x-coordinate of each bounding box
+        y_min : cudf.Series
+            the minimum y-coordinate of each bounding box
+        x_max : cudf.Series
+            the maximum x-coordinate of each bounding box
+        y_max : cudf.Series
+            the maximum y-coordinate of each bounding box
 
     Examples
     --------
@@ -116,9 +116,9 @@ def trajectory_bounding_boxes(num_trajectories, object_ids, xs, ys):
             objects['y']
         )
     >>> print(traj_bounding_boxes)
-        x1   y1   x2   y2
-    0  0.0  0.0  2.0  2.0
-    1  1.0  1.0  3.0  3.0
+        x_min   y_min   x_max   y_max
+    0     0.0     0.0     2.0     2.0
+    1     1.0     1.0     3.0     3.0
     """
 
     object_ids = as_column(object_ids, dtype=np.int32)

--- a/python/cuspatial/cuspatial/tests/test_polygon_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polygon_bounding_boxes.py
@@ -21,10 +21,10 @@ def test_polygon_bounding_boxes_empty(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([], dtype=dtype),
-                "y1": cudf.Series([], dtype=dtype),
-                "x2": cudf.Series([], dtype=dtype),
-                "y2": cudf.Series([], dtype=dtype),
+                "x_min": cudf.Series([], dtype=dtype),
+                "y_min": cudf.Series([], dtype=dtype),
+                "x_max": cudf.Series([], dtype=dtype),
+                "y_max": cudf.Series([], dtype=dtype),
             }
         ),
     )
@@ -42,10 +42,10 @@ def test_polygon_bounding_boxes_one(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([1.333584], dtype=dtype),
-                "y1": cudf.Series([4.586599], dtype=dtype),
-                "x2": cudf.Series([3.460720], dtype=dtype),
-                "y2": cudf.Series([5.856625], dtype=dtype),
+                "x_min": cudf.Series([1.333584], dtype=dtype),
+                "y_min": cudf.Series([4.586599], dtype=dtype),
+                "x_max": cudf.Series([3.460720], dtype=dtype),
+                "y_max": cudf.Series([5.856625], dtype=dtype),
             }
         ),
     )
@@ -113,7 +113,7 @@ def test_polygon_bounding_boxes_small(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series(
+                "x_min": cudf.Series(
                     [
                         1.3335840000000001,
                         5.0398230000000002,
@@ -122,7 +122,7 @@ def test_polygon_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "y1": cudf.Series(
+                "y_min": cudf.Series(
                     [
                         4.5865989999999996,
                         1.503906,
@@ -131,7 +131,7 @@ def test_polygon_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "x2": cudf.Series(
+                "x_max": cudf.Series(
                     [
                         3.4607199999999998,
                         7.1906739999999996,
@@ -140,7 +140,7 @@ def test_polygon_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "y2": cudf.Series(
+                "y_max": cudf.Series(
                     [
                         5.8566250000000002,
                         5.653384,

--- a/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
@@ -15,7 +15,7 @@ def test_polyline_bounding_boxes_empty(dtype):
         cudf.Series(),
         cudf.Series([], dtype=dtype),
         cudf.Series([], dtype=dtype),
-        0, # expansion_radius
+        0,  # expansion_radius
     )
     assert_eq(
         result,
@@ -36,7 +36,7 @@ def test_polyline_bounding_boxes_one(dtype):
         cudf.Series([0]),
         cudf.Series([2.488450, 1.333584, 3.460720], dtype=dtype),
         cudf.Series([5.856625, 5.008840, 4.586599], dtype=dtype),
-        0, # expansion_radius
+        0,  # expansion_radius
     )
     assert_eq(
         result,

--- a/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
@@ -21,10 +21,10 @@ def test_polyline_bounding_boxes_empty(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([], dtype=dtype),
-                "y1": cudf.Series([], dtype=dtype),
-                "x2": cudf.Series([], dtype=dtype),
-                "y2": cudf.Series([], dtype=dtype),
+                "x_min": cudf.Series([], dtype=dtype),
+                "y_min": cudf.Series([], dtype=dtype),
+                "x_max": cudf.Series([], dtype=dtype),
+                "y_max": cudf.Series([], dtype=dtype),
             }
         ),
     )
@@ -42,10 +42,10 @@ def test_polyline_bounding_boxes_one(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([1.333584], dtype=dtype),
-                "y1": cudf.Series([4.586599], dtype=dtype),
-                "x2": cudf.Series([3.460720], dtype=dtype),
-                "y2": cudf.Series([5.856625], dtype=dtype),
+                "x_min": cudf.Series([1.333584], dtype=dtype),
+                "y_min": cudf.Series([4.586599], dtype=dtype),
+                "x_max": cudf.Series([3.460720], dtype=dtype),
+                "y_max": cudf.Series([5.856625], dtype=dtype),
             }
         ),
     )
@@ -113,7 +113,7 @@ def test_polyline_bounding_boxes_small(dtype):
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series(
+                "x_min": cudf.Series(
                     [
                         0.8335840000000001,
                         4.5398230000000002,
@@ -122,7 +122,7 @@ def test_polyline_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "y1": cudf.Series(
+                "y_min": cudf.Series(
                     [
                         4.0865989999999996,
                         1.003906,
@@ -131,7 +131,7 @@ def test_polyline_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "x2": cudf.Series(
+                "x_max": cudf.Series(
                     [
                         3.9607199999999998,
                         7.6906739999999996,
@@ -140,7 +140,7 @@ def test_polyline_bounding_boxes_small(dtype):
                     ],
                     dtype=dtype,
                 ),
-                "y2": cudf.Series(
+                "y_max": cudf.Series(
                     [
                         6.3566250000000002,
                         6.153384,

--- a/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
@@ -15,7 +15,7 @@ def test_polyline_bounding_boxes_empty(dtype):
         cudf.Series(),
         cudf.Series([], dtype=dtype),
         cudf.Series([], dtype=dtype),
-        0,
+        0, # expansion_radius
     )
     assert_eq(
         result,
@@ -36,7 +36,7 @@ def test_polyline_bounding_boxes_one(dtype):
         cudf.Series([0]),
         cudf.Series([2.488450, 1.333584, 3.460720], dtype=dtype),
         cudf.Series([5.856625, 5.008840, 4.586599], dtype=dtype),
-        0,
+        0, # expansion_radius
     )
     assert_eq(
         result,
@@ -107,7 +107,7 @@ def test_polyline_bounding_boxes_small(dtype):
             ],
             dtype=dtype,
         ),
-        0.5,  # R
+        0.5,  # expansion_radius
     )
     assert_eq(
         result,

--- a/python/cuspatial/cuspatial/tests/test_trajectory.py
+++ b/python/cuspatial/cuspatial/tests/test_trajectory.py
@@ -20,10 +20,10 @@ def test_trajectory_bounding_boxes_empty_float32():
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([], dtype=np.float32),
-                "y1": cudf.Series([], dtype=np.float32),
-                "x2": cudf.Series([], dtype=np.float32),
-                "y2": cudf.Series([], dtype=np.float32),
+                "x_min": cudf.Series([], dtype=np.float32),
+                "y_min": cudf.Series([], dtype=np.float32),
+                "x_max": cudf.Series([], dtype=np.float32),
+                "y_max": cudf.Series([], dtype=np.float32),
             }
         ),
     )
@@ -40,10 +40,10 @@ def test_trajectory_bounding_boxes_empty_float64():
         result,
         cudf.DataFrame(
             {
-                "x1": cudf.Series([], dtype=np.float64),
-                "y1": cudf.Series([], dtype=np.float64),
-                "x2": cudf.Series([], dtype=np.float64),
-                "y2": cudf.Series([], dtype=np.float64),
+                "x_min": cudf.Series([], dtype=np.float64),
+                "y_min": cudf.Series([], dtype=np.float64),
+                "x_max": cudf.Series([], dtype=np.float64),
+                "y_max": cudf.Series([], dtype=np.float64),
             }
         ),
     )
@@ -55,7 +55,9 @@ def test_trajectory_bounding_boxes_zeros():
     )
     assert_eq(
         result,
-        cudf.DataFrame({"x1": [0.0], "y1": [0.0], "x2": [0.0], "y2": [0.0]}),
+        cudf.DataFrame(
+            {"x_min": [0.0], "y_min": [0.0], "x_max": [0.0], "y_max": [0.0]}
+        ),
     )
 
 
@@ -65,7 +67,9 @@ def test_trajectory_bounding_boxes_ones():
     )
     assert_eq(
         result,
-        cudf.DataFrame({"x1": [1.0], "y1": [1.0], "x2": [1.0], "y2": [1.0]}),
+        cudf.DataFrame(
+            {"x_min": [1.0], "y_min": [1.0], "x_max": [1.0], "y_max": [1.0]}
+        ),
     )
 
 
@@ -75,7 +79,9 @@ def test_trajectory_bounding_boxes_zero_to_one():
     )
     assert_eq(
         result,
-        cudf.DataFrame({"x1": [0.0], "y1": [0.0], "x2": [0.0], "y2": [1.0]}),
+        cudf.DataFrame(
+            {"x_min": [0.0], "y_min": [0.0], "x_max": [0.0], "y_max": [1.0]}
+        ),
     )
 
 
@@ -85,7 +91,9 @@ def test_trajectory_bounding_boxes_zero_to_one_xy():
     )
     assert_eq(
         result,
-        cudf.DataFrame({"x1": [0.0], "y1": [0.0], "x2": [1.0], "y2": [1.0]}),
+        cudf.DataFrame(
+            {"x_min": [0.0], "y_min": [0.0], "x_max": [1.0], "y_max": [1.0]}
+        ),
     )
 
 
@@ -100,10 +108,10 @@ def test_trajectory_bounding_boxes_subsetted():
         result,
         cudf.DataFrame(
             {
-                "x1": [0.0, -1.0],
-                "y1": [0.0, -1.0],
-                "x2": [1.0, 2.0],
-                "y2": [1.0, 2.0],
+                "x_min": [0.0, -1.0],
+                "y_min": [0.0, -1.0],
+                "x_max": [1.0, 2.0],
+                "y_max": [1.0, 2.0],
             }
         ),
     )
@@ -120,10 +128,10 @@ def test_trajectory_bounding_boxes_intersected():
         result,
         cudf.DataFrame(
             {
-                "x1": [0.0, 1.0],
-                "y1": [0.0, 1.0],
-                "x2": [2.0, 3.0],
-                "y2": [2.0, 3.0],
+                "x_min": [0.0, 1.0],
+                "y_min": [0.0, 1.0],
+                "x_max": [2.0, 3.0],
+                "y_max": [2.0, 3.0],
             }
         ),
     )
@@ -140,10 +148,10 @@ def test_trajectory_bounding_boxes_two_and_three():
         result,
         cudf.DataFrame(
             {
-                "x1": [0.0, 1.0],
-                "y1": [0.0, 1.0],
-                "x2": [2.0, 3.0],
-                "y2": [2.0, 3.0],
+                "x_min": [0.0, 1.0],
+                "y_min": [0.0, 1.0],
+                "x_max": [2.0, 3.0],
+                "y_max": [2.0, 3.0],
             }
         ),
     )


### PR DESCRIPTION
Follow-up PR to https://github.com/rapidsai/cuspatial/pull/145

* Renames the `polyline_bounding_boxes` function's `R` parameter to `expansion_radius`
* Updates to the `polygon_bounding_boxes` and `polyline_bounding_boxes` C++ and Python docstrings