### PR TITLE
Install dependencies via meta package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #239 Add docs build script
 - PR #238 Fix library and include paths in CMakeLists.txt and setup.py
 - PR #240 Remove deprecated RMM header references.
+- PR #243 Install dependencies via meta package
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -44,7 +44,12 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install "cudf=${MINOR_VERSION}.*" "cudatoolkit=$CUDA_REL" "gdal>=3.0.2"
+conda install "cudf=${MINOR_VERSION}.*" "cudatoolkit=$CUDA_REL" \
+    "rapids-build-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env
+# conda install "your-pkg=1.0.0"
 
 logger "Check versions..."
 python --version


### PR DESCRIPTION
Install dependencies via `rapids-build-env` (which is pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/