### PR TITLE
Update prebuild.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #243 Install dependencies via meta package
 - PR #247 Use rmm::device_uvector and cudf::UINT types for quadtree construction
 - PR #246 Hausdorff performance improvement
+- PR #253 Update conda upload versions for new supported CUDA/Python
 
 ## Bug Fixes
 - PR #244 Restrict gdal version

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 #Upload cuspatial once per PYTHON
-if [[ "$CUDA" == "10.0" ]]; then
+if [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_CUSPATIAL=1
 else
     export UPLOAD_CUSPATIAL=0
 fi
 
 #Upload libcuspatial once per CUDA
-if [[ "$PYTHON" == "3.6" ]]; then
+if [[ "$PYTHON" == "3.7" ]]; then
     export UPLOAD_LIBCUSPATIAL=1
 else
     export UPLOAD_LIBCUSPATIAL=0


### PR DESCRIPTION
Update conda upload versions for new supported CUDA/Python

Edited ci/cpu/prebuild.sh with CUDA 10.1 and python 3.7 as new defaults.