### PR TITLE
Convert cudaStream_t to rmm::cuda_stream_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## Improvements
 - PR #310 Pin cmake policies to cmake 3.17 version
+- PR #325 Convert `cudaStream_t` to `rmm::cuda_stream_view`
 
 ## Bug Fixes
-- PR #320 Fix a quadtree construction bug - needs zero out device_uvector before scatter
+- PR #320 Fix quadtree construction bug: zero out `device_uvector` before `scatter`
 
 # cuSpatial 0.16.0 (Date TBD)
 

--- a/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/cpp/benchmarks/synchronization/synchronization.cpp
@@ -16,47 +16,45 @@
 
 #include "synchronization.hpp"
 
-#include <rmm/device_buffer.hpp>
+#include <cudf/utilities/error.hpp>
 
-#define RMM_CUDA_ASSERT_OK(expr)       \
-  do {                                 \
-    cudaError_t const status = (expr); \
-    assert(cudaSuccess == status);     \
-  } while (0);
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
 
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
-                                   cudaStream_t stream)
+                                   rmm::cuda_stream_view stream)
   : p_state(&state), stream(stream)
 {
   // flush all of L2$
   if (flush_l2_cache) {
     int current_device = 0;
-    RMM_CUDA_TRY(cudaGetDevice(&current_device));
+    CUDA_TRY(cudaGetDevice(&current_device));
 
     int l2_cache_bytes = 0;
-    RMM_CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
+    CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
 
     if (l2_cache_bytes > 0) {
       const int memset_value = 0;
       rmm::device_buffer l2_cache_buffer(l2_cache_bytes, stream);
-      RMM_CUDA_TRY(cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream));
+      CUDA_TRY(
+        cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream.value()));
     }
   }
 
-  RMM_CUDA_TRY(cudaEventCreate(&start));
-  RMM_CUDA_TRY(cudaEventCreate(&stop));
-  RMM_CUDA_TRY(cudaEventRecord(start, stream));
+  CUDA_TRY(cudaEventCreate(&start));
+  CUDA_TRY(cudaEventCreate(&stop));
+  CUDA_TRY(cudaEventRecord(start, stream.value()));
 }
 
 cuda_event_timer::~cuda_event_timer()
 {
-  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream));
-  RMM_CUDA_ASSERT_OK(cudaEventSynchronize(stop));
+  CUDA_TRY(cudaEventRecord(stop, stream.value()));
+  CUDA_TRY(cudaEventSynchronize(stop));
 
   float milliseconds = 0.0f;
-  RMM_CUDA_ASSERT_OK(cudaEventElapsedTime(&milliseconds, start, stop));
+  CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
   p_state->SetIterationTime(milliseconds / (1000.0f));
-  RMM_CUDA_ASSERT_OK(cudaEventDestroy(start));
-  RMM_CUDA_ASSERT_OK(cudaEventDestroy(stop));
+  CUDA_TRY(cudaEventDestroy(start));
+  CUDA_TRY(cudaEventDestroy(stop));
 }

--- a/cpp/include/cuspatial/cubic_spline.hpp
+++ b/cpp/include/cuspatial/cubic_spline.hpp
@@ -18,8 +18,9 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
 #include <memory>
-#include "cudf/types.hpp"
 
 namespace cuspatial {
 

--- a/cpp/include/cuspatial/cubic_spline.hpp
+++ b/cpp/include/cuspatial/cubic_spline.hpp
@@ -19,6 +19,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 #include <memory>
+#include "cudf/types.hpp"
 
 namespace cuspatial {
 
@@ -43,16 +44,19 @@ namespace cuspatial {
  * @param[in] offsets the exclusive scan of the spline sizes, prefixed by
  * 0. For example, for 3 splines of 5 vertices each, the offsets input array
  * is {0, 5, 10, 15}.
+ * @param[in] mr The memory resource to use for allocating output
  *
  * @return cudf::table_view of coefficients for spline interpolation. The size
  * of the table is ((M-n), 4) where M is `t.size()` and and n is
  * `ids.size()-1`.
  **/
-std::unique_ptr<cudf::column> cubicspline_interpolate(cudf::column_view const& query_points,
-                                                      cudf::column_view const& spline_ids,
-                                                      cudf::column_view const& offsets,
-                                                      cudf::column_view const& source_points,
-                                                      cudf::table_view const& coefficients);
+std::unique_ptr<cudf::column> cubicspline_interpolate(
+  cudf::column_view const& query_points,
+  cudf::column_view const& spline_ids,
+  cudf::column_view const& offsets,
+  cudf::column_view const& source_points,
+  cudf::table_view const& coefficients,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Compute cubic interpolations of a set of points based on their
@@ -69,11 +73,14 @@ std::unique_ptr<cudf::column> cubicspline_interpolate(cudf::column_view const& q
  * identify which specific spline a given query_point is interpolated with.
  * @param[in] coefficients table of spline coefficients produced by
  * cubicspline_coefficients.
+ * @param[in] mr The memory resource to use for allocating output
  *
  * @return cudf::column `y` coordinates interpolated from `x` and `coefs`.
  **/
-std::unique_ptr<cudf::table> cubicspline_coefficients(cudf::column_view const& t,
-                                                      cudf::column_view const& y,
-                                                      cudf::column_view const& ids,
-                                                      cudf::column_view const& offsets);
+std::unique_ptr<cudf::table> cubicspline_coefficients(
+  cudf::column_view const& t,
+  cudf::column_view const& y,
+  cudf::column_view const& ids,
+  cudf::column_view const& offsets,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 }  // namespace cuspatial

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -24,6 +24,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/functional.h>
@@ -57,11 +58,11 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
                                       T y_max,
                                       T scale,
                                       int8_t max_depth,
-                                      rmm::mr::device_memory_resource *mr,
-                                      cudaStream_t stream)
+                                      rmm::cuda_stream_view stream,
+                                      rmm::mr::device_memory_resource *mr)
 {
   rmm::device_uvector<uint32_t> keys(x.size(), stream);
-  thrust::transform(rmm::exec_policy(stream)->on(stream),
+  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()) + x.size(),
                     keys.begin(),
@@ -77,12 +78,12 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
 
   auto indices = make_fixed_width_column<uint32_t>(keys.size(), stream, mr);
 
-  thrust::sequence(rmm::exec_policy(stream)->on(stream),
+  thrust::sequence(rmm::exec_policy(stream)->on(stream.value()),
                    indices->mutable_view().begin<uint32_t>(),
                    indices->mutable_view().end<uint32_t>());
 
   // Sort the codes and point indices
-  thrust::stable_sort_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::stable_sort_by_key(rmm::exec_policy(stream)->on(stream.value()),
                              keys.begin(),
                              keys.end(),
                              indices->mutable_view().begin<int32_t>());
@@ -106,9 +107,9 @@ inline cudf::size_type build_tree_level(InputIterator1 keys_begin,
                                         OutputIterator1 keys_out,
                                         OutputIterator2 vals_out,
                                         BinaryOp binary_op,
-                                        cudaStream_t stream)
+                                        rmm::cuda_stream_view stream)
 {
-  auto result = thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
+  auto result = thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
                                       keys_begin,
                                       keys_end,
                                       vals_in,
@@ -133,7 +134,7 @@ build_tree_levels(int8_t max_depth,
                   KeysIterator keys_begin,
                   ValsIterator quad_point_count_begin,
                   ValsIterator quad_child_count_begin,
-                  cudaStream_t stream)
+                  rmm::cuda_stream_view stream)
 {
   // begin/end offsets
   cudf::size_type begin{0};
@@ -193,7 +194,7 @@ reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
                     std::vector<cudf::size_type> const &begin_pos,
                     std::vector<cudf::size_type> const &end_pos,
                     int8_t max_depth,
-                    cudaStream_t stream)
+                    rmm::cuda_stream_view stream)
 {
   rmm::device_uvector<uint32_t> quad_keys(quad_keys_in.size(), stream);
   rmm::device_uvector<uint8_t> quad_levels(quad_keys_in.size(), stream);
@@ -205,19 +206,19 @@ reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
     cudf::size_type level_end   = end_pos[level];
     cudf::size_type level_begin = begin_pos[level];
     cudf::size_type num_quads   = level_end - level_begin;
-    thrust::fill(rmm::exec_policy(stream)->on(stream),
+    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
                  quad_levels.begin() + offset,
                  quad_levels.begin() + offset + num_quads,
                  level);
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                  quad_keys_in.begin() + level_begin,
                  quad_keys_in.begin() + level_end,
                  quad_keys.begin() + offset);
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                  quad_point_count_in.begin() + level_begin,
                  quad_point_count_in.begin() + level_end,
                  quad_point_count.begin() + offset);
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                  quad_child_count_in.begin() + level_begin,
                  quad_child_count_in.begin() + level_end,
                  quad_child_count.begin() + offset);
@@ -255,15 +256,15 @@ inline auto make_full_levels(cudf::column_view const &x,
                              T scale,
                              int8_t max_depth,
                              cudf::size_type min_size,
-                             rmm::mr::device_memory_resource *mr,
-                             cudaStream_t stream)
+                             rmm::cuda_stream_view stream,
+                             rmm::mr::device_memory_resource *mr)
 {
   // Compute point keys and sort into bottom-level quadrants
   // (i.e. quads at level `max_depth - 1`)
 
   // Compute Morton code (z-order) keys for each point
   auto keys_and_indices = compute_point_keys_and_sorted_indices<T>(
-    x, y, x_min, x_max, y_min, y_max, scale, max_depth, mr, stream);
+    x, y, x_min, x_max, y_min, y_max, scale, max_depth, stream, mr);
 
   auto &point_keys    = keys_and_indices.first;
   auto &point_indices = keys_and_indices.second;
@@ -291,8 +292,10 @@ inline auto make_full_levels(cudf::column_view const &x,
   quad_child_count.resize(num_bottom_quads * (max_depth + 1), stream);
 
   // Zero out the quad_child_count vector because we're reusing the point_keys vector
-  thrust::fill(
-    rmm::exec_policy(stream)->on(stream), quad_child_count.begin(), quad_child_count.end(), 0);
+  thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
+               quad_child_count.begin(),
+               quad_child_count.end(),
+               0);
 
   //
   // Compute "full" quads for the tree at each level. Starting from the quadrant

--- a/cpp/src/indexing/construction/detail/utilities.cuh
+++ b/cpp/src/indexing/construction/detail/utilities.cuh
@@ -19,9 +19,9 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-#include "rmm/cuda_stream_view.hpp"
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>

--- a/cpp/src/indexing/construction/detail/utilities.cuh
+++ b/cpp/src/indexing/construction/detail/utilities.cuh
@@ -19,6 +19,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
+#include "rmm/cuda_stream_view.hpp"
 
 #include <rmm/thrust_rmm_allocator.h>
 
@@ -53,7 +54,7 @@ struct tuple_sum {
 template <typename T>
 inline std::unique_ptr<cudf::column> make_fixed_width_column(
   cudf::size_type size,
-  cudaStream_t stream                 = 0,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   return cudf::make_fixed_width_column(

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -23,6 +23,7 @@
 
 #include <cudf/table/table.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 /*
@@ -49,11 +50,11 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
                                                    int8_t max_depth,
                                                    cudf::size_type min_size,
                                                    cudf::size_type level_1_size,
-                                                   rmm::mr::device_memory_resource *mr,
-                                                   cudaStream_t stream)
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::mr::device_memory_resource *mr)
 {
   // count the number of child nodes
-  auto num_child_nodes = thrust::reduce(rmm::exec_policy(stream)->on(stream),
+  auto num_child_nodes = thrust::reduce(rmm::exec_policy(stream)->on(stream.value()),
                                         quad_child_count.begin(),
                                         quad_child_count.begin() + num_parent_nodes);
 
@@ -90,7 +91,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
 
     auto quad_child_pos = make_fixed_width_column<uint32_t>(num_valid_nodes, stream, mr);
     // line 9 of algorithm in Fig. 5 in ref.
-    thrust::replace_if(rmm::exec_policy(stream)->on(stream),
+    thrust::replace_if(rmm::exec_policy(stream)->on(stream.value()),
                        quad_child_count.begin(),
                        quad_child_count.begin() + num_valid_nodes,
                        is_quad->view().begin<uint8_t>(),
@@ -98,7 +99,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
                        0);
 
     // line 10 of algorithm in Fig. 5 in ref.
-    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream),
+    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                            quad_child_count.begin(),
                            quad_child_count.end(),
                            quad_child_pos->mutable_view().begin<uint32_t>(),
@@ -111,7 +112,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
 
     // for each value in `is_quad` copy from `quad_child_pos` if true, else
     // `quad_point_pos`
-    thrust::transform(rmm::exec_policy(stream)->on(stream),
+    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
                       offsets_iter,
                       offsets_iter + num_valid_nodes,
                       offsets->mutable_view().template begin<uint32_t>(),
@@ -130,7 +131,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
   auto lengths_iter = make_zip_iterator(is_quad->view().begin<bool>(),  //
                                         quad_child_count.begin(),
                                         quad_point_count.begin());
-  thrust::transform(rmm::exec_policy(stream)->on(stream),
+  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
                     lengths_iter,
                     lengths_iter + num_valid_nodes,
                     lengths->mutable_view().template begin<uint32_t>(),
@@ -143,7 +144,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
   auto keys = make_fixed_width_column<uint32_t>(num_valid_nodes, stream, mr);
 
   // Copy quad keys to keys output column
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                quad_keys.begin(),
                quad_keys.end(),
                keys->mutable_view().begin<uint32_t>());
@@ -152,7 +153,7 @@ inline std::unique_ptr<cudf::table> make_quad_tree(rmm::device_uvector<uint32_t>
   auto levels = make_fixed_width_column<uint8_t>(num_valid_nodes, stream, mr);
 
   // Copy quad levels to levels output column
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                quad_levels.begin(),
                quad_levels.end(),
                levels->mutable_view().begin<uint8_t>());
@@ -174,8 +175,8 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
   rmm::device_uvector<uint32_t> const &quad_keys,
   rmm::device_uvector<uint32_t> const &quad_point_count,
   cudf::size_type num_top_quads,
-  rmm::mr::device_memory_resource *mr,
-  cudaStream_t stream)
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr)
 {
   auto keys    = make_fixed_width_column<uint32_t>(num_top_quads, stream, mr);
   auto levels  = make_fixed_width_column<uint8_t>(num_top_quads, stream, mr);
@@ -184,31 +185,31 @@ inline std::unique_ptr<cudf::table> make_leaf_tree(
   auto offsets = make_fixed_width_column<uint32_t>(num_top_quads, stream, mr);
 
   // copy quad keys from the front of the quad_keys list
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                quad_keys.begin(),
                quad_keys.begin() + num_top_quads,
                keys->mutable_view().begin<uint32_t>());
 
   // copy point counts from the front of the quad_point_count list
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                quad_point_count.begin(),
                quad_point_count.begin() + num_top_quads,
                lengths->mutable_view().begin<uint32_t>());
 
   // All leaves are children of the root node (level 0)
-  thrust::fill(rmm::exec_policy(stream)->on(stream),
+  thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
                levels->mutable_view().begin<uint8_t>(),
                levels->mutable_view().end<uint8_t>(),
                0);
 
   // Quad node indicators are false for leaf nodes
-  thrust::fill(rmm::exec_policy(stream)->on(stream),
+  thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
                is_quad->mutable_view().begin<bool>(),
                is_quad->mutable_view().end<bool>(),
                false);
 
   // compute offsets from lengths
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream),
+  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                          lengths->view().begin<uint32_t>(),
                          lengths->view().end<uint32_t>(),
                          offsets->mutable_view().begin<uint32_t>());
@@ -252,8 +253,8 @@ struct dispatch_construct_quadtree {
     double scale,
     int8_t max_depth,
     cudf::size_type min_size,
-    rmm::mr::device_memory_resource *mr,
-    cudaStream_t stream)
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource *mr)
   {
     // Construct the full set of non-empty subquadrants starting from the lowest level.
     // Corresponds to "Phase 1" of quadtree construction in ref.
@@ -266,8 +267,8 @@ struct dispatch_construct_quadtree {
                                      scale,
                                      max_depth,
                                      min_size,
-                                     mr,
-                                     stream);
+                                     stream,
+                                     mr);
 
     auto &point_indices    = std::get<0>(quads);
     auto &quad_keys        = std::get<1>(quads);
@@ -281,7 +282,7 @@ struct dispatch_construct_quadtree {
     // Optimization: return early if the top level nodes are all leaves
     if (num_parent_nodes <= 0) {
       return std::make_pair(std::move(point_indices),
-                            make_leaf_tree(quad_keys, quad_point_count, num_top_quads, mr, stream));
+                            make_leaf_tree(quad_keys, quad_point_count, num_top_quads, stream, mr));
     }
 
     // Corresponds to "Phase 2" of quadtree construction in ref.
@@ -294,8 +295,8 @@ struct dispatch_construct_quadtree {
                                          max_depth,
                                          min_size,
                                          level_1_size,
-                                         mr,
-                                         stream));
+                                         stream,
+                                         mr));
   }
 };
 
@@ -311,8 +312,8 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   double scale,
   int8_t max_depth,
   cudf::size_type min_size,
-  rmm::mr::device_memory_resource *mr,
-  cudaStream_t stream)
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr)
 {
   return cudf::type_dispatcher(x.type(),
                                dispatch_construct_quadtree{},
@@ -325,8 +326,8 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
                                scale,
                                max_depth,
                                min_size,
-                               mr,
-                               stream);
+                               stream,
+                               mr);
 }
 
 }  // namespace detail
@@ -362,7 +363,7 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
                           std::make_unique<cudf::table>(std::move(cols)));
   }
   return detail::quadtree_on_points(
-    x, y, x_min, x_max, y_min, y_max, scale, max_depth, min_size, mr, cudaStream_t{0});
+    x, y, x_min, x_max, y_min, y_max, scale, max_depth, min_size, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/join/detail/traversal.cuh
+++ b/cpp/src/join/detail/traversal.cuh
@@ -20,6 +20,7 @@
 #include "utility/z_order.cuh"
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/gather.h>
@@ -60,14 +61,14 @@ descend_quadtree(LengthsIter counts,
                  rmm::device_uvector<uint8_t> &parent_levels,
                  rmm::device_uvector<uint32_t> &parent_node_indices,
                  rmm::device_uvector<uint32_t> &parent_poly_indices,
-                 cudaStream_t stream)
+                 rmm::cuda_stream_view stream)
 {
   // Use the current parent node indices as the lookup into the global child counts
   auto parent_counts = thrust::make_permutation_iterator(counts, parent_node_indices.begin());
   // scan on the number of child nodes to compute the offsets
   // note: size is `num_quads + 1` so the last element is `num_children`
   rmm::device_uvector<uint32_t> parent_offsets(num_quads + 1, stream);
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream),
+  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                          parent_counts,
                          parent_counts + num_quads,
                          parent_offsets.begin() + 1);
@@ -79,9 +80,9 @@ descend_quadtree(LengthsIter counts,
   rmm::device_uvector<uint32_t> parent_indices(num_children, stream);
   // fill with zeroes
   thrust::fill(
-    rmm::exec_policy(stream)->on(stream), parent_indices.begin(), parent_indices.end(), 0);
+    rmm::exec_policy(stream)->on(stream.value()), parent_indices.begin(), parent_indices.end(), 0);
   // use the parent_offsets as the map to scatter sequential parent_indices
-  thrust::scatter(rmm::exec_policy(stream)->on(stream),
+  thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
                   thrust::make_counting_iterator(0),
                   thrust::make_counting_iterator(0) + num_quads,
                   parent_offsets.begin(),
@@ -89,7 +90,7 @@ descend_quadtree(LengthsIter counts,
 
   // inclusive scan with maximum functor to fill the empty elements with their left-most non-empty
   // elements. `parent_indices` is now a full array of the sequence index of each quadrant's parent
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream),
+  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                          parent_indices.begin(),
                          parent_indices.begin() + num_children,
                          parent_indices.begin(),
@@ -102,7 +103,7 @@ descend_quadtree(LengthsIter counts,
   rmm::device_uvector<uint32_t> child_poly_indices(num_children, stream);
 
   // `parent_indices` is a gather map to retrieve non-leaf quads' respective child nodes
-  thrust::gather(rmm::exec_policy(stream)->on(stream),
+  thrust::gather(rmm::exec_policy(stream)->on(stream.value()),
                  parent_indices.begin(),
                  parent_indices.begin() + num_children,
                  // curr level iterator
@@ -117,7 +118,7 @@ descend_quadtree(LengthsIter counts,
                                    child_poly_indices.begin()));
 
   rmm::device_uvector<uint32_t> relative_child_offsets(num_children, stream);
-  thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream.value()),
                                 parent_indices.begin(),
                                 parent_indices.begin() + num_children,
                                 thrust::constant_iterator<uint32_t>(1),
@@ -125,7 +126,7 @@ descend_quadtree(LengthsIter counts,
 
   // compute child quad indices using parent and relative child offsets
   auto child_offsets_iter = thrust::make_permutation_iterator(offsets, child_quad_indices.begin());
-  thrust::transform(rmm::exec_policy(stream)->on(stream),
+  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
                     child_offsets_iter,
                     child_offsets_iter + num_children,
                     relative_child_offsets.begin(),

--- a/cpp/src/join/quadtree_point_to_nearest_polyline.cu
+++ b/cpp/src/join/quadtree_point_to_nearest_polyline.cu
@@ -26,6 +26,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/gather.h>
@@ -140,8 +141,8 @@ struct compute_quadtree_point_to_nearest_polyline {
     cudf::column_view const &poly_offsets,
     cudf::column_view const &poly_points_x,
     cudf::column_view const &poly_points_y,
-    rmm::mr::device_memory_resource *mr,
-    cudaStream_t stream)
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource *mr)
   {
     auto poly_idx            = poly_quad_pairs.column(0);
     auto quad_idx            = poly_quad_pairs.column(1);
@@ -151,20 +152,20 @@ struct compute_quadtree_point_to_nearest_polyline {
 
     rmm::device_uvector<uint32_t> d_poly_idx(num_pairs, stream);
 
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                  poly_idx.begin<uint32_t>(),
                  poly_idx.end<uint32_t>(),
                  d_poly_idx.begin());
 
     rmm::device_uvector<uint32_t> d_quad_idx(num_pairs, stream);
 
-    thrust::copy(rmm::exec_policy(stream)->on(stream),
+    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                  quad_idx.begin<uint32_t>(),
                  quad_idx.end<uint32_t>(),
                  d_quad_idx.begin());
 
     // sort (d_poly_idx, d_quad_idx) using d_quad_idx as key => (quad_idxs, poly_idxs)
-    thrust::sort_by_key(rmm::exec_policy(stream)->on(stream),
+    thrust::sort_by_key(rmm::exec_policy(stream)->on(stream.value()),
                         d_quad_idx.begin(),
                         d_quad_idx.end(),
                         d_poly_idx.begin());
@@ -176,7 +177,7 @@ struct compute_quadtree_point_to_nearest_polyline {
 
     uint32_t num_quads =
       thrust::distance(d_poly_idx_offsets.begin(),
-                       thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
+                       thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
                                              d_quad_idx.begin(),
                                              d_quad_idx.end(),
                                              thrust::constant_iterator<uint32_t>(1),
@@ -187,7 +188,7 @@ struct compute_quadtree_point_to_nearest_polyline {
     d_quad_idx.resize(num_quads, stream);
     d_poly_idx_offsets.resize(num_quads, stream);
 
-    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream),
+    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                            d_poly_idx_offsets.begin(),
                            d_poly_idx_offsets.end(),
                            d_poly_idx_offsets.begin());
@@ -196,7 +197,7 @@ struct compute_quadtree_point_to_nearest_polyline {
     auto poly_index_col  = make_fixed_width_column<uint32_t>(point_x.size(), stream, mr);
     auto distance_col    = make_fixed_width_column<T>(point_x.size(), stream, mr);
 
-    find_nearest_polyline_kernel<T><<<num_quads, threads_per_block, 0, stream>>>(
+    find_nearest_polyline_kernel<T><<<num_quads, threads_per_block, 0, stream.value()>>>(
       d_quad_idx.begin(),
       d_poly_idx_offsets.size(),
       d_poly_idx_offsets.begin(),
@@ -234,8 +235,8 @@ std::unique_ptr<cudf::table> quadtree_point_to_nearest_polyline(
   cudf::column_view const &poly_offsets,
   cudf::column_view const &poly_points_x,
   cudf::column_view const &poly_points_y,
-  rmm::mr::device_memory_resource *mr,
-  cudaStream_t stream)
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource *mr)
 {
   return cudf::type_dispatcher(point_x.type(),
                                compute_quadtree_point_to_nearest_polyline{},
@@ -247,8 +248,8 @@ std::unique_ptr<cudf::table> quadtree_point_to_nearest_polyline(
                                poly_offsets,
                                poly_points_x,
                                poly_points_y,
-                               mr,
-                               stream);
+                               stream,
+                               mr);
 }
 
 }  // namespace detail
@@ -297,8 +298,8 @@ std::unique_ptr<cudf::table> quadtree_point_to_nearest_polyline(
                                                     poly_offsets,
                                                     poly_points_x,
                                                     poly_points_y,
-                                                    mr,
-                                                    cudaStream_t{0});
+                                                    rmm::cuda_stream_default,
+                                                    mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/join/quadtree_poly_filtering.cu
+++ b/cpp/src/join/quadtree_poly_filtering.cu
@@ -26,6 +26,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <tuple>
@@ -51,8 +52,8 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
                                                              T y_max,
                                                              T scale,
                                                              int8_t max_depth,
-                                                             rmm::mr::device_memory_resource *mr,
-                                                             cudaStream_t stream)
+                                                             rmm::cuda_stream_view stream,
+                                                             rmm::mr::device_memory_resource *mr)
 {
   auto const node_levels  = quadtree.column(1);  // uint8_t
   auto const node_counts  = quadtree.column(3);  // uint32_t
@@ -60,7 +61,7 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
 
   // Count the number of top-level nodes to start.
   // This could be provided explicitly, but count_if should be fast enough.
-  auto num_top_level_leaves = thrust::count_if(rmm::exec_policy(stream)->on(stream),
+  auto num_top_level_leaves = thrust::count_if(rmm::exec_policy(stream)->on(stream.value()),
                                                node_levels.begin<uint8_t>(),
                                                node_levels.end<uint8_t>(),
                                                thrust::placeholders::_1 == 0);
@@ -177,12 +178,12 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
   cols.push_back(make_fixed_width_column<uint32_t>(num_results, stream, mr));
   cols.push_back(make_fixed_width_column<uint32_t>(num_results, stream, mr));
 
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                out_poly_idxs.begin(),
                out_poly_idxs.begin() + num_results,
                cols.at(0)->mutable_view().begin<uint32_t>());
 
-  thrust::copy(rmm::exec_policy(stream)->on(stream),
+  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
                out_node_idxs.begin(),
                out_node_idxs.begin() + num_results,
                cols.at(1)->mutable_view().begin<uint32_t>());
@@ -200,8 +201,8 @@ struct dispatch_quadtree_bounding_box_join {
                                                  double y_max,
                                                  double scale,
                                                  int8_t max_depth,
-                                                 rmm::mr::device_memory_resource *mr,
-                                                 cudaStream_t stream)
+                                                 rmm::cuda_stream_view stream,
+                                                 rmm::mr::device_memory_resource *mr)
   {
     return join_quadtree_and_bboxes<T>(quadtree,
                                        poly_bbox,
@@ -211,8 +212,8 @@ struct dispatch_quadtree_bounding_box_join {
                                        static_cast<T>(y_max),
                                        static_cast<T>(scale),
                                        max_depth,
-                                       mr,
-                                       stream);
+                                       stream,
+                                       mr);
   }
   template <typename T,
             std::enable_if_t<!std::is_floating_point<T>::value> * = nullptr,
@@ -232,8 +233,8 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(cudf::table_view c
                                                               double y_max,
                                                               double scale,
                                                               int8_t max_depth,
-                                                              rmm::mr::device_memory_resource *mr,
-                                                              cudaStream_t stream)
+                                                              rmm::cuda_stream_view stream,
+                                                              rmm::mr::device_memory_resource *mr)
 {
   return cudf::type_dispatcher(poly_bbox.column(0).type(),
                                dispatch_quadtree_bounding_box_join{},
@@ -245,8 +246,8 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(cudf::table_view c
                                y_max,
                                scale,
                                max_depth,
-                               mr,
-                               stream);
+                               stream,
+                               mr);
 }
 
 }  // namespace detail
@@ -277,8 +278,16 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(cudf::table_view c
     return std::make_unique<cudf::table>(std::move(cols));
   }
 
-  return detail::join_quadtree_and_bounding_boxes(
-    quadtree, poly_bbox, x_min, x_max, y_min, y_max, scale, max_depth, mr, cudaStream_t{0});
+  return detail::join_quadtree_and_bounding_boxes(quadtree,
+                                                  poly_bbox,
+                                                  x_min,
+                                                  x_max,
+                                                  y_min,
+                                                  y_max,
+                                                  scale,
+                                                  max_depth,
+                                                  rmm::cuda_stream_default,
+                                                  mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/spatial/lonlat_to_cartesian.cu
+++ b/cpp/src/spatial/lonlat_to_cartesian.cu
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+#include <cuspatial/error.hpp>
+
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
-#include <cuspatial/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
 #include <type_traits>
 #include <utility>
 
@@ -55,8 +59,8 @@ struct lonlat_to_cartesian_functor {
     double origin_lat,
     cudf::column_view const& input_lon,
     cudf::column_view const& input_lat,
-    rmm::mr::device_memory_resource* mr,
-    cudaStream_t stream)
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr)
   {
     auto size = input_lon.size();
     auto tid  = cudf::type_to_id<T>();
@@ -81,7 +85,7 @@ struct lonlat_to_cartesian_functor {
                                lat_to_y(origin_lat - lat));
     };
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream),
+    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
                       input_zip,
                       input_zip + input_lon.size(),
                       output_zip,
@@ -100,8 +104,8 @@ pair_of_columns lonlat_to_cartesian(double origin_lon,
                                     double origin_lat,
                                     cudf::column_view const& input_lon,
                                     cudf::column_view const& input_lat,
-                                    rmm::mr::device_memory_resource* mr,
-                                    cudaStream_t stream)
+                                    rmm::cuda_stream_view stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   return cudf::type_dispatcher(input_lon.type(),
                                lonlat_to_cartesian_functor(),
@@ -109,8 +113,8 @@ pair_of_columns lonlat_to_cartesian(double origin_lon,
                                origin_lat,
                                input_lon,
                                input_lat,
-                               mr,
-                               stream);
+                               stream,
+                               mr);
 }
 
 }  // namespace detail
@@ -132,7 +136,8 @@ pair_of_columns lonlat_to_cartesian(double origin_lon,
   CUSPATIAL_EXPECTS(not input_lon.has_nulls() && not input_lat.has_nulls(),
                     "input cannot contain nulls");
 
-  return detail::lonlat_to_cartesian(origin_lon, origin_lat, input_lon, input_lat, mr, 0);
+  return detail::lonlat_to_cartesian(
+    origin_lon, origin_lat, input_lon, input_lat, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/spatial/polygon_bounding_box.cu
+++ b/cpp/src/spatial/polygon_bounding_box.cu
@@ -25,6 +25,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/gather.h>
@@ -58,8 +59,8 @@ std::unique_ptr<cudf::table> compute_polygon_bounding_boxes(cudf::column_view co
                                                             cudf::column_view const &ring_offsets,
                                                             cudf::column_view const &x,
                                                             cudf::column_view const &y,
-                                                            rmm::mr::device_memory_resource *mr,
-                                                            cudaStream_t stream)
+                                                            rmm::cuda_stream_view stream,
+                                                            rmm::mr::device_memory_resource *mr)
 {
   auto num_polygons = poly_offsets.size();
   // Wrapped in an IEFE so `first_ring_offsets` is freed on return
@@ -68,20 +69,20 @@ std::unique_ptr<cudf::table> compute_polygon_bounding_boxes(cudf::column_view co
     rmm::device_vector<int32_t> first_ring_offsets(num_polygons);
 
     // Gather the first ring offset for each polygon
-    thrust::gather(rmm::exec_policy(stream)->on(stream),
+    thrust::gather(rmm::exec_policy(stream)->on(stream.value()),
                    poly_offsets.begin<int32_t>(),
                    poly_offsets.end<int32_t>(),
                    ring_offsets.begin<int32_t>(),
                    first_ring_offsets.begin());
 
     // Scatter the first ring offset into a list of point_ids for reduction
-    thrust::scatter(rmm::exec_policy(stream)->on(stream),
+    thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(0) + num_polygons,
                     first_ring_offsets.begin(),
                     point_ids.begin());
 
-    thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream),
+    thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
                            point_ids.begin(),
                            point_ids.end(),
                            point_ids.begin(),
@@ -112,7 +113,7 @@ std::unique_ptr<cudf::table> compute_polygon_bounding_boxes(cudf::column_view co
   auto points_iter = thrust::make_zip_iterator(thrust::make_tuple(x.begin<T>(), y.begin<T>()));
   auto points_squared_iter = thrust::make_transform_iterator(points_iter, point_to_square<T>{});
 
-  thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream),
+  thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
                         point_ids.begin(),
                         point_ids.end(),
                         points_squared_iter,
@@ -147,10 +148,10 @@ struct dispatch_compute_polygon_bounding_boxes {
              cudf::column_view const &ring_offsets,
              cudf::column_view const &x,
              cudf::column_view const &y,
-             rmm::mr::device_memory_resource *mr,
-             cudaStream_t stream)
+             rmm::cuda_stream_view stream,
+             rmm::mr::device_memory_resource *mr)
   {
-    return compute_polygon_bounding_boxes<T>(poly_offsets, ring_offsets, x, y, mr, stream);
+    return compute_polygon_bounding_boxes<T>(poly_offsets, ring_offsets, x, y, stream, mr);
   }
 };
 
@@ -162,8 +163,8 @@ std::unique_ptr<cudf::table> polygon_bounding_boxes(cudf::column_view const &pol
                                                     cudf::column_view const &ring_offsets,
                                                     cudf::column_view const &x,
                                                     cudf::column_view const &y,
-                                                    rmm::mr::device_memory_resource *mr,
-                                                    cudaStream_t stream)
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::mr::device_memory_resource *mr)
 {
   return cudf::type_dispatcher(x.type(),
                                dispatch_compute_polygon_bounding_boxes{},
@@ -171,8 +172,8 @@ std::unique_ptr<cudf::table> polygon_bounding_boxes(cudf::column_view const &pol
                                ring_offsets,
                                x,
                                y,
-                               mr,
-                               stream);
+                               stream,
+                               mr);
 }
 
 }  // namespace detail
@@ -201,7 +202,8 @@ std::unique_ptr<cudf::table> polygon_bounding_boxes(cudf::column_view const &pol
     return std::make_unique<cudf::table>(std::move(cols));
   }
 
-  return detail::polygon_bounding_boxes(poly_offsets, ring_offsets, x, y, mr, cudaStream_t{0});
+  return detail::polygon_bounding_boxes(
+    poly_offsets, ring_offsets, x, y, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/spatial_window/spatial_window.cu
+++ b/cpp/src/spatial_window/spatial_window.cu
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+#include <cuspatial/error.hpp>
+
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/copy_if.cuh>
 
-#include <cuspatial/error.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
 #include <type_traits>
@@ -71,7 +73,7 @@ struct spatial_window_dispatch {
                                           double window_max_y,
                                           cudf::column_view const& x,
                                           cudf::column_view const& y,
-                                          cudaStream_t stream,
+                                          rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
   {
     auto device_x = cudf::column_device_view::create(x, stream);
@@ -83,8 +85,8 @@ struct spatial_window_dispatch {
                                                           static_cast<T>(window_max_y),
                                                           *device_x,
                                                           *device_y},
-                                 mr,
-                                 stream);
+                                 stream,
+                                 mr);
   }
 
   template <typename T,
@@ -114,7 +116,7 @@ std::unique_ptr<cudf::table> points_in_spatial_window(double window_min_x,
                                                       double window_max_y,
                                                       cudf::column_view const& x,
                                                       cudf::column_view const& y,
-                                                      cudaStream_t stream,
+                                                      rmm::cuda_stream_view stream,
                                                       rmm::mr::device_memory_resource* mr)
 {
   CUSPATIAL_EXPECTS(x.type() == y.type(), "Type mismatch between x and y arrays");
@@ -149,7 +151,7 @@ std::unique_ptr<cudf::table> points_in_spatial_window(double window_min_x,
                                                       rmm::mr::device_memory_resource* mr)
 {
   return detail::points_in_spatial_window(
-    window_min_x, window_max_x, window_min_y, window_max_y, x, y, 0, mr);
+    window_min_x, window_max_x, window_min_y, window_max_y, x, y, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/src/trajectory/trajectory_bounding_boxes.cu
+++ b/cpp/src/trajectory/trajectory_bounding_boxes.cu
@@ -98,7 +98,7 @@ struct dispatch_element {
       });
 
     // check for errors
-    CHECK_CUDA(stream);
+    CHECK_CUDA(stream.value());
 
     return std::make_unique<cudf::table>(std::move(cols));
   }

--- a/cpp/tests/trajectory/trajectory_utilities.cuh
+++ b/cpp/tests/trajectory/trajectory_utilities.cuh
@@ -63,8 +63,8 @@ std::unique_ptr<cudf::table> make_test_trajectories_table(
     cudf::timestamp_ms{duration_ms{2500000000000}}    // Mon, 22 Mar 2049 04:26:40 GMT
   );
 
-  auto sorted = cudf::detail::sort_by_key(
-    cudf::table_view{{id, x, y, ts}}, cudf::table_view{{id, ts}}, {}, {}, mr, 0);
+  auto sorted = cudf::detail::sort_by_key(  
+    cudf::table_view{{id, x, y, ts}}, cudf::table_view{{id, ts}}, {}, {}, 0, mr);
 
   return sorted;
 }

--- a/cpp/tests/trajectory/trajectory_utilities.cuh
+++ b/cpp/tests/trajectory/trajectory_utilities.cuh
@@ -63,7 +63,7 @@ std::unique_ptr<cudf::table> make_test_trajectories_table(
     cudf::timestamp_ms{duration_ms{2500000000000}}    // Mon, 22 Mar 2049 04:26:40 GMT
   );
 
-  auto sorted = cudf::detail::sort_by_key(  
+  auto sorted = cudf::detail::sort_by_key(
     cudf::table_view{{id, x, y, ts}}, cudf::table_view{{id, ts}}, {}, {}, 0, mr);
 
   return sorted;


### PR DESCRIPTION
This PR converts all usage of `cudaStream_t` in cuSpatial to `rmm::cuda_stream_view`, following on from  rapidsai/cudf#6646, rapidsai/cudf#6648 and rapidsai/cudf#6744.

This PR should only depend on the first of those, but it's possible it depends on changes from all of them. CI will tell us...

Also reorders stream parameters to occur before MR parameters in all functions.