### PR TITLE
[WIP] Problem importing libgdal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/cuspatial/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/cuspatial/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/conda/environments/cuspatial_dev_cuda10.0.yml
+++ b/conda/environments/cuspatial_dev_cuda10.0.yml
@@ -10,5 +10,5 @@ dependencies:
   - clang-tools=8.0.1
   - cudf=0.15.*
   - cudatoolkit=10.0
-  - gdal>=3.0.2
+  - gdal>=3.0.2,<3.1.0a0
   - geopandas=0.7.0

--- a/conda/environments/cuspatial_dev_cuda10.1.yml
+++ b/conda/environments/cuspatial_dev_cuda10.1.yml
@@ -10,5 +10,5 @@ dependencies:
   - clang-tools=8.0.1
   - cudf=0.15.*
   - cudatoolkit=10.1
-  - gdal>=3.0.2
+  - gdal>=3.0.2,<3.1.0a0
   - geopandas=0.7.0

--- a/conda/environments/cuspatial_dev_cuda10.2.yml
+++ b/conda/environments/cuspatial_dev_cuda10.2.yml
@@ -10,5 +10,5 @@ dependencies:
   - clang-tools=8.0.1
   - cudf=0.15.*
   - cudatoolkit=10.2
-  - gdal>=3.0.2
+  - gdal>=3.0.2,<3.1.0a0
   - geopandas=0.7.0

--- a/conda/environments/cuspatial_dev_cuda9.2.yml
+++ b/conda/environments/cuspatial_dev_cuda9.2.yml
@@ -10,5 +10,5 @@ dependencies:
   - clang-tools=8.0.1
   - cudf=0.15.*
   - cudatoolkit=9.2
-  - gdal>=3.0.2
+  - gdal>=3.0.2,<3.1.0a0
   - geopandas=0.7.0


### PR DESCRIPTION
This may fix #275. I can't test it directly but instead will just see how the next nightly works out. There's a problem with libgdal.so in the nightly docker containers. This change makes the gdal requirements for building from source match the requirements of the conda installation - hopefully this will resolve the issue?

@kkraus14 maybe you have an idea behind what is causing #275? Think this will help?