### PR TITLE
Fix include of removed RMM header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Bug Fixes
 - PR #291 Fix mislabeled columns in Python spatial join result table.
+- PR #294 Fix include of deprecated RMM header file
+
 
 # cuSpatial 0.15.0 (26 Aug 2020)
 

--- a/cpp/include/cuspatial/trajectory.hpp
+++ b/cpp/include/cuspatial/trajectory.hpp
@@ -18,7 +18,7 @@
 
 #include <cudf/types.hpp>
 #include <memory>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace cuspatial {
 


### PR DESCRIPTION
Updates a `#include <rmm/mr/device/default_memory_resource.hpp>` to include `per_device_resource.hpp` instead, as the former is being removed.
