### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 - PR #320 Fix quadtree construction bug: zero out `device_uvector` before `scatter`
+- PR #328 Fix point in polygon test for cudf::gather breaking change
 
 # cuSpatial 0.16.0 (Date TBD)
 

--- a/cpp/tests/join/point_in_polygon_test_large.cpp
+++ b/cpp/tests/join/point_in_polygon_test_large.cpp
@@ -158,7 +158,8 @@ TYPED_TEST(PIPRefineTestLarge, TestLarge)
 
   auto &quadtree      = std::get<1>(quadtree_pair);
   auto &point_indices = std::get<0>(quadtree_pair);
-  auto points         = cudf::gather(cudf::table_view{{x, y}}, *point_indices, this->mr());
+  auto points         = cudf::gather(
+    cudf::table_view{{x, y}}, *point_indices, cudf::out_of_bounds_policy::DONT_CHECK, this->mr());
 
   fixed_width_column_wrapper<int32_t> poly_offsets({0, 1, 2, 3});
   fixed_width_column_wrapper<int32_t> ring_offsets({0, 4, 10, 14});


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.