### PR TITLE
[REVIEW] Rename quad_bbox_join to join_quadtree_and_bounding_boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #253 Update conda upload versions for new supported CUDA/Python.
 - PR #250 Cartesian product iterator + more Hausdorff performance improvements.
 - PR #260 Replace RMM `cnmem_memory_resource` with `pool_memory_resource` in benchmark fixture.
+- PR #264 Rename `quad_bbox_join` to `join_quadtree_and_bounding_boxes`.
 
 ## Bug Fixes
 - PR #244 Restrict gdal version.

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -50,7 +50,7 @@ namespace cuspatial {
  * poly_offset - INT32 column of indices for each poly bbox that intersects with the quadtree.
  * quad_offset - INT32 column of indices for each leaf quadrant intersecting with a poly bbox.
  */
-std::unique_ptr<cudf::table> quad_bbox_join(
+std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(
   cudf::table_view const& quadtree,
   cudf::table_view const& poly_bbox,
   double x_min,
@@ -64,15 +64,16 @@ std::unique_ptr<cudf::table> quad_bbox_join(
 /**
  * @brief Test whether the specified points are inside any of the specified polygons.
  *
- * Uses the table of (polygon, quadrant) pairs returned by `cuspatial::quad_bbox_join` to
- * ensure only the points in the same quadrant as each polygon are tested for intersection.
+ * Uses the table of (polygon, quadrant) pairs returned by
+ *`cuspatial::join_quadtree_and_bounding_boxes` to ensure only the points in the same quadrant as
+ *each polygon are tested for intersection.
  *
  * This pre-filtering can dramatically reduce number of points tested per polygon, enabling
  * faster intersection-testing at the expense of extra memory allocated to store the quadtree and
  * sorted point_indices.
  *
  * @param poly_quad_pairs cudf table of (polygon, quadrant) index pairs returned by
- * `cuspatial::quad_bbox_join`
+ * `cuspatial::join_quadtree_and_bounding_boxes`
  * @param quadtree cudf table representing a quadtree (key, level, is_quad, length, offset).
  * @param point_indices Sorted point indices returned by `cuspatial::quadtree_on_points`
  * @param point_x x-coordinates of points to test
@@ -114,11 +115,12 @@ std::unique_ptr<cudf::table> quadtree_point_in_polygon(
  * @brief Finds the nearest polyline to each point in a quadrant, and computes the distances between
  * each point and polyline.
  *
- * Uses the table of (polyline, quadrant) pairs returned by `cuspatial::quad_bbox_join` to
- * ensure distances are computed only for the points in the same quadrant as each polyline.
+ * Uses the table of (polyline, quadrant) pairs returned by
+ *`cuspatial::join_quadtree_and_bounding_boxes` to ensure distances are computed only for the points
+ *in the same quadrant as each polyline.
  *
  * @param poly_quad_pairs cudf table of (polyline, quadrant) index pairs returned by
- * `cuspatial::quad_bbox_join`
+ * `cuspatial::join_quadtree_and_bounding_boxes`
  * @param quadtree cudf table representing a quadtree (key, level, is_quad, length, offset).
  * @param point_indices Sorted point indices returned by `cuspatial::quadtree_on_points`
  * @param point_x x-coordinates of points to test

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -65,8 +65,8 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(
  * @brief Test whether the specified points are inside any of the specified polygons.
  *
  * Uses the table of (polygon, quadrant) pairs returned by
- *`cuspatial::join_quadtree_and_bounding_boxes` to ensure only the points in the same quadrant as
- *each polygon are tested for intersection.
+ * `cuspatial::join_quadtree_and_bounding_boxes` to ensure only the points in the same quadrant as
+ * each polygon are tested for intersection.
  *
  * This pre-filtering can dramatically reduce number of points tested per polygon, enabling
  * faster intersection-testing at the expense of extra memory allocated to store the quadtree and

--- a/cpp/src/join/quadtree_poly_filtering.cu
+++ b/cpp/src/join/quadtree_poly_filtering.cu
@@ -224,16 +224,16 @@ struct dispatch_quadtree_bounding_box_join {
 };
 }  // namespace
 
-std::unique_ptr<cudf::table> quad_bbox_join(cudf::table_view const &quadtree,
-                                            cudf::table_view const &poly_bbox,
-                                            double x_min,
-                                            double x_max,
-                                            double y_min,
-                                            double y_max,
-                                            double scale,
-                                            int8_t max_depth,
-                                            rmm::mr::device_memory_resource *mr,
-                                            cudaStream_t stream)
+std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(cudf::table_view const &quadtree,
+                                                              cudf::table_view const &poly_bbox,
+                                                              double x_min,
+                                                              double x_max,
+                                                              double y_min,
+                                                              double y_max,
+                                                              double scale,
+                                                              int8_t max_depth,
+                                                              rmm::mr::device_memory_resource *mr,
+                                                              cudaStream_t stream)
 {
   return cudf::type_dispatcher(poly_bbox.column(0).type(),
                                dispatch_quadtree_bounding_box_join{},
@@ -251,15 +251,15 @@ std::unique_ptr<cudf::table> quad_bbox_join(cudf::table_view const &quadtree,
 
 }  // namespace detail
 
-std::unique_ptr<cudf::table> quad_bbox_join(cudf::table_view const &quadtree,
-                                            cudf::table_view const &poly_bbox,
-                                            double x_min,
-                                            double x_max,
-                                            double y_min,
-                                            double y_max,
-                                            double scale,
-                                            int8_t max_depth,
-                                            rmm::mr::device_memory_resource *mr)
+std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(cudf::table_view const &quadtree,
+                                                              cudf::table_view const &poly_bbox,
+                                                              double x_min,
+                                                              double x_max,
+                                                              double y_min,
+                                                              double y_max,
+                                                              double scale,
+                                                              int8_t max_depth,
+                                                              rmm::mr::device_memory_resource *mr)
 {
   CUSPATIAL_EXPECTS(quadtree.num_columns() == 5, "quadtree table must have 5 columns");
   CUSPATIAL_EXPECTS(poly_bbox.num_columns() == 4, "polygon bbox table must have 4 columns");
@@ -277,7 +277,7 @@ std::unique_ptr<cudf::table> quad_bbox_join(cudf::table_view const &quadtree,
     return std::make_unique<cudf::table>(std::move(cols));
   }
 
-  return detail::quad_bbox_join(
+  return detail::join_quadtree_and_bounding_boxes(
     quadtree, poly_bbox, x_min, x_max, y_min, y_max, scale, max_depth, mr, cudaStream_t{0});
 }
 

--- a/cpp/tests/join/point_in_polygon_test_large.cpp
+++ b/cpp/tests/join/point_in_polygon_test_large.cpp
@@ -212,7 +212,7 @@ TYPED_TEST(PIPRefineTestLarge, TestLarge)
   auto polygon_bboxes =
     cuspatial::polygon_bounding_boxes(poly_offsets, ring_offsets, poly_x, poly_y, this->mr());
 
-  auto polygon_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polygon_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     *quadtree, *polygon_bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   auto point_in_polygon_pairs = cuspatial::quadtree_point_in_polygon(*polygon_quadrant_pairs,

--- a/cpp/tests/join/point_in_polygon_test_small.cpp
+++ b/cpp/tests/join/point_in_polygon_test_small.cpp
@@ -152,7 +152,7 @@ TYPED_TEST(PIPRefineTestSmall, TestSmall)
   auto polygon_bboxes =
     cuspatial::polygon_bounding_boxes(poly_offsets, ring_offsets, poly_x, poly_y, this->mr());
 
-  auto polygon_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polygon_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     *quadtree, *polygon_bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   auto point_in_polygon_pairs = cuspatial::quadtree_point_in_polygon(*polygon_quadrant_pairs,

--- a/cpp/tests/join/point_to_nearest_polyline_test_small.cpp
+++ b/cpp/tests/join/point_to_nearest_polyline_test_small.cpp
@@ -153,7 +153,7 @@ TYPED_TEST(PIPRefineTestSmall, TestSmall)
   auto polyline_bboxes =
     cuspatial::polyline_bounding_boxes(poly_offsets, poly_x, poly_y, expansion_radius, this->mr());
 
-  auto polygon_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polygon_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     *quadtree, *polyline_bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   auto point_to_polyline_distances =

--- a/cpp/tests/join/quadtree_polygon_filtering_test.cu
+++ b/cpp/tests/join/quadtree_polygon_filtering_test.cu
@@ -57,32 +57,34 @@ TYPED_TEST(QuadtreePolygonFilteringTest, test_errors)
                                  fixed_width_column_wrapper<T>({})}};
 
   // Test throws on bad quadtree
-  EXPECT_THROW(cuspatial::quad_bbox_join(bad_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 1, this->mr()),
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 bad_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 1, this->mr()),
                cuspatial::logic_error);
 
   // Test throws on bad bboxes
-  EXPECT_THROW(cuspatial::quad_bbox_join(empty_quadtree, bad_bboxes, 0, 1, 0, 1, 1, 1, this->mr()),
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 empty_quadtree, bad_bboxes, 0, 1, 0, 1, 1, 1, this->mr()),
                cuspatial::logic_error);
 
   // Test throws on bad scale
-  EXPECT_THROW(
-    cuspatial::quad_bbox_join(empty_quadtree, empty_bboxes, 0, 1, 0, 1, 0, 1, this->mr()),
-    cuspatial::logic_error);
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 empty_quadtree, empty_bboxes, 0, 1, 0, 1, 0, 1, this->mr()),
+               cuspatial::logic_error);
 
   // Test throws on bad max_depth <= 0
-  EXPECT_THROW(
-    cuspatial::quad_bbox_join(empty_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 0, this->mr()),
-    cuspatial::logic_error);
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 empty_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 0, this->mr()),
+               cuspatial::logic_error);
 
   // Test throws on bad max_depth >= 16
-  EXPECT_THROW(
-    cuspatial::quad_bbox_join(empty_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 16, this->mr()),
-    cuspatial::logic_error);
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 empty_quadtree, empty_bboxes, 0, 1, 0, 1, 1, 16, this->mr()),
+               cuspatial::logic_error);
 
   // Test throws on reversed area of interest bbox coordinates
-  EXPECT_THROW(
-    cuspatial::quad_bbox_join(empty_quadtree, empty_bboxes, 1, 0, 1, 0, 1, 1, this->mr()),
-    cuspatial::logic_error);
+  EXPECT_THROW(cuspatial::join_quadtree_and_bounding_boxes(
+                 empty_quadtree, empty_bboxes, 1, 0, 1, 0, 1, 1, this->mr()),
+               cuspatial::logic_error);
 }
 
 TYPED_TEST(QuadtreePolygonFilteringTest, test_empty)
@@ -111,7 +113,7 @@ TYPED_TEST(QuadtreePolygonFilteringTest, test_empty)
                            fixed_width_column_wrapper<T>({}),
                            fixed_width_column_wrapper<T>({})}};
 
-  auto polygon_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polygon_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     quadtree, bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   expect_tables_equal(cudf::table_view{{fixed_width_column_wrapper<uint32_t>({}),
@@ -225,7 +227,7 @@ TYPED_TEST(QuadtreePolygonFilteringTest, test_small)
   auto polygon_bboxes =
     cuspatial::polygon_bounding_boxes(poly_offsets, ring_offsets, poly_x, poly_y, this->mr());
 
-  auto polygon_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polygon_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     *quadtree, *polygon_bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   CUSPATIAL_EXPECTS(

--- a/cpp/tests/join/quadtree_polyline_filtering_test.cu
+++ b/cpp/tests/join/quadtree_polyline_filtering_test.cu
@@ -140,7 +140,7 @@ TYPED_TEST(QuadtreePolylineBoundingBoxJoinTest, test_small)
   auto polyline_bboxes =
     cuspatial::polyline_bounding_boxes(poly_offsets, poly_x, poly_y, expansion_radius, this->mr());
 
-  auto polyline_quadrant_pairs = cuspatial::quad_bbox_join(
+  auto polyline_quadrant_pairs = cuspatial::join_quadtree_and_bounding_boxes(
     *quadtree, *polyline_bboxes, x_min, x_max, y_min, y_max, scale, max_depth, this->mr());
 
   CUSPATIAL_EXPECTS(

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,7 +42,7 @@ Spatial Joining
 ----------------
 .. currentmodule:: cuspatial.core.spatial_join
 
-.. automethod:: cuspatial.core.spatial_join.quad_bbox_join
+.. automethod:: cuspatial.core.spatial_join.join_quadtree_and_bounding_boxes
 .. automethod:: cuspatial.core.spatial_join.quadtree_point_in_polygon
 .. automethod:: cuspatial.core.spatial_join.quadtree_point_to_nearest_polyline
 

--- a/python/cuspatial/cuspatial/__init__.py
+++ b/python/cuspatial/cuspatial/__init__.py
@@ -10,7 +10,7 @@ from .core.gis import (
 from .core.indexing import quadtree_on_points
 from .core.interpolate import CubicSpline
 from .core.spatial_join import (
-    quad_bbox_join,
+    join_quadtree_and_bounding_boxes,
     quadtree_point_in_polygon,
     quadtree_point_to_nearest_polyline,
 )

--- a/python/cuspatial/cuspatial/_lib/cpp/spatial_join.pxd
+++ b/python/cuspatial/cuspatial/_lib/cpp/spatial_join.pxd
@@ -7,8 +7,8 @@ from cudf._lib.move cimport move, unique_ptr
 
 cdef extern from "cuspatial/spatial_join.hpp" namespace "cuspatial" nogil:
 
-    cdef unique_ptr[table] quad_bbox_join \
-        "cuspatial::quad_bbox_join" (
+    cdef unique_ptr[table] join_quadtree_and_bounding_boxes \
+        "cuspatial::join_quadtree_and_bounding_boxes" (
         const table_view & quadtree,
         const table_view & poly_bbox,
         double x_min,

--- a/python/cuspatial/cuspatial/_lib/spatial_join.pyx
+++ b/python/cuspatial/cuspatial/_lib/spatial_join.pyx
@@ -5,7 +5,7 @@ from cudf._lib.table cimport table, table_view, Table
 from cudf._lib.column cimport column, column_view, Column
 
 from cuspatial._lib.cpp.spatial_join cimport (
-    quad_bbox_join as cpp_quad_bbox_join,
+    join_quadtree_and_bounding_boxes as cpp_join_quadtree_and_bounding_boxes,
     quadtree_point_in_polygon as cpp_quadtree_pip,
     quadtree_point_to_nearest_polyline as cpp_quadtree_p2p,
 )
@@ -16,19 +16,19 @@ from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
 from libc.stdint cimport int8_t
 
-cpdef quad_bbox_join(Table quadtree,
-                     Table poly_bounding_boxes,
-                     double x_min,
-                     double x_max,
-                     double y_min,
-                     double y_max,
-                     double scale,
-                     int8_t max_depth):
+cpdef join_quadtree_and_bounding_boxes(Table quadtree,
+                                       Table poly_bounding_boxes,
+                                       double x_min,
+                                       double x_max,
+                                       double y_min,
+                                       double y_max,
+                                       double scale,
+                                       int8_t max_depth):
     cdef table_view c_quadtree = quadtree.data_view()
     cdef table_view c_poly_bounding_boxes = poly_bounding_boxes.data_view()
     cdef unique_ptr[table] result
     with nogil:
-        result = move(cpp_quad_bbox_join(
+        result = move(cpp_join_quadtree_and_bounding_boxes(
             c_quadtree,
             c_poly_bounding_boxes,
             x_min, x_max, y_min, y_max, scale, max_depth

--- a/python/cuspatial/cuspatial/core/spatial_join.py
+++ b/python/cuspatial/cuspatial/core/spatial_join.py
@@ -10,7 +10,7 @@ from cuspatial._lib import spatial_join
 from cuspatial.utils.column_utils import normalize_point_columns
 
 
-def quad_bbox_join(
+def join_quadtree_and_bounding_boxes(
     quadtree, poly_bounding_boxes, x_min, x_max, y_min, y_max, scale, max_depth
 ):
     """ Search a quadtree for polygon or polyline bounding box intersections.
@@ -64,7 +64,7 @@ def quad_bbox_join(
         )
 
     return DataFrame._from_table(
-        spatial_join.quad_bbox_join(
+        spatial_join.join_quadtree_and_bounding_boxes(
             quadtree,
             poly_bounding_boxes,
             x_min,
@@ -92,8 +92,8 @@ def quadtree_point_in_polygon(
     polygons.
 
     Uses the table of (polygon, quadrant) pairs returned by
-    ``cuspatial.quad_bbox_join`` to ensure only the points in the same
-    quadrant as each polygon are tested for intersection.
+    ``cuspatial.join_quadtree_and_bounding_boxes`` to ensure only the points
+    in the same quadrant as each polygon are tested for intersection.
 
     This pre-filtering can dramatically reduce number of points tested per
     polygon, enabling faster intersection-testing at the expense of extra
@@ -103,7 +103,7 @@ def quadtree_point_in_polygon(
     ----------
     poly_quad_pairs: cudf.DataFrame
         Table of (polygon, quadrant) index pairs returned by
-        ``cuspatial.quad_bbox_join``.
+        ``cuspatial.join_quadtree_and_bounding_boxes``.
     quadtree : cudf.DataFrame
         A complete quadtree for a given area-of-interest bounding box.
     point_indices : cudf.Series
@@ -172,14 +172,14 @@ def quadtree_point_to_nearest_polyline(
     the distances between each point and polyline.
 
     Uses the table of (polyline, quadrant) pairs returned by
-    ``cuspatial.quad_bbox_join`` to ensure distances are computed only for
-    the points in the same quadrant as each polyline.
+    ``cuspatial.join_quadtree_and_bounding_boxes`` to ensure distances are
+    computed only for the points in the same quadrant as each polyline.
 
     Parameters
     ----------
     poly_quad_pairs: cudf.DataFrame
         Table of (polyline, quadrant) index pairs returned by
-        ``cuspatial.quad_bbox_join``.
+        ``cuspatial.join_quadtree_and_bounding_boxes``.
     quadtree : cudf.DataFrame
         A complete quadtree for a given area-of-interest bounding box.
     point_indices : cudf.Series

--- a/python/cuspatial/cuspatial/tests/test_spatial_join.py
+++ b/python/cuspatial/cuspatial/tests/test_spatial_join.py
@@ -226,7 +226,7 @@ def test_empty(dtype):
         cudf.Series([], dtype=dtype),
     )
     # empty should not throw
-    intersections = cuspatial.quad_bbox_join(
+    intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, *bbox_1, 1, 1,  # bbox  # scale  # max_depth
     )
     assert_eq(
@@ -267,7 +267,7 @@ def test_polygon_join_small(dtype):
     poly_bboxes = cuspatial.polygon_bounding_boxes(
         small_poly_offsets, small_ring_offsets, poly_points_x, poly_points_y,
     )
-    intersections = cuspatial.quad_bbox_join(
+    intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, x_min, x_max, y_min, y_max, scale, max_depth,
     )
     assert_eq(
@@ -313,7 +313,7 @@ def test_polyline_join_small(dtype):
     poly_bboxes = cuspatial.polyline_bounding_boxes(
         small_ring_offsets, poly_points_x, poly_points_y, expansion_radius,
     )
-    intersections = cuspatial.quad_bbox_join(
+    intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, x_min, x_max, y_min, y_max, scale, max_depth,
     )
     assert_eq(
@@ -404,7 +404,7 @@ def test_quadtree_point_in_polygon_small(dtype):
     poly_bboxes = cuspatial.polygon_bounding_boxes(
         small_poly_offsets, small_ring_offsets, poly_points_x, poly_points_y,
     )
-    intersections = cuspatial.quad_bbox_join(
+    intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, x_min, x_max, y_min, y_max, scale, max_depth,
     )
     points_and_polygons = cuspatial.quadtree_point_in_polygon(
@@ -484,7 +484,7 @@ def run_test_quadtree_point_to_nearest_polyline_small(
     poly_bboxes = cuspatial.polyline_bounding_boxes(
         small_ring_offsets, poly_points_x, poly_points_y, expansion_radius,
     )
-    intersections = cuspatial.quad_bbox_join(
+    intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, x_min, x_max, y_min, y_max, scale, max_depth,
     )
     p2np_result = cuspatial.quadtree_point_to_nearest_polyline(


### PR DESCRIPTION
As mentioned in https://github.com/rapidsai/cuspatial/pull/149#discussion_r467185668, this PR renames the `quad_bbox_join` method to a more descriptive `join_quadtree_and_bounding_boxes`.