### PR TITLE
[REVIEW] Update docs to remove references to master [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           v1.5.1 
+                    GIT_TAG           master
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           main 
+                    GIT_TAG           v1.5.1 
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master
+                    GIT_TAG           master 
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master 
+                    GIT_TAG           main 
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.