### PR TITLE
[REVIEW] Fix mislabeled columns in Python spatial join result table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ## Improvements
 - PR #278 Update googlebenchmark version to match rmm & cudf.
-- PR #286 Upgrade Thrust to latest commit
+- PR #286 Upgrade Thrust to latest commit.
 - PR #287 Replace RMM get_default_resource with get_current_device_resource.
-- PR #289 Fix cmake warnings for GoogleTest amd GoogleBenchmark external projects
+- PR #289 Fix cmake warnings for GoogleTest amd GoogleBenchmark external projects.
 
 ## Bug Fixes
+- PR #291 Fix mislabeled columns in Python spatial join result table.
 
 # cuSpatial 0.15.0 (26 Aug 2020)
 

--- a/python/cuspatial/cuspatial/_lib/move.pxd
+++ b/python/cuspatial/cuspatial/_lib/move.pxd
@@ -26,12 +26,6 @@ from cudf._lib.move cimport *
 # (copying a unique_ptr).
 #
 cdef extern from "<utility>" namespace "std" nogil:
-    cdef pair[unique_ptr[column], unique_ptr[column]] move(
-        pair[unique_ptr[column], unique_ptr[column]]
-    )
-    cdef pair[unique_ptr[table], unique_ptr[column]] move(
-        pair[unique_ptr[table], unique_ptr[column]]
-    )
     cdef pair[unique_ptr[column], unique_ptr[table]] move(
         pair[unique_ptr[column], unique_ptr[table]]
     )

--- a/python/cuspatial/cuspatial/_lib/spatial_join.pyx
+++ b/python/cuspatial/cuspatial/_lib/spatial_join.pyx
@@ -72,7 +72,7 @@ cpdef quadtree_point_in_polygon(Table poly_quad_pairs,
         ))
     return Table.from_unique_ptr(
         move(result),
-        column_names=["point_index", "polygon_index"]
+        column_names=["polygon_index", "point_index"]
     )
 
 

--- a/python/cuspatial/cuspatial/core/spatial_join.py
+++ b/python/cuspatial/cuspatial/core/spatial_join.py
@@ -126,10 +126,10 @@ def quadtree_point_in_polygon(
     result : cudf.DataFrame
         Indices for each intersecting point and polygon pair.
 
-        point_offset : cudf.Series
-            Indices of each point that intersects with a polygon.
-        polygon_offset : cudf.Series
+        polygon_index : cudf.Series
             Indices of each polygon with which a point intersected.
+        point_index : cudf.Series
+            Indices of each point that intersects with a polygon.
     """
 
     (
@@ -201,9 +201,9 @@ def quadtree_point_to_nearest_polyline(
         Indices for each point and its nearest polyline, and the distance
         between the two.
 
-        point_offset : cudf.Series
+        point_index : cudf.Series
             Indices of each point that intersects with a polyline.
-        polyline_offset : cudf.Series
+        polyline_index : cudf.Series
             Indices of each polyline with which a point intersected.
         distance : cudf.Series
             Distances between each point and its nearest polyline.

--- a/python/cuspatial/cuspatial/tests/test_spatial_join.py
+++ b/python/cuspatial/cuspatial/tests/test_spatial_join.py
@@ -407,7 +407,7 @@ def test_quadtree_point_in_polygon_small(dtype):
     intersections = cuspatial.join_quadtree_and_bounding_boxes(
         quadtree, poly_bboxes, x_min, x_max, y_min, y_max, scale, max_depth,
     )
-    points_and_polygons = cuspatial.quadtree_point_in_polygon(
+    polygons_and_points = cuspatial.quadtree_point_in_polygon(
         intersections,
         quadtree,
         point_indices,
@@ -419,14 +419,14 @@ def test_quadtree_point_in_polygon_small(dtype):
         poly_points_y,
     )
     assert_eq(
-        points_and_polygons,
+        polygons_and_points,
         cudf.DataFrame(
             {
-                "point_index": cudf.Series(
+                "polygon_index": cudf.Series(
                     [0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3],
                     dtype=np.uint32,
                 ),
-                "polygon_index": cudf.Series(
+                "point_index": cudf.Series(
                     [
                         62,
                         60,


### PR DESCRIPTION
* Fixes a cython compilation error from cuDF adding more `move()` overloads
* Fixes mislabeled column names in `quadtree_point_in_polygon`

Closes #284