### PR TITLE
[REVIEW] Fix point in polygon test for cudf::gather breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 - PR #320 Fix quadtree construction bug: zero out `device_uvector` before `scatter`
+- PR #328 Fix point in polygon test for cudf::gather breaking change
 
 # cuSpatial 0.16.0 (Date TBD)
 

--- a/cpp/tests/join/point_in_polygon_test_large.cpp
+++ b/cpp/tests/join/point_in_polygon_test_large.cpp
@@ -158,7 +158,8 @@ TYPED_TEST(PIPRefineTestLarge, TestLarge)
 
   auto &quadtree      = std::get<1>(quadtree_pair);
   auto &point_indices = std::get<0>(quadtree_pair);
-  auto points         = cudf::gather(cudf::table_view{{x, y}}, *point_indices, this->mr());
+  auto points         = cudf::gather(
+    cudf::table_view{{x, y}}, *point_indices, cudf::out_of_bounds_policy::DONT_CHECK, this->mr());
 
   fixed_width_column_wrapper<int32_t> poly_offsets({0, 1, 2, 3});
   fixed_width_column_wrapper<int32_t> ring_offsets({0, 4, 10, 14});


### PR DESCRIPTION
Update `cudf::gather` callsite in `point_in_polygon_test_large` to account for the new out of bounds policy parameter.