### PR TITLE
[REVIEW] Fix compiler errors from cudf's new duration types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #248 Fix build by updating type_id usages after upstream breaking changes.
 - PR #252 Fix CI style check failures
 - PR #254 Fix issue with incorrect docker image being used in local build script
+- PR #258 Fix compiler errors from cudf's new duration types
 
 # cuSpatial 0.14.0 (03 Jun 2020)
 

--- a/cpp/tests/spatial/coordinate_transform_test.cu
+++ b/cpp/tests/spatial/coordinate_transform_test.cu
@@ -189,7 +189,7 @@ template <typename T>
 struct LatLonToCartesianUnsupportedTypesTest : public BaseFixture {
 };
 
-using UnsupportedTestTypes = RemoveIf<ContainedIn<Types<float, double>>, AllTypes>;
+using UnsupportedTestTypes = RemoveIf<ContainedIn<Types<float, double>>, NumericTypes>;
 TYPED_TEST_CASE(LatLonToCartesianUnsupportedTypesTest, UnsupportedTestTypes);
 
 TYPED_TEST(LatLonToCartesianUnsupportedTypesTest, MismatchSize)
@@ -199,6 +199,24 @@ TYPED_TEST(LatLonToCartesianUnsupportedTypesTest, MismatchSize)
   auto camera_lat = 0;
   auto point_lon  = fixed_width_column_wrapper<T>({0});
   auto point_lat  = fixed_width_column_wrapper<T>({0});
+
+  EXPECT_THROW(cuspatial::lonlat_to_cartesian(camera_lon, camera_lat, point_lon, point_lat),
+               cuspatial::logic_error);
+}
+
+template <typename T>
+struct LatLonToCartesianUnsupportedChronoTypesTest : public BaseFixture {
+};
+
+TYPED_TEST_CASE(LatLonToCartesianUnsupportedChronoTypesTest, ChronoTypes);
+
+TYPED_TEST(LatLonToCartesianUnsupportedChronoTypesTest, MismatchSize)
+{
+  using T         = TypeParam;
+  auto camera_lon = 0;
+  auto camera_lat = 0;
+  auto point_lon  = fixed_width_column_wrapper<T>({T{0}});
+  auto point_lat  = fixed_width_column_wrapper<T>({T{0}});
 
   EXPECT_THROW(cuspatial::lonlat_to_cartesian(camera_lon, camera_lat, point_lon, point_lat),
                cuspatial::logic_error);

--- a/cpp/tests/spatial/haversine_test.cpp
+++ b/cpp/tests/spatial/haversine_test.cpp
@@ -105,7 +105,7 @@ template <typename T>
 struct HaversineUnsupportedTypesTest : public BaseFixture {
 };
 
-using UnsupportedTypes = RemoveIf<ContainedIn<Types<float, double>>, AllTypes>;
+using UnsupportedTypes = RemoveIf<ContainedIn<Types<float, double>>, NumericTypes>;
 TYPED_TEST_CASE(HaversineUnsupportedTypesTest, UnsupportedTypes);
 
 TYPED_TEST(HaversineUnsupportedTypesTest, MismatchSize)
@@ -116,6 +116,24 @@ TYPED_TEST(HaversineUnsupportedTypesTest, MismatchSize)
   auto a_lat = fixed_width_column_wrapper<T>({0});
   auto b_lon = fixed_width_column_wrapper<T>({0});
   auto b_lat = fixed_width_column_wrapper<T>({0});
+
+  EXPECT_THROW(cuspatial::haversine_distance(a_lon, a_lat, b_lon, b_lat), cuspatial::logic_error);
+}
+
+template <typename T>
+struct HaversineUnsupportedChronoTypesTest : public BaseFixture {
+};
+
+TYPED_TEST_CASE(HaversineUnsupportedChronoTypesTest, ChronoTypes);
+
+TYPED_TEST(HaversineUnsupportedChronoTypesTest, MismatchSize)
+{
+  using T = TypeParam;
+
+  auto a_lon = fixed_width_column_wrapper<T>({T{0}});
+  auto a_lat = fixed_width_column_wrapper<T>({T{0}});
+  auto b_lon = fixed_width_column_wrapper<T>({T{0}});
+  auto b_lat = fixed_width_column_wrapper<T>({T{0}});
 
   EXPECT_THROW(cuspatial::haversine_distance(a_lon, a_lat, b_lon, b_lat), cuspatial::logic_error);
 }

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -219,7 +219,7 @@ template <typename T>
 struct PointInPolygonUnsupportedTypesTest : public BaseFixture {
 };
 
-using UnsupportedTestTypes = RemoveIf<ContainedIn<TestTypes>, AllTypes>;
+using UnsupportedTestTypes = RemoveIf<ContainedIn<TestTypes>, NumericTypes>;
 TYPED_TEST_CASE(PointInPolygonUnsupportedTypesTest, UnsupportedTestTypes);
 
 TYPED_TEST(PointInPolygonUnsupportedTypesTest, UnsupportedPointType)
@@ -232,6 +232,29 @@ TYPED_TEST(PointInPolygonUnsupportedTypesTest, UnsupportedPointType)
   auto poly_ring_offsets = wrapper<cudf::size_type>({0});
   auto poly_point_xs     = wrapper<T>({0.0, 1.0, 0.0, -1.0});
   auto poly_point_ys     = wrapper<T>({1.0, 0.0, -1.0, 0.0});
+
+  EXPECT_THROW(
+    cuspatial::point_in_polygon(
+      test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys),
+    cuspatial::logic_error);
+}
+
+template <typename T>
+struct PointInPolygonUnsupportedChronoTypesTest : public BaseFixture {
+};
+
+TYPED_TEST_CASE(PointInPolygonUnsupportedChronoTypesTest, ChronoTypes);
+
+TYPED_TEST(PointInPolygonUnsupportedChronoTypesTest, UnsupportedPointChronoType)
+{
+  using T = TypeParam;
+
+  auto test_point_xs     = wrapper<T>({T{0}, T{0}});
+  auto test_point_ys     = wrapper<T>({T{0}});
+  auto poly_offsets      = wrapper<cudf::size_type>({0});
+  auto poly_ring_offsets = wrapper<cudf::size_type>({0});
+  auto poly_point_xs     = wrapper<T>({T{0}, T{1}, T{0}, T{-1}});
+  auto poly_point_ys     = wrapper<T>({T{1}, T{0}, T{-1}, T{0}});
 
   EXPECT_THROW(
     cuspatial::point_in_polygon(

--- a/cpp/tests/spatial_window/spatial_window_test.cpp
+++ b/cpp/tests/spatial_window/spatial_window_test.cpp
@@ -99,7 +99,7 @@ struct IsFloat {
   using Call = std::is_floating_point<T>;
 };
 
-using NonFloatTypes = cudf::test::RemoveIf<IsFloat, cudf::test::AllTypes>;
+using NonFloatTypes = cudf::test::RemoveIf<IsFloat, cudf::test::NumericTypes>;
 
 template <typename T>
 struct SpatialWindowUnsupportedTypesTest : public cudf::test::BaseFixture {
@@ -111,6 +111,23 @@ TYPED_TEST(SpatialWindowUnsupportedTypesTest, ShouldThrow)
 {
   auto points_x = cudf::test::fixed_width_column_wrapper<TypeParam>({1.0, 2.0, 3.0});
   auto points_y = cudf::test::fixed_width_column_wrapper<TypeParam>({0.0, 1.0, 2.0});
+
+  EXPECT_THROW(
+    auto result = cuspatial::points_in_spatial_window(1.5, 5.5, 1.5, 5.5, points_x, points_y),
+    cuspatial::logic_error);
+}
+
+template <typename T>
+struct SpatialWindowUnsupportedChronoTypesTest : public cudf::test::BaseFixture {
+};
+
+TYPED_TEST_CASE(SpatialWindowUnsupportedChronoTypesTest, cudf::test::ChronoTypes);
+
+TYPED_TEST(SpatialWindowUnsupportedChronoTypesTest, ShouldThrow)
+{
+  using T       = TypeParam;
+  auto points_x = cudf::test::fixed_width_column_wrapper<T>({T{1}, T{2}, T{3}});
+  auto points_y = cudf::test::fixed_width_column_wrapper<T>({T{0}, T{1}, T{2}});
 
   EXPECT_THROW(
     auto result = cuspatial::points_in_spatial_window(1.5, 5.5, 1.5, 5.5, points_x, points_y),


### PR DESCRIPTION
Fixes compiler errors from cuDF's new duration types recently added as part of https://github.com/rapidsai/cudf/issues/5272.