### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
-# 0.18.0
+# cuSpatial 0.18.0 (24 Feb 2021)
 
-Please see https://github.com/rapidsai/cuspatial/releases/tag/branch-0.18-latest for the latest changes to this development branch.
+## Documentation 📖
+
+- Fix directed_hausdorff_distance space_offsets name + documentation (#332) @cwharris
+
+## New Features 🚀
+
+- New build process script changes &amp; gpuCI enhancements (#338) @raydouglass
+
+## Improvements 🛠️
+
+- Update stale GHA with exemptions &amp; new labels (#357) @mike-wendt
+- Add GHA to mark issues/prs as stale/rotten (#355) @Ethyling
+- Prepare Changelog for Automation (#345) @ajschmidt8
+- Pin gdal to 3.1.x (#339) @weiji14
+- Use simplified `rmm::exec_policy` (#331) @harrism
+- Upgrade to libcu++ on GitHub (#297) @trxcllnt
 
 # cuSpatial 0.17.0 (10 Dec 2020)
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.