### PR TITLE
[REVIEW] Fix CI style check failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
       - repo: https://github.com/timothycrosley/isort
-        rev: 4.3.21
+        rev: 5.0.4
         hooks:
               - id: isort
       - repo: https://github.com/ambv/black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - PR #245 Pin gdal to be compatible with cuxfilter
 - PR #242 Fix benchmark_fixture to use memory resources.
 - PR #248 Fix build by updating type_id usages after upstream breaking changes.
-
+- PR #252 Fix CI style check failures
 
 # cuSpatial 0.14.0 (Date TBD)
 

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -14,7 +14,7 @@ LANG=C.UTF-8
 source activate gdf
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only python`
+ISORT=`isort --check-only python/**/*.py`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code

--- a/conda/environments/cuspatial_dev_cuda10.0.yml
+++ b/conda/environments/cuspatial_dev_cuda10.0.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black=3.7.7
+  - black=19.10
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*

--- a/conda/environments/cuspatial_dev_cuda10.0.yml
+++ b/conda/environments/cuspatial_dev_cuda10.0.yml
@@ -6,9 +6,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - black=3.7.7
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*
   - cudatoolkit=10.0
+  - flake8=3.7.7
   - gdal>=3.0.2
   - geopandas=0.7.0
+  - isort=5.0.4

--- a/conda/environments/cuspatial_dev_cuda10.1.yml
+++ b/conda/environments/cuspatial_dev_cuda10.1.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black=3.7.7
+  - black=19.10
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*

--- a/conda/environments/cuspatial_dev_cuda10.1.yml
+++ b/conda/environments/cuspatial_dev_cuda10.1.yml
@@ -6,9 +6,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - black=3.7.7
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*
   - cudatoolkit=10.1
+  - flake8=3.7.7
   - gdal>=3.0.2
   - geopandas=0.7.0
+  - isort=5.0.4

--- a/conda/environments/cuspatial_dev_cuda10.2.yml
+++ b/conda/environments/cuspatial_dev_cuda10.2.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black=3.7.7
+  - black=19.10
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*

--- a/conda/environments/cuspatial_dev_cuda10.2.yml
+++ b/conda/environments/cuspatial_dev_cuda10.2.yml
@@ -6,9 +6,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - black=3.7.7
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*
   - cudatoolkit=10.2
+  - flake8=3.7.7
   - gdal>=3.0.2
   - geopandas=0.7.0
+  - isort=5.0.4

--- a/conda/environments/cuspatial_dev_cuda9.2.yml
+++ b/conda/environments/cuspatial_dev_cuda9.2.yml
@@ -6,9 +6,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - black=3.7.7
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*
   - cudatoolkit=9.2
+  - flake8=3.7.7
   - gdal>=3.0.2
   - geopandas=0.7.0
+  - isort=5.0.4

--- a/conda/environments/cuspatial_dev_cuda9.2.yml
+++ b/conda/environments/cuspatial_dev_cuda9.2.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black=3.7.7
+  - black=19.10
   - clang=8.0.1
   - clang-tools=8.0.1
   - cudf=0.14.*

--- a/python/cuspatial/setup.py
+++ b/python/cuspatial/setup.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
-
 import os
 import shutil
 import sysconfig
 from distutils.sysconfig import get_python_lib
 
 import numpy as np
-import versioneer
 from Cython.Build import cythonize
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
+
+import versioneer
 
 install_requires = ["numba", "cython"]
 cython_files = ["cuspatial/_lib/**/*.pyx"]


### PR DESCRIPTION
* Pin flake8, black, isort versions
* Update `ci/checks/style.sh` for new isort version

Similar to changes made in https://github.com/rapidsai/cudf/pull/5643