### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,9 @@ Here are some guidelines to help the review process go smoothly.
    features or make changes out of the scope of those requested by the reviewer
    (doing this just add delays as already reviewed code ends up having to be
    re-reviewed/it is hard to tell what is new etc!). Further, please do not
-   rebase your branch on master/force push/rewrite history, doing any of these
+   rebase your branch on main/force push/rewrite history, doing any of these
    causes the context of any comments made by reviewers to be lost. If
-   conflicts occur against master they should be resolved by merging master
+   conflicts occur against main they should be resolved by merging main
    into the branch used for making the pull request.
 
 Many thanks in advance for your cooperation!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.