### PR TITLE
[REVIEW] Fix benchmark_fixture to use RMM resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Bug Fixes
 
-- PR #241 Fix benchmark_fixture to use memory resources.
+- PR #242 Fix benchmark_fixture to use memory resources.
 
 
 # cuSpatial 0.14.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## Bug Fixes
 
+- PR #241 Fix benchmark_fixture to use memory resources.
+
+
 # cuSpatial 0.14.0 (Date TBD)
 
 ## New Features

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 #include <benchmark/benchmark.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include "rmm/mr/device/cnmem_memory_resource.hpp"
+#include "rmm/mr/device/default_memory_resource.hpp"
 
-namespace cudf {
+namespace cuspatial {
 /**
  * @brief Google Benchmark fixture for libcudf benchmarks
  *
@@ -53,11 +54,15 @@ class benchmark : public ::benchmark::Fixture {
  public:
   virtual void SetUp(const ::benchmark::State& state)
   {
-    rmmOptions_t options{PoolAllocation, 0, false};
-    rmmInitialize(&options);
+    auto mr = new rmm::mr::cnmem_memory_resource;
+    rmm::mr::set_default_resource(mr);  // set default resource to cnmem
   }
 
-  virtual void TearDown(const ::benchmark::State& state) { rmmFinalize(); }
+  virtual void TearDown(const ::benchmark::State& state)
+  {
+    delete rmm::mr::get_default_resource();
+    rmm::mr::set_default_resource(nullptr);  // reset default resource to the initial resource
+  }
 
   // eliminate partial override warnings (see benchmark/benchmark.h)
   virtual void SetUp(::benchmark::State& st) { SetUp(const_cast<const ::benchmark::State&>(st)); }
@@ -67,4 +72,4 @@ class benchmark : public ::benchmark::Fixture {
   }
 };
 
-};  // namespace cudf
+};  // namespace cuspatial


### PR DESCRIPTION
Replace calls to rmmInit/Finalize with cnmem_memory_resource.
