### PR TITLE
Remove references to deprecated rmm headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 - PR #237 Remove nvstrings references from CMakeLists.txt
 - PR #238 Fix library and include paths in CMakeLists.txt and setup.py
+- PR #240 Remove deprecated RMM header references.
 
 ## Bug Fixes
 

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -15,7 +15,6 @@
  */
 
 #include <benchmark/benchmark.h>
-#include <rmm/rmm_api.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 namespace cudf {


### PR DESCRIPTION
https://github.com/rapidsai/rmm/pull/396 removed all deprecated headers and APIs. 

This PR cleans up references to unused, deprecated RMM headers. 