### PR TITLE
[REVIEW] Pin cmake policies to cmake 3.17 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #XXX Pin cmake policies to cmake 3.17 version
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## New Features
 
 ## Improvements
-- PR #XXX Pin cmake policies to cmake 3.17 version
+- PR #310 Pin cmake policies to cmake 3.17 version
 
 ## Bug Fixes
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+cmake_minimum_required(VERSION 3.12...3.17 FATAL_ERROR)
 
 project(CUDA_SPATIAL VERSION 0.17.0 LANGUAGES C CXX CUDA)
 

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -1,6 +1,18 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-
-project(CUSPATIAL_BENCHMARKS LANGUAGES C CXX CUDA)
+#=============================================================================
+# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
 
 if(NOT CMAKE_CUDA_COMPILER)
   message(SEND_ERROR "CMake cannot locate a CUDA compiler")

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-
-project(CUSPATIAL_TESTS LANGUAGES C CXX CUDA)
 
 if(NOT CMAKE_CUDA_COMPILER)
   message(SEND_ERROR "CMake cannot locate a CUDA compiler")


### PR DESCRIPTION
Planning to upgrade to cmake 3.18 in the near future and the CUDA_ARCHITECTURES change is a breaking change, so pinning to 3.17 policies to prevent the breakages.