### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# https://github.com/actions/labeler#common-examples
+# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Labels culled from https://github.com/rapidsai/cuspatial/labels
+
+Python:
+  - python/**
+  - notebooks/**
+  
+libcusignal:
+  - cpp/**
+
+CMake:
+  - **/CMakeLists.txt
+  - **/cmake/**
+  
+Java:
+  - java/**
+  
+Ops:
+  - .github/**
+  - /ci/**
+  - conda/**
+  - **/Dockerfile
+  - **/.dockerignore
+  - docker/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,20 +6,19 @@ Python:
   - 'python/**'
   - 'notebooks/**'
   
-libcuspatial:
+cpp:
   - 'cpp/**'
 
 CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
+
+ci:
+  - 'ci/**'
+
+conda:
+    - 'conda/**'
   
 Java:
   - 'java/**'
   
-Ops:
-  - '.github/**'
-  - 'ci/**'
-  - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,25 @@
 # https://github.com/actions/labeler#common-examples
-# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Adapted from https://github.com/rapidsai/cuspatial/blob/main/.github/CODEOWNERS
 # Labels culled from https://github.com/rapidsai/cuspatial/labels
 
 Python:
-  - python/**
-  - notebooks/**
+  - 'python/**'
+  - 'notebooks/**'
   
 libcuspatial:
-  - cpp/**
+  - 'cpp/**'
 
 CMake:
-  - **/CMakeLists.txt
-  - **/cmake/**
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
   
 Java:
-  - java/**
+  - 'java/**'
   
 Ops:
-  - .github/**
-  - /ci/**
-  - conda/**
-  - **/Dockerfile
-  - **/.dockerignore
-  - docker/**
+  - '.github/**'
+  - 'ci/**'
+  - 'conda/**'
+  - '**/Dockerfile'
+  - '**/.dockerignore'
+  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
 
-ci:
+gpuCI:
   - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Python:
   - python/**
   - notebooks/**
   
-libcusignal:
+libcuspatial:
   - cpp/**
 
 CMake:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).