### PR TITLE
[REVIEW] Pin gdal to be compatible with cuxfilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Bug Fixes
 - PR #244 Restrict gdal version
+- PR #245 Pin gdal to be compatible with cuxfilter
 
 # cuSpatial 0.14.0 (Date TBD)
 

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - cudf {{ minor_version }}.*
-    - gdal >=3.1.0,<3.2.0a0
+    - gdal >=3.0.2,<3.1.0a0
 
 test:
   commands:

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - libcudf {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - gdal >=3.0.0,<3.1.0a0
+    - gdal >=3.0.2,<3.1.0a0
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - libcudf {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - gdal >=3.1.0,<3.2.0a0
+    - gdal >=3.0.0,<3.1.0a0
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 


### PR DESCRIPTION
`cuxfilter` has a dependency on `geopandas` which seems to be locked to `gdal` 3.0.x.