### PR TITLE
[REVIEW] Updates for RMM being header only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Bug Fixes
 - PR #291 Fix mislabeled columns in Python spatial join result table.
 - PR #294 Fix include of deprecated RMM header file
+- PR #296 Updates for RMM being header only
 
 
 # cuSpatial 0.15.0 (26 Aug 2020)
@@ -108,7 +109,7 @@
 
 ## New Features
 
-- PR #126 Create and build cuSpatial Docs 
+- PR #126 Create and build cuSpatial Docs
 - PR #130 Add cubic spline fit and interpolation
 
 ## Improvements

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,15 +53,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     # Suppress parentheses warning which causes gmock to fail
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-parentheses")
 
-    option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
-    if(CMAKE_CXX11_ABI)
-        message(STATUS "CUSPATIAL: Enabling the GLIBCXX11 ABI")
-    else()
-        message(STATUS "CUSPATIAL: Disabling the GLIBCXX11 ABI")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -D_GLIBCXX_USE_CXX11_ABI=0")
-    endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(CMAKE_CUDA_COMPILER_VERSION)
@@ -183,17 +174,8 @@ endif("$ENV{CONDA_BUILD}" STREQUAL "1")
 find_path(RMM_INCLUDE "rmm"
           HINTS "$ENV{RMM_ROOT}/include")
 
-find_library(RMM_LIBRARY "rmm"
-             HINTS "$ENV{RMM_ROOT}/lib")
-
 message(STATUS "RMM: RMM_ROOT set to $ENV{RMM_ROOT}")
-message(STATUS "RMM: RMM_LIBRARY set to ${RMM_LIBRARY}")
 message(STATUS "RMM: RMM_INCLUDE set to ${RMM_INCLUDE}")
-
-add_library(rmm SHARED IMPORTED ${RMM_LIBRARY})
-if (RMM_INCLUDE AND RMM_LIBRARY)
-    set_target_properties(rmm PROPERTIES IMPORTED_LOCATION ${RMM_LIBRARY})
-endif (RMM_INCLUDE AND RMM_LIBRARY)
 
 # - CUDF -------------------------------------------------------------------------------------------
 
@@ -338,7 +320,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(cuspatial cudf rmm cudart cuda cusparse nvrtc GDAL::GDAL)
+target_link_libraries(cuspatial cudf cudart cuda cusparse nvrtc GDAL::GDAL)
 
 
 ###################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -273,7 +273,6 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT
                  "${FLATBUFFERS_LIBRARY_DIR}"
                  "${GDAL_LIBRARIES}"
                  "${GTEST_LIBRARY_DIR}"
-                 "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}")
 
 if(CONDA_LINK_DIRS)

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -29,7 +29,7 @@ function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
                    "${CMAKE_CURRENT_SOURCE_DIR}/synchronization/synchronization.cpp")
     set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${CMAKE_BENCH_NAME} benchmark benchmark_main pthread cuspatial cudf
-                          cudftestutil rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES}
+                          cudftestutil cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES}
                           nvrtc GDAL::GDAL)
     set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES
                             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gbenchmarks")
@@ -64,7 +64,6 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT
                  "${CONDA_LINK_DIRS}"
                  "${GTEST_LIBRARY_DIR}"
                  "${GBENCH_LIBRARY_DIR}"
-                 "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}"
                  "${CUSPATIAL_LIBRARY}")
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
                 ${CMAKE_TEST_SRC})
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cuspatial cudf
-                        cudftestutil rmm cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES}
+                        cudftestutil cudart cuda "${ARROW_LIB}" ${ZLIB_LIBRARIES}
                         nvrtc GDAL::GDAL)
     if(USE_NVTX)
         target_link_libraries(${CMAKE_TEST_NAME} ${NVTX_LIBRARY})
@@ -73,7 +73,7 @@ include_directories("${CMAKE_BINARY_DIR}/include"
                     "${RMM_INCLUDE}"
                     "${CUDF_INCLUDE}"
                     "${CUDF_TEST_INCLUDE}")
- 
+
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
 
@@ -82,7 +82,6 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT
                  "${GDAL_LIBRARIES}"
                  "${CONDA_LINK_DIRS}"
                  "${GTEST_LIBRARY_DIR}"
-                 "${RMM_LIBRARY}"
                  "${CUDF_LIBRARY}"
                  "${CUSPATIAL_LIBRARY}")
 


### PR DESCRIPTION
Fix for RMM being header only, also removes cmake option `CMAKE_CXX11_ABI` following other RAPIDS repos.