### PR TITLE
Use simplified `rmm::exec_policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #331 Use simplified `rmm::exec_policy`
+
 ## Bug Fixes
 
 # cuSpatial 0.17.0 (Date TBD)

--- a/cpp/src/indexing/construction/detail/phase_1.cuh
+++ b/cpp/src/indexing/construction/detail/phase_1.cuh
@@ -26,6 +26,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -62,7 +63,7 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
                                       rmm::mr::device_memory_resource *mr)
 {
   rmm::device_uvector<uint32_t> keys(x.size(), stream);
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()),
                     make_zip_iterator(x.begin<T>(), y.begin<T>()) + x.size(),
                     keys.begin(),
@@ -78,15 +79,13 @@ compute_point_keys_and_sorted_indices(cudf::column_view const &x,
 
   auto indices = make_fixed_width_column<uint32_t>(keys.size(), stream, mr);
 
-  thrust::sequence(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::sequence(rmm::exec_policy(stream),
                    indices->mutable_view().begin<uint32_t>(),
                    indices->mutable_view().end<uint32_t>());
 
   // Sort the codes and point indices
-  thrust::stable_sort_by_key(rmm::exec_policy(stream)->on(stream.value()),
-                             keys.begin(),
-                             keys.end(),
-                             indices->mutable_view().begin<int32_t>());
+  thrust::stable_sort_by_key(
+    rmm::exec_policy(stream), keys.begin(), keys.end(), indices->mutable_view().begin<int32_t>());
 
   return std::make_pair(std::move(keys), std::move(indices));
 }
@@ -109,7 +108,7 @@ inline cudf::size_type build_tree_level(InputIterator1 keys_begin,
                                         BinaryOp binary_op,
                                         rmm::cuda_stream_view stream)
 {
-  auto result = thrust::reduce_by_key(rmm::exec_policy(stream)->on(stream.value()),
+  auto result = thrust::reduce_by_key(rmm::exec_policy(stream),
                                       keys_begin,
                                       keys_end,
                                       vals_in,
@@ -206,19 +205,19 @@ reverse_tree_levels(rmm::device_uvector<uint32_t> const &quad_keys_in,
     cudf::size_type level_end   = end_pos[level];
     cudf::size_type level_begin = begin_pos[level];
     cudf::size_type num_quads   = level_end - level_begin;
-    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::fill(rmm::exec_policy(stream),
                  quad_levels.begin() + offset,
                  quad_levels.begin() + offset + num_quads,
                  level);
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy(rmm::exec_policy(stream),
                  quad_keys_in.begin() + level_begin,
                  quad_keys_in.begin() + level_end,
                  quad_keys.begin() + offset);
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy(rmm::exec_policy(stream),
                  quad_point_count_in.begin() + level_begin,
                  quad_point_count_in.begin() + level_end,
                  quad_point_count.begin() + offset);
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy(rmm::exec_policy(stream),
                  quad_child_count_in.begin() + level_begin,
                  quad_child_count_in.begin() + level_end,
                  quad_child_count.begin() + offset);
@@ -292,10 +291,7 @@ inline auto make_full_levels(cudf::column_view const &x,
   quad_child_count.resize(num_bottom_quads * (max_depth + 1), stream);
 
   // Zero out the quad_child_count vector because we're reusing the point_keys vector
-  thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
-               quad_child_count.begin(),
-               quad_child_count.end(),
-               0);
+  thrust::fill(rmm::exec_policy(stream), quad_child_count.begin(), quad_child_count.end(), 0);
 
   //
   // Compute "full" quads for the tree at each level. Starting from the quadrant

--- a/cpp/src/indexing/construction/detail/phase_2.cuh
+++ b/cpp/src/indexing/construction/detail/phase_2.cuh
@@ -25,6 +25,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -47,7 +48,7 @@ inline rmm::device_uvector<uint32_t> compute_leaf_positions(cudf::column_view co
                                                             rmm::cuda_stream_view stream)
 {
   rmm::device_uvector<uint32_t> leaf_pos(num_valid_nodes, stream);
-  auto result = thrust::copy_if(rmm::exec_policy(stream)->on(stream.value()),
+  auto result = thrust::copy_if(rmm::exec_policy(stream),
                                 thrust::make_counting_iterator(0),
                                 thrust::make_counting_iterator(0) + num_valid_nodes,
                                 indicator.begin<bool>(),
@@ -70,7 +71,7 @@ inline rmm::device_uvector<uint32_t> flatten_point_keys(
   rmm::device_uvector<uint32_t> flattened_keys(num_valid_nodes, stream);
   auto keys_and_levels =
     make_zip_iterator(quad_keys.begin(), quad_level.begin(), indicator.begin<bool>());
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     keys_and_levels,
                     keys_and_levels + num_valid_nodes,
                     flattened_keys.begin(),
@@ -107,24 +108,23 @@ inline rmm::device_uvector<uint32_t> compute_flattened_first_point_positions(
       flatten_point_keys(quad_keys, quad_level, indicator, num_valid_nodes, max_depth, stream);
 
     rmm::device_uvector<uint32_t> initial_sort_indices(num_valid_nodes, stream);
-    thrust::sequence(rmm::exec_policy(stream)->on(stream.value()),
-                     initial_sort_indices.begin(),
-                     initial_sort_indices.end());
+    thrust::sequence(
+      rmm::exec_policy(stream), initial_sort_indices.begin(), initial_sort_indices.end());
 
     rmm::device_uvector<uint32_t> quad_point_count_tmp(num_valid_nodes, stream);
-    thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::copy(rmm::exec_policy(stream),
                  quad_point_count.begin(),
                  quad_point_count.end(),
                  quad_point_count_tmp.begin());
 
     // sort indices and temporary point counts
     thrust::stable_sort_by_key(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       flattened_keys.begin(),
       flattened_keys.end(),
       make_zip_iterator(initial_sort_indices.begin(), quad_point_count_tmp.begin()));
 
-    thrust::remove_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::remove_if(rmm::exec_policy(stream),
                       quad_point_count_tmp.begin(),
                       quad_point_count_tmp.begin() + num_valid_nodes,
                       quad_point_count_tmp.begin(),
@@ -151,7 +151,7 @@ inline rmm::device_uvector<uint32_t> compute_flattened_first_point_positions(
 
   rmm::device_uvector<uint32_t> quad_point_offsets_tmp(leaf_offsets.size(), stream);
 
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::exclusive_scan(rmm::exec_policy(stream),
                          quad_point_count_tmp.begin(),
                          quad_point_count_tmp.end(),
                          quad_point_offsets_tmp.begin());
@@ -159,14 +159,14 @@ inline rmm::device_uvector<uint32_t> compute_flattened_first_point_positions(
   auto counts_and_offsets =
     make_zip_iterator(quad_point_count_tmp.begin(), quad_point_offsets_tmp.begin());
 
-  thrust::stable_sort_by_key(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::stable_sort_by_key(rmm::exec_policy(stream),
                              initial_sort_indices.begin(),
                              initial_sort_indices.end(),
                              counts_and_offsets);
 
   rmm::device_uvector<uint32_t> quad_point_offsets(num_valid_nodes, stream);
 
-  thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::scatter(rmm::exec_policy(stream),
                   counts_and_offsets,
                   counts_and_offsets + leaf_offsets.size(),
                   leaf_offsets.begin(),
@@ -188,15 +188,14 @@ inline rmm::device_uvector<uint32_t> compute_parent_positions(
   auto parent_pos = [&]() {
     rmm::device_uvector<uint32_t> position_map(num_parent_nodes, stream);
     // line 1 of algorithm in Fig. 5 in ref.
-    thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::exclusive_scan(rmm::exec_policy(stream),
                            quad_child_count.begin(),
                            quad_child_count.begin() + num_parent_nodes,
                            position_map.begin());
     // line 2 of algorithm in Fig. 5 in ref.
     rmm::device_uvector<uint32_t> parent_pos(num_child_nodes, stream);
-    thrust::uninitialized_fill(
-      rmm::exec_policy(stream)->on(stream.value()), parent_pos.begin(), parent_pos.end(), 0);
-    thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::uninitialized_fill(rmm::exec_policy(stream), parent_pos.begin(), parent_pos.end(), 0);
+    thrust::scatter(rmm::exec_policy(stream),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(0) + num_parent_nodes,
                     position_map.begin(),
@@ -205,7 +204,7 @@ inline rmm::device_uvector<uint32_t> compute_parent_positions(
   }();
 
   // line 3 of algorithm in Fig. 5 in ref.
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::inclusive_scan(rmm::exec_policy(stream),
                          parent_pos.begin(),
                          parent_pos.begin() + num_child_nodes,
                          parent_pos.begin(),
@@ -249,7 +248,7 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
   // Start counting nodes at level 2, since children of the root node should not
   // be discarded.
   auto num_invalid_parent_nodes =
-    thrust::count_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::count_if(rmm::exec_policy(stream),
                      parent_point_counts,
                      parent_point_counts + (num_parent_nodes - level_1_size),
                      // i.e. quad_point_count[parent_pos] <= min_size
@@ -268,7 +267,7 @@ inline std::pair<uint32_t, uint32_t> remove_unqualified_quads(
                                 quad_levels.begin() + level_1_size);
 
   auto last_valid =
-    thrust::remove_if(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::remove_if(rmm::exec_policy(stream),
                       tree,
                       tree + num_child_nodes,
                       parent_point_counts,
@@ -314,14 +313,14 @@ inline std::unique_ptr<cudf::column> construct_non_leaf_indicator(
   auto is_quad = make_fixed_width_column<bool>(num_valid_nodes, stream, mr);
 
   // line 6 of algorithm in Fig. 5 in ref.
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     quad_point_count.begin(),
                     quad_point_count.begin() + num_parent_nodes,
                     is_quad->mutable_view().begin<bool>(),
                     thrust::placeholders::_1 > min_size);
 
   // line 7 of algorithm in Fig. 5 in ref.
-  thrust::replace_if(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::replace_if(rmm::exec_policy(stream),
                      quad_point_count.begin(),
                      quad_point_count.begin() + num_parent_nodes,
                      is_quad->view().begin<bool>(),
@@ -331,7 +330,7 @@ inline std::unique_ptr<cudf::column> construct_non_leaf_indicator(
   if (num_valid_nodes > num_parent_nodes) {
     // zero-fill the rest of the indicator column because
     // device_memory_resources aren't required to initialize allocations
-    thrust::fill(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::fill(rmm::exec_policy(stream),
                  is_quad->mutable_view().begin<bool>() + num_parent_nodes,
                  is_quad->mutable_view().end<bool>(),
                  0);

--- a/cpp/src/interpolate/cubic_spline.cu
+++ b/cpp/src/interpolate/cubic_spline.cu
@@ -24,6 +24,7 @@
 #include <cuspatial/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <cusparse.h>
 
@@ -48,7 +49,7 @@ struct parallel_search {
       curve_ids.type(), t.size(), cudf::mask_state::UNALLOCATED, stream, mr);
     int32_t* p_result = result->mutable_view().data<int32_t>();
     thrust::for_each(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::make_counting_iterator<int>(0),
       thrust::make_counting_iterator<int>(query_coords.size()),
       [p_t, p_curve_ids, p_prefixes, p_query_coords, p_result] __device__(int index) {
@@ -103,7 +104,7 @@ struct interpolate {
       cudf::make_numeric_column(t.type(), t.size(), cudf::mask_state::UNALLOCATED, stream, mr);
     T* p_result = result->mutable_view().data<T>();
     thrust::for_each(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::make_counting_iterator<int>(0),
       thrust::make_counting_iterator<int>(t.size()),
       [p_t, p_ids, p_coef_indices, p_d3, p_d2, p_d1, p_d0, p_result] __device__(int index) {
@@ -150,7 +151,7 @@ struct coefficients_compute {
     T* p_d1                   = d1.data<T>();
     T* p_d0                   = d0.data<T>();
     thrust::for_each(
-      rmm::exec_policy(stream)->on(stream.value()),
+      rmm::exec_policy(stream),
       thrust::make_counting_iterator<int>(1),
       thrust::make_counting_iterator<int>(prefixes.size()),
       [p_t, p_y, p_prefixes, p_h, p_i, p_z, p_d3, p_d2, p_d1, p_d0] __device__(int index) {
@@ -214,7 +215,7 @@ struct compute_spline_tridiagonals {
     T* p_u                    = u.data<T>();
     T* p_h                    = h.data<T>();
     T* p_i                    = i.data<T>();
-    thrust::for_each(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::for_each(rmm::exec_policy(stream),
                      thrust::make_counting_iterator<int>(1),
                      thrust::make_counting_iterator<int>(prefixes.size()),
                      [p_t, p_y, p_prefixes, p_d, p_dlu, p_u, p_h, p_i] __device__(int index) {

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -20,9 +20,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/scan.h>
@@ -63,13 +63,13 @@ std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
   auto ys              = make_column<double>(std::get<3>(poly_vectors), stream, mr);
 
   // transform polygon lengths to polygon offsets
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::exclusive_scan(rmm::exec_policy(stream),
                          polygon_offsets->view().begin<cudf::size_type>(),
                          polygon_offsets->view().end<cudf::size_type>(),
                          polygon_offsets->mutable_view().begin<cudf::size_type>());
 
   // transform ring lengths to ring offsets
-  thrust::exclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::exclusive_scan(rmm::exec_policy(stream),
                          ring_offsets->view().begin<cudf::size_type>(),
                          ring_offsets->view().end<cudf::size_type>(),
                          ring_offsets->mutable_view().begin<cudf::size_type>());

--- a/cpp/src/join/detail/intersection.cuh
+++ b/cpp/src/join/detail/intersection.cuh
@@ -25,6 +25,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -48,11 +49,10 @@ inline cudf::size_type copy_leaf_intersections(InputIterator input_begin,
 {
   return thrust::distance(
     output_begin,
-    thrust::copy_if(rmm::exec_policy(stream)->on(stream.value()),
-                    input_begin,
-                    input_end,
-                    output_begin,
-                    [] __device__(auto const &t) { return thrust::get<0>(t) == leaf_indicator; }));
+    thrust::copy_if(
+      rmm::exec_policy(stream), input_begin, input_end, output_begin, [] __device__(auto const &t) {
+        return thrust::get<0>(t) == leaf_indicator;
+      }));
 }
 
 template <typename InputIterator, typename OutputIterator>
@@ -61,14 +61,12 @@ inline cudf::size_type remove_non_quad_intersections(InputIterator input_begin,
                                                      OutputIterator output_begin,
                                                      rmm::cuda_stream_view stream)
 {
-  return thrust::distance(output_begin,
-                          thrust::remove_if(rmm::exec_policy(stream)->on(stream.value()),
-                                            input_begin,
-                                            input_end,
-                                            output_begin,
-                                            [] __device__(auto const &t) {
-                                              return thrust::get<0>(t) != quad_indicator;
-                                            }));
+  return thrust::distance(
+    output_begin,
+    thrust::remove_if(
+      rmm::exec_policy(stream), input_begin, input_end, output_begin, [] __device__(auto const &t) {
+        return thrust::get<0>(t) != quad_indicator;
+      }));
 }
 
 template <typename T,
@@ -98,7 +96,7 @@ inline std::pair<cudf::size_type, cudf::size_type> find_intersections(
   auto d_poly_x_max = cudf::column_device_view::create(poly_bbox.column(2), stream);
   auto d_poly_y_max = cudf::column_device_view::create(poly_bbox.column(3), stream);
 
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     make_zip_iterator(node_indices, poly_indices),
                     make_zip_iterator(node_indices, poly_indices) + num_pairs,
                     node_pairs,

--- a/cpp/src/join/detail/traversal.cuh
+++ b/cpp/src/join/detail/traversal.cuh
@@ -22,6 +22,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/gather.h>
 #include <thrust/scan.h>
@@ -68,10 +69,8 @@ descend_quadtree(LengthsIter counts,
   // scan on the number of child nodes to compute the offsets
   // note: size is `num_quads + 1` so the last element is `num_children`
   rmm::device_uvector<uint32_t> parent_offsets(num_quads + 1, stream);
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
-                         parent_counts,
-                         parent_counts + num_quads,
-                         parent_offsets.begin() + 1);
+  thrust::inclusive_scan(
+    rmm::exec_policy(stream), parent_counts, parent_counts + num_quads, parent_offsets.begin() + 1);
 
   parent_offsets.set_element_async(0, 0, stream);
 
@@ -79,10 +78,9 @@ descend_quadtree(LengthsIter counts,
 
   rmm::device_uvector<uint32_t> parent_indices(num_children, stream);
   // fill with zeroes
-  thrust::fill(
-    rmm::exec_policy(stream)->on(stream.value()), parent_indices.begin(), parent_indices.end(), 0);
+  thrust::fill(rmm::exec_policy(stream), parent_indices.begin(), parent_indices.end(), 0);
   // use the parent_offsets as the map to scatter sequential parent_indices
-  thrust::scatter(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::scatter(rmm::exec_policy(stream),
                   thrust::make_counting_iterator(0),
                   thrust::make_counting_iterator(0) + num_quads,
                   parent_offsets.begin(),
@@ -90,7 +88,7 @@ descend_quadtree(LengthsIter counts,
 
   // inclusive scan with maximum functor to fill the empty elements with their left-most non-empty
   // elements. `parent_indices` is now a full array of the sequence index of each quadrant's parent
-  thrust::inclusive_scan(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::inclusive_scan(rmm::exec_policy(stream),
                          parent_indices.begin(),
                          parent_indices.begin() + num_children,
                          parent_indices.begin(),
@@ -103,7 +101,7 @@ descend_quadtree(LengthsIter counts,
   rmm::device_uvector<uint32_t> child_poly_indices(num_children, stream);
 
   // `parent_indices` is a gather map to retrieve non-leaf quads' respective child nodes
-  thrust::gather(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::gather(rmm::exec_policy(stream),
                  parent_indices.begin(),
                  parent_indices.begin() + num_children,
                  // curr level iterator
@@ -118,7 +116,7 @@ descend_quadtree(LengthsIter counts,
                                    child_poly_indices.begin()));
 
   rmm::device_uvector<uint32_t> relative_child_offsets(num_children, stream);
-  thrust::exclusive_scan_by_key(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::exclusive_scan_by_key(rmm::exec_policy(stream),
                                 parent_indices.begin(),
                                 parent_indices.begin() + num_children,
                                 thrust::constant_iterator<uint32_t>(1),
@@ -126,7 +124,7 @@ descend_quadtree(LengthsIter counts,
 
   // compute child quad indices using parent and relative child offsets
   auto child_offsets_iter = thrust::make_permutation_iterator(offsets, child_quad_indices.begin());
-  thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::transform(rmm::exec_policy(stream),
                     child_offsets_iter,
                     child_offsets_iter + num_children,
                     relative_child_offsets.begin(),

--- a/cpp/src/join/quadtree_poly_filtering.cu
+++ b/cpp/src/join/quadtree_poly_filtering.cu
@@ -28,6 +28,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <tuple>
 
@@ -61,7 +62,7 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
 
   // Count the number of top-level nodes to start.
   // This could be provided explicitly, but count_if should be fast enough.
-  auto num_top_level_leaves = thrust::count_if(rmm::exec_policy(stream)->on(stream.value()),
+  auto num_top_level_leaves = thrust::count_if(rmm::exec_policy(stream),
                                                node_levels.begin<uint8_t>(),
                                                node_levels.end<uint8_t>(),
                                                thrust::placeholders::_1 == 0);
@@ -178,12 +179,12 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
   cols.push_back(make_fixed_width_column<uint32_t>(num_results, stream, mr));
   cols.push_back(make_fixed_width_column<uint32_t>(num_results, stream, mr));
 
-  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::copy(rmm::exec_policy(stream),
                out_poly_idxs.begin(),
                out_poly_idxs.begin() + num_results,
                cols.at(0)->mutable_view().begin<uint32_t>());
 
-  thrust::copy(rmm::exec_policy(stream)->on(stream.value()),
+  thrust::copy(rmm::exec_policy(stream),
                out_node_idxs.begin(),
                out_node_idxs.begin() + num_results,
                cols.at(1)->mutable_view().begin<uint32_t>());

--- a/cpp/src/spatial/hausdorff.cu
+++ b/cpp/src/spatial/hausdorff.cu
@@ -28,6 +28,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
 #include <thrust/functional.h>
@@ -128,14 +129,14 @@ struct hausdorff_functor {
 
     auto num_cartesian = num_points * num_points;
 
-    thrust::inclusive_scan_by_key(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::inclusive_scan_by_key(rmm::exec_policy(stream),
                                   gpc_key_iter,
                                   gpc_key_iter + num_cartesian,
                                   hausdorff_acc_iter,
                                   scatter_out,
                                   thrust::equal_to<thrust::pair<int32_t, int32_t>>());
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       result_temp_iter,
                       result_temp_iter + num_results,
                       result->mutable_view().begin<T>(),

--- a/cpp/src/spatial/haversine.cu
+++ b/cpp/src/spatial/haversine.cu
@@ -26,6 +26,7 @@
 
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
@@ -82,7 +83,7 @@ struct haversine_functor {
 
     auto input_iter = thrust::make_zip_iterator(input_tuple);
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
+    thrust::transform(rmm::exec_policy(stream),
                       input_iter,
                       input_iter + result->size(),
                       result->mutable_view().begin<T>(),

--- a/cpp/src/spatial/lonlat_to_cartesian.cu
+++ b/cpp/src/spatial/lonlat_to_cartesian.cu
@@ -22,6 +22,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -85,11 +86,8 @@ struct lonlat_to_cartesian_functor {
                                lat_to_y(origin_lat - lat));
     };
 
-    thrust::transform(rmm::exec_policy(stream)->on(stream.value()),
-                      input_zip,
-                      input_zip + input_lon.size(),
-                      output_zip,
-                      to_cartesian);
+    thrust::transform(
+      rmm::exec_policy(stream), input_zip, input_zip + input_lon.size(), output_zip, to_cartesian);
 
     return std::make_pair(std::move(output_x), std::move(output_y));
   }

--- a/cpp/src/trajectory/trajectory_distances_and_speeds.cu
+++ b/cpp/src/trajectory/trajectory_distances_and_speeds.cu
@@ -27,6 +27,7 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/iterator/discard_iterator.h>
 
@@ -63,8 +64,6 @@ struct dispatch_timestamp {
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr)
   {
-    auto policy = rmm::exec_policy(stream);
-
     // Construct output columns
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.reserve(2);
@@ -104,7 +103,7 @@ struct dispatch_timestamp {
 
     // Compute duration and distance difference between adjacent elements that
     // share the same object id
-    thrust::adjacent_difference(policy->on(stream.value()),
+    thrust::adjacent_difference(rmm::exec_policy(stream),
                                 timestamp_point_and_id,                     // first
                                 timestamp_point_and_id + durations.size(),  // last
                                 duration_and_distance_1,                    // result
@@ -148,7 +147,7 @@ struct dispatch_timestamp {
 
     // Reduce the intermediate durations and kilometer distances into meter
     // distances and speeds in meters/second
-    thrust::reduce_by_key(policy->on(stream.value()),
+    thrust::reduce_by_key(rmm::exec_policy(stream),
                           object_id.begin<int32_t>(),       // keys_first
                           object_id.end<int32_t>(),         // keys_last
                           duration_and_distance_2 + 1,      // values_first


### PR DESCRIPTION
Updates libcudf to use the new, simplified rmm::exec_policy and include the new refactored headers rmm/exec_policy.hpp and rmm/device_vector.hpp

The new exec_policy can be passed directly to Thrust, no longer any need to call rmm::exec_policy(stream)->on(stream).

Depends on rapidsai/rmm#647