### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,8 @@
-# cuSpatial 0.18.0 (Date TBD)
+# 0.18.0
 
-## New Features
+Please see https://github.com/rapidsai/cuspatial/releases/tag/branch-0.18-latest for the latest changes to this development branch.
 
-## Improvements
-- PR #297 Upgrade to libcu++ on GitHub.
-- PR #332 fix directed_hausdorff_distance's space_offsets name + documentation
-- PR #331 Use simplified `rmm::exec_policy`
-
-## Bug Fixes
-
-# cuSpatial 0.17.0 (Date TBD)
+# cuSpatial 0.17.0 (10 Dec 2020)
 
 ## New Features
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.