### PR TITLE
[REVIEW] Fix libcuspatial dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - PR #212 Rename calls to cudf::experimental namespace to cudf::
 - PR #215 Replace legacy RMM calls
 - PR #218 Fix benchmark build by removing test_benchmark.cpp
-
+- PR #232 Fix conda dependencies
 
 # cuSpatial 0.13.0 (31 Mar 2020)
 

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -24,12 +24,11 @@ requirements:
     - cython >=0.29,<0.30
     - setuptools
     - cudf {{ minor_version }}.*
-    - libcuspatial {{ minor_version}}.*
+    - libcuspatial {{ version }}.*
 
   run:
     - python
     - cudf {{ minor_version }}.*
-    - libcuspatial {{ minor_version}}.*
     - gdal >=3.0.2
 
 test:

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - gdal >=3.0.2
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - libcudf {{ minor_version }}.*
 
 test:
   commands:


### PR DESCRIPTION
Fixes libcuspatial dependency to be the same git hash. Also removes its runtime dependency as that should be compiled. You can see in the screenshot how the dependency doubles up and can cause conda solver issues.

<img width="999" alt="Screen Shot 2020-05-29 at 12 59 39 PM" src="https://user-images.githubusercontent.com/18494947/83285490-49a1aa80-a1ac-11ea-969d-1f3167172e75.png">

