### PR TITLE
[REVIEW] Fix CMake warnings in external projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 - PR #278 Update googlebenchmark version to match rmm & cudf.
+- PR #289 Fix cmake warnings for GoogleTest amd GoogleBenchmark external projects
 
 ## Bug Fixes
 

--- a/cpp/cmake/Modules/ConfigureGoogleBenchmark.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleBenchmark.cmake
@@ -14,7 +14,7 @@ elseif(CMAKE_CXX11_ABI)
     list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
 endif(NOT CMAKE_CXX11_ABI)
 
-configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake"
                "${GBENCH_ROOT}/CMakeLists.txt")
 
 file(MAKE_DIRECTORY "${GBENCH_ROOT}/build")
@@ -56,4 +56,3 @@ message(STATUS "Google Benchmark installed here: " ${GBENCH_ROOT}/install)
 set(GBENCH_INCLUDE_DIR "${GBENCH_ROOT}/install/include")
 set(GBENCH_LIBRARY_DIR "${GBENCH_ROOT}/install/lib" "${GBENCH_ROOT}/install/lib64")
 set(GBENCH_FOUND TRUE)
-

--- a/cpp/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cpp/cmake/Modules/ConfigureGoogleTest.cmake
@@ -14,7 +14,7 @@ elseif(CMAKE_CXX11_ABI)
     list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
 endif(NOT CMAKE_CXX11_ABI)
 
-configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
                "${GTEST_ROOT}/CMakeLists.txt")
 
 file(MAKE_DIRECTORY "${GTEST_ROOT}/build")
@@ -56,4 +56,3 @@ message(STATUS "GoogleTest installed here: " ${GTEST_ROOT}/install)
 set(GTEST_INCLUDE_DIR "${GTEST_ROOT}/install/include")
 set(GTEST_LIBRARY_DIR "${GTEST_ROOT}/install/lib")
 set(GTEST_FOUND TRUE)
-

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
+project(cuspatial-GoogleBenchmark)
 
 include(ExternalProject)
 
@@ -10,10 +11,3 @@ ExternalProject_Add(GoogleBenchmark
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"
                     CMAKE_ARGS        ${GBENCH_CMAKE_ARGS} -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${GBENCH_ROOT}/install)
                     # The flag BENCHMARK_ENABLE_TESTING=OFF prevents Google Benchmark from asking for Google Test.
-
-
-
-
-
-
-

--- a/cpp/cmake/Templates/GoogleTest.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleTest.CMakeLists.txt.cmake
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
+project(cuspatial-GoogleTest)
 
 include(ExternalProject)
 
@@ -9,11 +10,3 @@ ExternalProject_Add(GoogleTest
                     BINARY_DIR        "${GTEST_ROOT}/build"
                     INSTALL_DIR		  "${GTEST_ROOT}/install"
                     CMAKE_ARGS        ${GTEST_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${GTEST_ROOT}/install)
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR adds project names to cuDF's external project templates to squash cmake warnings they currently create. This is along the lines of rapidsai/rmm#541

It also changes CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR in case this library is build from another project using add_subdirectory (admittedly rare, but that was the motivation for rapidsai/rmm#541).