### PR TITLE
Pin gdal version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #243 Install dependencies via meta package
 
 ## Bug Fixes
+- PR #244 Restrict gdal version
 
 # cuSpatial 0.14.0 (Date TBD)
 

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - cudf {{ minor_version }}.*
-    - gdal >=3.0.2
+    - gdal >=3.1.0,<3.2.0a0
 
 test:
   commands:

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - libcudf {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - gdal >=3.0.2
+    - gdal >=3.1.0,<3.2.0a0
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 


### PR DESCRIPTION
Need to restrict the gdal version more closely since 3.0.2 and 3.1.0 are linked in an incompatible way. Since 3.1.0 works, just restrict to that minor version.