### PR TITLE
[REVIEW] Use rmm::device_uvector and cudf::UINT types for quadtree construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 - PR #238 Fix library and include paths in CMakeLists.txt and setup.py
 - PR #240 Remove deprecated RMM header references.
 - PR #243 Install dependencies via meta package
+- PR #247 Use rmm::device_uvector and cudf::UINT types for quadtree construction
 
 ## Bug Fixes
 - PR #244 Restrict gdal version
 - PR #245 Pin gdal to be compatible with cuxfilter
-
 - PR #242 Fix benchmark_fixture to use memory resources.
 
 

--- a/cpp/include/cuspatial/point_quadtree.hpp
+++ b/cpp/include/cuspatial/point_quadtree.hpp
@@ -48,11 +48,11 @@ namespace cuspatial {
  *
  * @return Pair of INT32 column of sorted keys to point indices, and cudf table with five
  * columns for a complete quadtree:
- *     key - INT32 column of quad node keys
- *   level - INT8 column of quadtree levels
+ *     key - UINT32 column of quad node keys
+ *   level - UINT8 column of quadtree levels
  * is_node - BOOL8 column indicating whether the node is a leaf or not
- *  length - INT32 column for the number of child nodes (if is_node), or number of points
- *  offset - INT32 column for the first child position (if is_node), or first point position
+ *  length - UINT32 column for the number of child nodes (if is_node), or number of points
+ *  offset - UINT32 column for the first child position (if is_node), or first point position
  */
 std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_on_points(
   cudf::column_view const& x,

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -75,7 +75,7 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
                       return cuspatial::utility::z_order((x - x_min) / scale, (y - y_min) / scale);
                     });
 
-  auto indices = make_fixed_width_column<int32_t>(keys.size(), stream, mr);
+  auto indices = make_fixed_width_column<uint32_t>(keys.size(), stream, mr);
 
   thrust::sequence(rmm::exec_policy(stream)->on(stream),
                    indices->mutable_view().begin<uint32_t>(),
@@ -186,7 +186,7 @@ build_tree_levels(cudf::size_type max_depth,
 inline std::tuple<rmm::device_uvector<uint32_t>,
                   rmm::device_uvector<uint32_t>,
                   rmm::device_uvector<uint32_t>,
-                  rmm::device_uvector<int8_t>>
+                  rmm::device_uvector<uint8_t>>
 reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
                     rmm::device_uvector<uint32_t> const &quad_point_count_in,
                     rmm::device_uvector<uint32_t> const &quad_child_count_in,
@@ -196,7 +196,7 @@ reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
                     cudaStream_t stream)
 {
   rmm::device_uvector<uint32_t> quad_keys(quad_keys_in.size(), stream);
-  rmm::device_uvector<int8_t> quad_levels(quad_keys_in.size(), stream);
+  rmm::device_uvector<uint8_t> quad_levels(quad_keys_in.size(), stream);
   rmm::device_uvector<uint32_t> quad_point_count(quad_point_count_in.size(), stream);
   rmm::device_uvector<uint32_t> quad_child_count(quad_child_count_in.size(), stream);
   cudf::size_type offset{0};
@@ -357,7 +357,7 @@ inline auto make_full_levels(cudf::column_view const &x,
                            std::move(quad_keys),
                            std::move(quad_point_count),
                            std::move(quad_child_count),
-                           std::move(rmm::device_uvector<int8_t>(quad_keys.size(), stream)),
+                           std::move(rmm::device_uvector<uint8_t>(quad_keys.size(), stream)),
                            num_bottom_quads,
                            num_parent_nodes,
                            0);

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -47,7 +48,7 @@ namespace detail {
  * mapping original point index to sorted z-order.
  */
 template <typename T>
-inline std::pair<rmm::device_vector<uint32_t>, std::unique_ptr<cudf::column>>
+inline std::pair<rmm::device_uvector<uint32_t>, std::unique_ptr<cudf::column>>
 compute_point_keys_and_sorted_indices(cudf::column_view const &x,
                                       cudf::column_view const &y,
                                       T x_min,
@@ -59,7 +60,7 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
                                       rmm::mr::device_memory_resource *mr,
                                       cudaStream_t stream)
 {
-  rmm::device_vector<uint32_t> keys(x.size());
+  rmm::device_uvector<uint32_t> keys(x.size(), stream);
   thrust::transform(rmm::exec_policy(stream)->on(stream),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()) + x.size(),
@@ -182,22 +183,22 @@ build_tree_levels(cudf::size_type max_depth,
  * node at the end. This function reverses the order of the levels, so the level
  * just below the root node is at the front, and the leaves are at the end.
  */
-inline std::tuple<rmm::device_vector<uint32_t>,
-                  rmm::device_vector<uint32_t>,
-                  rmm::device_vector<uint32_t>,
-                  rmm::device_vector<int8_t>>
-reverse_tree_levels(rmm::device_vector<uint32_t> const &quad_keys_in,
-                    rmm::device_vector<uint32_t> const &quad_point_count_in,
-                    rmm::device_vector<uint32_t> const &quad_child_count_in,
+inline std::tuple<rmm::device_uvector<uint32_t>,
+                  rmm::device_uvector<uint32_t>,
+                  rmm::device_uvector<uint32_t>,
+                  rmm::device_uvector<int8_t>>
+reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
+                    rmm::device_uvector<uint32_t> const &quad_point_count_in,
+                    rmm::device_uvector<uint32_t> const &quad_child_count_in,
                     std::vector<cudf::size_type> const &begin_pos,
                     std::vector<cudf::size_type> const &end_pos,
                     cudf::size_type max_depth,
                     cudaStream_t stream)
 {
-  rmm::device_vector<uint32_t> quad_keys(quad_keys_in.size());
-  rmm::device_vector<int8_t> quad_levels(quad_keys_in.size());
-  rmm::device_vector<uint32_t> quad_point_count(quad_point_count_in.size());
-  rmm::device_vector<uint32_t> quad_child_count(quad_child_count_in.size());
+  rmm::device_uvector<uint32_t> quad_keys(quad_keys_in.size(), stream);
+  rmm::device_uvector<int8_t> quad_levels(quad_keys_in.size(), stream);
+  rmm::device_uvector<uint32_t> quad_point_count(quad_point_count_in.size(), stream);
+  rmm::device_uvector<uint32_t> quad_child_count(quad_child_count_in.size(), stream);
   cudf::size_type offset{0};
 
   for (cudf::size_type level{0}; level < max_depth; ++level) {
@@ -224,10 +225,10 @@ reverse_tree_levels(rmm::device_vector<uint32_t> const &quad_keys_in,
   }
 
   // Shrink vectors' underlying device allocations to reduce peak memory usage
-  quad_keys.shrink_to_fit();
-  quad_point_count.shrink_to_fit();
-  quad_child_count.shrink_to_fit();
-  quad_levels.shrink_to_fit();
+  quad_keys.shrink_to_fit(stream);
+  quad_point_count.shrink_to_fit(stream);
+  quad_child_count.shrink_to_fit(stream);
+  quad_levels.shrink_to_fit(stream);
 
   return std::make_tuple(std::move(quad_keys),
                          std::move(quad_point_count),
@@ -273,8 +274,8 @@ inline auto make_full_levels(cudf::column_view const &x,
   auto &point_keys    = keys_and_indices.first;
   auto &point_indices = keys_and_indices.second;
 
-  rmm::device_vector<uint32_t> quad_keys(x.size());
-  rmm::device_vector<uint32_t> quad_point_count(x.size());
+  rmm::device_uvector<uint32_t> quad_keys(x.size(), stream);
+  rmm::device_uvector<uint32_t> quad_point_count(x.size(), stream);
 
   // Construct quadrants at the finest level of detail, i.e. the quadrants
   // furthest from the root. Reduces points with common z-order codes into
@@ -291,9 +292,13 @@ inline auto make_full_levels(cudf::column_view const &x,
   // leaf quadrants
   auto &quad_child_count = point_keys;
 
-  quad_keys.resize(num_bottom_quads * (max_depth + 1));
-  quad_point_count.resize(num_bottom_quads * (max_depth + 1));
-  quad_child_count.resize(num_bottom_quads * (max_depth + 1));
+  quad_keys.resize(num_bottom_quads * (max_depth + 1), stream);
+  quad_point_count.resize(num_bottom_quads * (max_depth + 1), stream);
+  quad_child_count.resize(num_bottom_quads * (max_depth + 1), stream);
+
+  // Zero out the quad_child_count vector because we're reusing the point_keys vector
+  thrust::fill(
+    rmm::exec_policy(stream)->on(stream), quad_child_count.begin(), quad_child_count.end(), 0);
 
   //
   // Compute "full" quads for the tree at each level. Starting from the quadrant
@@ -339,12 +344,12 @@ inline auto make_full_levels(cudf::column_view const &x,
   auto const &end_pos          = std::get<3>(quads);
 
   // Shrink vectors' underlying device allocations to reduce peak memory usage
-  quad_keys.resize(quad_tree_size);
-  quad_keys.shrink_to_fit();
-  quad_point_count.resize(quad_tree_size);
-  quad_point_count.shrink_to_fit();
-  quad_child_count.resize(quad_tree_size);
-  quad_child_count.shrink_to_fit();
+  quad_keys.resize(quad_tree_size, stream);
+  quad_keys.shrink_to_fit(stream);
+  quad_point_count.resize(quad_tree_size, stream);
+  quad_point_count.shrink_to_fit(stream);
+  quad_child_count.resize(quad_tree_size, stream);
+  quad_child_count.shrink_to_fit(stream);
 
   // Optimization: return early if the top level nodes are all leaves
   if (num_parent_nodes <= 0) {
@@ -352,7 +357,7 @@ inline auto make_full_levels(cudf::column_view const &x,
                            std::move(quad_keys),
                            std::move(quad_point_count),
                            std::move(quad_child_count),
-                           std::move(rmm::device_vector<int8_t>(quad_keys.size())),
+                           std::move(rmm::device_uvector<int8_t>(quad_keys.size(), stream)),
                            num_bottom_quads,
                            num_parent_nodes,
                            0);

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -224,12 +224,6 @@ reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
     offset += num_quads;
   }
 
-  // Shrink vectors' underlying device allocations to reduce peak memory usage
-  quad_keys.shrink_to_fit(stream);
-  quad_point_count.shrink_to_fit(stream);
-  quad_child_count.shrink_to_fit(stream);
-  quad_levels.shrink_to_fit(stream);
-
   return std::make_tuple(std::move(quad_keys),
                          std::move(quad_point_count),
                          std::move(quad_child_count),

--- a/cpp/src/indexing/construction/detail/phase_2.cuh
+++ b/cpp/src/indexing/construction/detail/phase_2.cuh
@@ -60,7 +60,7 @@ inline rmm::device_uvector<uint32_t> compute_leaf_positions(cudf::column_view co
 
 inline rmm::device_uvector<uint32_t> flatten_point_keys(
   rmm::device_uvector<uint32_t> const &quad_keys,
-  rmm::device_uvector<int8_t> const &quad_level,
+  rmm::device_uvector<uint8_t> const &quad_level,
   cudf::column_view const &indicator,
   cudf::size_type num_valid_nodes,
   cudf::size_type max_depth,
@@ -93,7 +93,7 @@ inline rmm::device_uvector<uint32_t> flatten_point_keys(
  */
 inline rmm::device_uvector<uint32_t> compute_flattened_first_point_positions(
   rmm::device_uvector<uint32_t> const &quad_keys,
-  rmm::device_uvector<int8_t> const &quad_level,
+  rmm::device_uvector<uint8_t> const &quad_level,
   rmm::device_uvector<uint32_t> &quad_point_count,
   cudf::column_view const &indicator,
   cudf::size_type num_valid_nodes,
@@ -229,7 +229,7 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
   rmm::device_uvector<uint32_t> &quad_keys,
   rmm::device_uvector<uint32_t> &quad_point_count,
   rmm::device_uvector<uint32_t> &quad_child_count,
-  rmm::device_uvector<int8_t> &quad_levels,
+  rmm::device_uvector<uint8_t> &quad_levels,
   cudf::size_type num_parent_nodes,
   cudf::size_type num_child_nodes,
   cudf::size_type min_size,

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -19,6 +19,8 @@
 #include <cuspatial/error.hpp>
 #include <cuspatial/point_quadtree.hpp>
 
+#include <rmm/device_uvector.hpp>
+
 #include "indexing/construction/detail/phase_1.cuh"
 #include "indexing/construction/detail/phase_2.cuh"
 #include "indexing/construction/detail/utilities.cuh"
@@ -39,10 +41,10 @@ namespace {
 /**
  * @brief Constructs a complete quad tree
  */
-inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> &quad_keys,
-                                                   rmm::device_vector<uint32_t> &quad_point_count,
-                                                   rmm::device_vector<uint32_t> &quad_child_count,
-                                                   rmm::device_vector<int8_t> &quad_levels,
+inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t> &quad_keys,
+                                                   rmm::device_uvector<uint32_t> &quad_point_count,
+                                                   rmm::device_uvector<uint32_t> &quad_child_count,
+                                                   rmm::device_uvector<int8_t> &quad_levels,
                                                    cudf::size_type num_parent_nodes,
                                                    cudf::size_type max_depth,
                                                    cudf::size_type min_size,
@@ -169,8 +171,8 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_vector<uint32_t> 
  * @brief Constructs a leaf-only quadtree
  */
 inline std::unique_ptr<cudf::table> make_leaf_tree(
-  rmm::device_vector<uint32_t> const &quad_keys,
-  rmm::device_vector<uint32_t> const &quad_point_count,
+  rmm::device_uvector<uint32_t> const &quad_keys,
+  rmm::device_uvector<uint32_t> const &quad_point_count,
   cudf::size_type num_top_quads,
   rmm::mr::device_memory_resource *mr,
   cudaStream_t stream)

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -44,7 +44,7 @@ namespace {
 inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t> &quad_keys,
                                                    rmm::device_uvector<uint32_t> &quad_point_count,
                                                    rmm::device_uvector<uint32_t> &quad_child_count,
-                                                   rmm::device_uvector<int8_t> &quad_levels,
+                                                   rmm::device_uvector<uint8_t> &quad_levels,
                                                    cudf::size_type num_parent_nodes,
                                                    cudf::size_type max_depth,
                                                    cudf::size_type min_size,
@@ -88,12 +88,12 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
     auto quad_point_pos = compute_flattened_first_point_positions(
       quad_keys, quad_levels, quad_point_count, *is_quad, num_valid_nodes, max_depth, stream);
 
-    auto quad_child_pos = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
+    auto quad_child_pos = make_fixed_width_column<uint32_t>(num_valid_nodes, stream, mr);
     // line 9 of algorithm in Fig. 5 in ref.
     thrust::replace_if(rmm::exec_policy(stream)->on(stream),
                        quad_child_count.begin(),
                        quad_child_count.begin() + num_valid_nodes,
-                       is_quad->view().begin<int8_t>(),
+                       is_quad->view().begin<uint8_t>(),
                        !thrust::placeholders::_1,
                        0);
 
@@ -124,7 +124,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
   }();
 
   // Construct the lengths output column
-  auto lengths = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
+  auto lengths = make_fixed_width_column<uint32_t>(num_valid_nodes, stream, mr);
   // for each value in `is_quad` copy from `quad_child_count` if true, else
   // `quad_point_count`
   auto lengths_iter = make_zip_iterator(is_quad->view().begin<bool>(),  //
@@ -140,7 +140,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
                     });
 
   // Construct the keys output column
-  auto keys = make_fixed_width_column<int32_t>(num_valid_nodes, stream, mr);
+  auto keys = make_fixed_width_column<uint32_t>(num_valid_nodes, stream, mr);
 
   // Copy quad keys to keys output column
   thrust::copy(rmm::exec_policy(stream)->on(stream),
@@ -149,13 +149,13 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
                keys->mutable_view().begin<uint32_t>());
 
   // Construct the levels output column
-  auto levels = make_fixed_width_column<int8_t>(num_valid_nodes, stream, mr);
+  auto levels = make_fixed_width_column<uint8_t>(num_valid_nodes, stream, mr);
 
   // Copy quad levels to levels output column
   thrust::copy(rmm::exec_policy(stream)->on(stream),
                quad_levels.begin(),
                quad_levels.end(),
-               levels->mutable_view().begin<int8_t>());
+               levels->mutable_view().begin<uint8_t>());
 
   std::vector<std::unique_ptr<cudf::column>> cols{};
   cols.reserve(5);
@@ -177,11 +177,11 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
   rmm::mr::device_memory_resource *mr,
   cudaStream_t stream)
 {
-  auto keys    = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
-  auto levels  = make_fixed_width_column<int8_t>(num_top_quads, stream, mr);
+  auto keys    = make_fixed_width_column<uint32_t>(num_top_quads, stream, mr);
+  auto levels  = make_fixed_width_column<uint8_t>(num_top_quads, stream, mr);
   auto is_quad = make_fixed_width_column<bool>(num_top_quads, stream, mr);
-  auto lengths = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
-  auto offsets = make_fixed_width_column<int32_t>(num_top_quads, stream, mr);
+  auto lengths = make_fixed_width_column<uint32_t>(num_top_quads, stream, mr);
+  auto offsets = make_fixed_width_column<uint32_t>(num_top_quads, stream, mr);
 
   // copy quad keys from the front of the quad_keys list
   thrust::copy(rmm::exec_policy(stream)->on(stream),
@@ -197,8 +197,8 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
 
   // All leaves are children of the root node (level 0)
   thrust::fill(rmm::exec_policy(stream)->on(stream),
-               levels->mutable_view().begin<int8_t>(),
-               levels->mutable_view().end<int8_t>(),
+               levels->mutable_view().begin<uint8_t>(),
+               levels->mutable_view().end<uint8_t>(),
                0);
 
   // Quad node indicators are false for leaf nodes
@@ -353,12 +353,12 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   if (x.is_empty() || y.is_empty()) {
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.reserve(5);
-    cols.push_back(detail::make_fixed_width_column<int32_t>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<int8_t>(0, 0, mr));
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
+    cols.push_back(detail::make_fixed_width_column<uint8_t>(0, 0, mr));
     cols.push_back(detail::make_fixed_width_column<bool>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<int32_t>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<int32_t>(0, 0, mr));
-    return std::make_pair(detail::make_fixed_width_column<int32_t>(0, 0, mr),
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
+    return std::make_pair(detail::make_fixed_width_column<uint32_t>(0, 0, mr),
                           std::make_unique<cudf::table>(std::move(cols)));
   }
   return detail::quadtree_on_points(

--- a/cpp/tests/indexing/point_quadtree_test.cu
+++ b/cpp/tests/indexing/point_quadtree_test.cu
@@ -79,11 +79,11 @@ TEST_F(QuadtreeOnPointIndexingTest, test_single)
 
   // the top level quadtree node is expected to have a value of (0,0,0,1,0)
   expect_tables_equal(*quadtree,
-                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({0}),
-                                        fixed_width_column_wrapper<int8_t>({0}),
+                      cudf::table_view{{fixed_width_column_wrapper<uint32_t>({0}),
+                                        fixed_width_column_wrapper<uint8_t>({0}),
                                         fixed_width_column_wrapper<bool>({0}),
-                                        fixed_width_column_wrapper<int32_t>({1}),
-                                        fixed_width_column_wrapper<int32_t>({0})}});
+                                        fixed_width_column_wrapper<uint32_t>({1}),
+                                        fixed_width_column_wrapper<uint32_t>({0})}});
 }
 
 TEST_F(QuadtreeOnPointIndexingTest, test_two)
@@ -112,11 +112,11 @@ TEST_F(QuadtreeOnPointIndexingTest, test_two)
   // the top level quadtree node is expected to have a value of
   // ([0, 3], [0, 0], [0, 0], [1, 1], [0, 1])
   expect_tables_equal(*quadtree,
-                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({0, 3}),
-                                        fixed_width_column_wrapper<int8_t>({0, 0}),
+                      cudf::table_view{{fixed_width_column_wrapper<uint32_t>({0, 3}),
+                                        fixed_width_column_wrapper<uint8_t>({0, 0}),
                                         fixed_width_column_wrapper<bool>({0, 0}),
-                                        fixed_width_column_wrapper<int32_t>({1, 1}),
-                                        fixed_width_column_wrapper<int32_t>({0, 1})}});
+                                        fixed_width_column_wrapper<uint32_t>({1, 1}),
+                                        fixed_width_column_wrapper<uint32_t>({0, 1})}});
 }
 
 TEST_F(QuadtreeOnPointIndexingTest, test_small)
@@ -179,11 +179,11 @@ TEST_F(QuadtreeOnPointIndexingTest, test_small)
   expect_tables_equal(
     *quadtree,
     cudf::table_view{
-      {fixed_width_column_wrapper<int32_t>({0, 1, 2, 0, 1, 3, 4, 7, 5, 6, 13, 14, 28, 31}),
-       fixed_width_column_wrapper<int8_t>({0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}),
+      {fixed_width_column_wrapper<uint32_t>({0, 1, 2, 0, 1, 3, 4, 7, 5, 6, 13, 14, 28, 31}),
+       fixed_width_column_wrapper<uint8_t>({0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}),
        fixed_width_column_wrapper<bool>({1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0}),
-       fixed_width_column_wrapper<int32_t>({3, 2, 11, 7, 2, 2, 9, 2, 9, 7, 5, 8, 8, 7}),
-       fixed_width_column_wrapper<int32_t>({3, 6, 60, 0, 8, 10, 36, 12, 7, 16, 23, 28, 45, 53})}});
+       fixed_width_column_wrapper<uint32_t>({3, 2, 11, 7, 2, 2, 9, 2, 9, 7, 5, 8, 8, 7}),
+       fixed_width_column_wrapper<uint32_t>({3, 6, 60, 0, 8, 10, 36, 12, 7, 16, 23, 28, 45, 53})}});
 }
 
 TEST_F(QuadtreeOnPointIndexingTest, test_all_lowest_level_quads)
@@ -215,9 +215,9 @@ TEST_F(QuadtreeOnPointIndexingTest, test_all_lowest_level_quads)
   // the top level quadtree node is expected to have a value of
   // ([3, 12, 15], [0, 1, 1], [1, 0, 0], [2, 1, 1], [1, 0, 1])
   expect_tables_equal(*quadtree,
-                      cudf::table_view{{fixed_width_column_wrapper<int32_t>({3, 12, 15}),
-                                        fixed_width_column_wrapper<int8_t>({0, 1, 1}),
+                      cudf::table_view{{fixed_width_column_wrapper<uint32_t>({3, 12, 15}),
+                                        fixed_width_column_wrapper<uint8_t>({0, 1, 1}),
                                         fixed_width_column_wrapper<bool>({1, 0, 0}),
-                                        fixed_width_column_wrapper<int32_t>({2, 1, 1}),
-                                        fixed_width_column_wrapper<int32_t>({1, 0, 1})}});
+                                        fixed_width_column_wrapper<uint32_t>({2, 1, 1}),
+                                        fixed_width_column_wrapper<uint32_t>({1, 0, 1})}});
 }

--- a/python/cuspatial/cuspatial/tests/test_indexing.py
+++ b/python/cuspatial/cuspatial/tests/test_indexing.py
@@ -26,11 +26,11 @@ def test_empty():
         quadtree,
         cudf.DataFrame(
             {
-                "key": cudf.Series([], dtype=np.int32),
-                "level": cudf.Series([], dtype=np.int8),
+                "key": cudf.Series([], dtype=np.uint32),
+                "level": cudf.Series([], dtype=np.uint8),
                 "is_quad": cudf.Series([], dtype=np.bool_),
-                "length": cudf.Series([], dtype=np.int32),
-                "offset": cudf.Series([], dtype=np.int32),
+                "length": cudf.Series([], dtype=np.uint32),
+                "offset": cudf.Series([], dtype=np.uint32),
             }
         ),
     )
@@ -50,11 +50,11 @@ def test_one_point(dtype):
         quadtree,
         cudf.DataFrame(
             {
-                "key": cudf.Series([0], dtype=np.int32),
-                "level": cudf.Series([0], dtype=np.int8),
+                "key": cudf.Series([0], dtype=np.uint32),
+                "level": cudf.Series([0], dtype=np.uint8),
                 "is_quad": cudf.Series([0], dtype=np.bool_),
-                "length": cudf.Series([1], dtype=np.int32),
-                "offset": cudf.Series([0], dtype=np.int32),
+                "length": cudf.Series([1], dtype=np.uint32),
+                "offset": cudf.Series([0], dtype=np.uint32),
             }
         ),
     )
@@ -74,11 +74,11 @@ def test_two_points(dtype):
         quadtree,
         cudf.DataFrame(
             {
-                "key": cudf.Series([0, 3], dtype=np.int32),
-                "level": cudf.Series([0, 0], dtype=np.int8),
+                "key": cudf.Series([0, 3], dtype=np.uint32),
+                "level": cudf.Series([0, 0], dtype=np.uint8),
                 "is_quad": cudf.Series([0, 0], dtype=np.bool_),
-                "length": cudf.Series([1, 1], dtype=np.int32),
-                "offset": cudf.Series([0, 1], dtype=np.int32),
+                "length": cudf.Series([1, 1], dtype=np.uint32),
+                "offset": cudf.Series([0, 1], dtype=np.uint32),
             }
         ),
     )
@@ -255,20 +255,21 @@ def test_small_number_of_points(dtype):
             {
                 "key": cudf.Series(
                     [0, 1, 2, 0, 1, 3, 4, 7, 5, 6, 13, 14, 28, 31],
-                    dtype=np.int32,
+                    dtype=np.uint32,
                 ),
                 "level": cudf.Series(
-                    [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2], dtype=np.int8
+                    [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2], dtype=np.uint8
                 ),
                 "is_quad": cudf.Series(
                     [1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0], dtype=np.bool_
                 ),
                 "length": cudf.Series(
-                    [3, 2, 11, 7, 2, 2, 9, 2, 9, 7, 5, 8, 8, 7], dtype=np.int32
+                    [3, 2, 11, 7, 2, 2, 9, 2, 9, 7, 5, 8, 8, 7],
+                    dtype=np.uint32,
                 ),
                 "offset": cudf.Series(
                     [3, 6, 60, 0, 8, 10, 36, 12, 7, 16, 23, 28, 45, 53],
-                    dtype=np.int32,
+                    dtype=np.uint32,
                 ),
             }
         ),


### PR DESCRIPTION
This PR replaces uses of `rmm::device_vector` with `rmm::device_uvector`, and changes `cudf::INT8` and `cudf::INT32` to the new unsigned integer types.

I see a runtime improvement on the NYC taxi notebook from ~77 ms to 65.5 ms with FP32 points.