### PR TITLE
[REVIEW] Update googlebenchmark version to match rmm & cudf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #278 Update googlebenchmark version to match rmm & cudf.
 
 ## Bug Fixes
 

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master 
+                    GIT_TAG           v1.5.1
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"


### PR DESCRIPTION
This PR updates `GoogleBenchmark.CMakeLists.txt.cmake` to match the version used by rmm ([link](https://github.com/rapidsai/rmm/blob/branch-0.16/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake)) and cudf ([link](https://github.com/rapidsai/cudf/blob/branch-0.16/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake)). This change was suggested by @harrism as a result of the findings from PR #271.
