### PR TITLE
[REVIEW] Replace RMM get_default_resource with get_current_device_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #278 Update googlebenchmark version to match rmm & cudf.
+- PR #287 Replace RMM get_default_resource with get_current_device_resource.
 
 ## Bug Fixes
 

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -23,11 +23,12 @@ requirements:
     - cython >=0.29,<0.30
     - setuptools
     - cudf {{ minor_version }}.*
+    - rmm {{ minor_version }}.*
     - libcuspatial {{ version }}.*
-
   run:
     - python
     - cudf {{ minor_version }}.*
+    - rmm {{ minor_version }}.*
     - gdal >=3.0.2,<3.1.0a0
 
 test:

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - cmake >=3.12.4
   host:
     - libcudf {{ minor_version }}.*
+    - librmm {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
     - gdal >=3.0.2,<3.1.0a0
   run:

--- a/cpp/include/cuspatial/coordinate_transform.hpp
+++ b/cpp/include/cuspatial/coordinate_transform.hpp
@@ -37,6 +37,6 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::column>> lonlat_t
   double origin_lat,
   cudf::column_view const& input_lon,
   cudf::column_view const& input_lat,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/hausdorff.hpp
+++ b/cpp/include/cuspatial/hausdorff.hpp
@@ -83,6 +83,6 @@ std::unique_ptr<cudf::column> directed_hausdorff_distance(
   cudf::column_view const& xs,
   cudf::column_view const& ys,
   cudf::column_view const& points_per_space,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/haversine.hpp
+++ b/cpp/include/cuspatial/haversine.hpp
@@ -43,6 +43,6 @@ std::unique_ptr<cudf::column> haversine_distance(
   cudf::column_view const& b_lon,
   cudf::column_view const& b_lat,
   double const radius                 = EARTH_RADIUS_KM,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/point_in_polygon.hpp
+++ b/cpp/include/cuspatial/point_in_polygon.hpp
@@ -65,6 +65,6 @@ std::unique_ptr<cudf::column> point_in_polygon(
   cudf::column_view const& poly_ring_offsets,
   cudf::column_view const& poly_points_x,
   cudf::column_view const& poly_points_y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/point_quadtree.hpp
+++ b/cpp/include/cuspatial/point_quadtree.hpp
@@ -71,6 +71,6 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   double scale,
   int8_t max_depth,
   cudf::size_type min_size,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/polygon_bounding_box.hpp
+++ b/cpp/include/cuspatial/polygon_bounding_box.hpp
@@ -42,6 +42,6 @@ std::unique_ptr<cudf::table> polygon_bounding_boxes(
   cudf::column_view const& ring_offsets,
   cudf::column_view const& x,
   cudf::column_view const& y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/polyline_bounding_box.hpp
+++ b/cpp/include/cuspatial/polyline_bounding_box.hpp
@@ -42,6 +42,6 @@ std::unique_ptr<cudf::table> polyline_bounding_boxes(
   cudf::column_view const& x,
   cudf::column_view const& y,
   double expansion_radius,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/shapefile_reader.hpp
+++ b/cpp/include/cuspatial/shapefile_reader.hpp
@@ -38,6 +38,6 @@ namespace cuspatial {
  **/
 std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
   std::string const& filename,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -59,7 +59,7 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(
   double y_max,
   double scale,
   int8_t max_depth,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Test whether the specified points are inside any of the specified polygons.
@@ -109,7 +109,7 @@ std::unique_ptr<cudf::table> quadtree_point_in_polygon(
   cudf::column_view const& ring_offsets,
   cudf::column_view const& poly_points_x,
   cudf::column_view const& poly_points_y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Finds the nearest polyline to each point in a quadrant, and computes the distances between
@@ -157,6 +157,6 @@ std::unique_ptr<cudf::table> quadtree_point_to_nearest_polyline(
   cudf::column_view const& poly_offsets,
   cudf::column_view const& poly_points_x,
   cudf::column_view const& poly_points_y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/spatial_window.hpp
+++ b/cpp/include/cuspatial/spatial_window.hpp
@@ -48,6 +48,6 @@ std::unique_ptr<cudf::table> points_in_spatial_window(
   double window_max_y,
   cudf::column_view const& x,
   cudf::column_view const& y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/trajectory.hpp
+++ b/cpp/include/cuspatial/trajectory.hpp
@@ -52,7 +52,7 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> derive_tr
   cudf::column_view const& x,
   cudf::column_view const& y,
   cudf::column_view const& timestamp,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Compute the distance and speed of objects in a trajectory. Groups the
@@ -85,7 +85,7 @@ std::unique_ptr<cudf::table> trajectory_distances_and_speeds(
   cudf::column_view const& x,
   cudf::column_view const& y,
   cudf::column_view const& timestamp,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Compute the spatial bounding boxes of trajectories. Groups the x, y,
@@ -117,6 +117,6 @@ std::unique_ptr<cudf::table> trajectory_bounding_boxes(
   cudf::column_view const& object_id,
   cudf::column_view const& x,
   cudf::column_view const& y,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource());
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/src/indexing/construction/detail/utilities.cuh
+++ b/cpp/src/indexing/construction/detail/utilities.cuh
@@ -54,7 +54,7 @@ template <typename T>
 inline std::unique_ptr<cudf::column> make_fixed_width_column(
   cudf::size_type size,
   cudaStream_t stream                 = 0,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_to_id<T>()}, size, cudf::mask_state::UNALLOCATED, stream, mr);

--- a/cpp/src/interpolate/cubic_spline.cu
+++ b/cpp/src/interpolate/cubic_spline.cu
@@ -504,7 +504,7 @@ std::unique_ptr<cudf::column> cubicspline_interpolate(cudf::column_view const& q
                                                     prefixes,
                                                     source_points,
                                                     coefficients,
-                                                    rmm::mr::get_default_resource(),
+                                                    rmm::mr::get_current_device_resource(),
                                                     0);
 }
 
@@ -515,7 +515,7 @@ std::unique_ptr<cudf::table> cubicspline_coefficients(cudf::column_view const& t
                                                       cudf::column_view const& prefixes)
 {
   return cuspatial::detail::cubicspline_coefficients(
-    t, y, ids, prefixes, rmm::mr::get_default_resource(), 0);
+    t, y, ids, prefixes, rmm::mr::get_current_device_resource(), 0);
 }
 
 }  // namespace cuspatial

--- a/cpp/tests/trajectory/trajectory_utilities.cuh
+++ b/cpp/tests/trajectory/trajectory_utilities.cuh
@@ -28,7 +28,8 @@ namespace test {
 
 template <typename T>
 std::unique_ptr<cudf::table> make_test_trajectories_table(
-  cudf::size_type size, rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+  cudf::size_type size,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   std::vector<int32_t> ids(size);
   std::vector<int32_t> map(size);


### PR DESCRIPTION
Fixes compile errors using the latest RMM on branch-0.16. Similar to https://github.com/rapidsai/cudf/pull/6121.