### PR TITLE
[REVIEW] Replace CNMeM with pool_memory_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,25 @@
 - PR #146 quadtree-polygon pairing for spatial filtering
 
 ## Improvements
-- PR #237 Remove nvstrings references from CMakeLists.txt
-- PR #239 Add docs build script
-- PR #238 Fix library and include paths in CMakeLists.txt and setup.py
+- PR #237 Remove nvstrings references from CMakeLists.txt.
+- PR #239 Add docs build script.
+- PR #238 Fix library and include paths in CMakeLists.txt and setup.py.
 - PR #240 Remove deprecated RMM header references.
-- PR #243 Install dependencies via meta package
-- PR #247 Use rmm::device_uvector and cudf::UINT types for quadtree construction
-- PR #246 Hausdorff performance improvement
-- PR #253 Update conda upload versions for new supported CUDA/Python
-- PR #250 cartesian product iterator + more Hausdorff performance improvements.
+- PR #243 Install dependencies via meta package.
+- PR #247 Use rmm::device_uvector and cudf::UINT types for quadtree construction.
+- PR #246 Hausdorff performance improvement.
+- PR #253 Update conda upload versions for new supported CUDA/Python.
+- PR #250 Cartesian product iterator + more Hausdorff performance improvements.
+- PR #260 Replace RMM `cnmem_memory_resource` with `pool_memory_resource` in benchmark fixture.
 
 ## Bug Fixes
-- PR #244 Restrict gdal version
-- PR #245 Pin gdal to be compatible with cuxfilter
+- PR #244 Restrict gdal version.
+- PR #245 Pin gdal to be compatible with cuxfilter.
 - PR #242 Fix benchmark_fixture to use memory resources.
 - PR #248 Fix build by updating type_id usages after upstream breaking changes.
-- PR #252 Fix CI style check failures
-- PR #254 Fix issue with incorrect docker image being used in local build script
-- PR #258 Fix compiler errors from cudf's new duration types
+- PR #252 Fix CI style check failures.
+- PR #254 Fix issue with incorrect docker image being used in local build script.
+- PR #258 Fix compiler errors from cudf's new duration types.
 
 # cuSpatial 0.14.0 (03 Jun 2020)
 

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
  */
 
 #include <benchmark/benchmark.h>
-#include "rmm/mr/device/cnmem_memory_resource.hpp"
-#include "rmm/mr/device/default_memory_resource.hpp"
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
-namespace cuspatial {
+namespace cudf {
 /**
  * @brief Google Benchmark fixture for libcudf benchmarks
  *
@@ -50,17 +52,24 @@ namespace cuspatial {
  *
  * BENCHMARK_REGISTER_F(my_benchmark, my_test_name)->Range(128, 512);
  */
+
+inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+
+inline auto make_pool()
+{
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+}
+
 class benchmark : public ::benchmark::Fixture {
  public:
   virtual void SetUp(const ::benchmark::State& state)
   {
-    auto mr = new rmm::mr::cnmem_memory_resource;
-    rmm::mr::set_default_resource(mr);  // set default resource to cnmem
+    auto mr = make_pool();
+    rmm::mr::set_default_resource(mr.get());  // set default resource to pool
   }
 
   virtual void TearDown(const ::benchmark::State& state)
   {
-    delete rmm::mr::get_default_resource();
     rmm::mr::set_default_resource(nullptr);  // reset default resource to the initial resource
   }
 
@@ -70,6 +79,8 @@ class benchmark : public ::benchmark::Fixture {
   {
     TearDown(const_cast<const ::benchmark::State&>(st));
   }
+
+  std::shared_ptr<rmm::mr::device_memory_resource> mr;
 };
 
-};  // namespace cuspatial
+};  // namespace cudf

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -33,9 +33,9 @@ inline auto make_pool()
 }  // namespace
 
 /**
- * @brief Google Benchmark fixture for libcudf benchmarks
+ * @brief Google Benchmark fixture for libcuspatial benchmarks
  *
- * libcudf benchmarks should use a fixture derived from this fixture class to
+ * libcuspatial benchmarks should use a fixture derived from this fixture class to
  * ensure that the RAPIDS Memory Manager pool mode is used in benchmarks, which
  * eliminates memory allocation / deallocation performance overhead from the
  * benchmark.
@@ -47,7 +47,7 @@ inline auto make_pool()
  * Example:
  *
  * template <class T>
- * class my_benchmark : public cudf::benchmark {
+ * class my_benchmark : public cuspatial::benchmark {
  * public:
  *   using TypeParam = T;
  * };

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -16,8 +16,8 @@
 
 #include <benchmark/benchmark.h>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 namespace cuspatial {
@@ -68,12 +68,13 @@ class benchmark : public ::benchmark::Fixture {
   virtual void SetUp(const ::benchmark::State& state)
   {
     auto mr = make_pool();
-    rmm::mr::set_default_resource(mr.get());  // set default resource to pool
+    rmm::mr::set_current_device_resource(mr.get());  // set default resource to pool
   }
 
   virtual void TearDown(const ::benchmark::State& state)
   {
-    rmm::mr::set_default_resource(nullptr);  // reset default resource to the initial resource
+    // reset default resource to the initial resource
+    rmm::mr::set_current_device_resource(nullptr);
   }
 
   // eliminate partial override warnings (see benchmark/benchmark.h)

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -20,7 +20,18 @@
 #include <rmm/mr/device/owning_wrapper.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
-namespace cudf {
+namespace cuspatial {
+
+namespace {
+// memory resource factory helpers
+inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+
+inline auto make_pool()
+{
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+}
+}  // namespace
+
 /**
  * @brief Google Benchmark fixture for libcudf benchmarks
  *
@@ -52,14 +63,6 @@ namespace cudf {
  *
  * BENCHMARK_REGISTER_F(my_benchmark, my_test_name)->Range(128, 512);
  */
-
-inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-inline auto make_pool()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
-}
-
 class benchmark : public ::benchmark::Fixture {
  public:
   virtual void SetUp(const ::benchmark::State& state)
@@ -83,4 +86,4 @@ class benchmark : public ::benchmark::Fixture {
   std::shared_ptr<rmm::mr::device_memory_resource> mr;
 };
 
-};  // namespace cudf
+};  // namespace cuspatial


### PR DESCRIPTION
Replaces usage of `cnmem_memory_resource` in benchmark fixture with `pool_memory_resource`.

Also adds option to test with `binning_memory_resource`.
