### PR TITLE
Improve performance of quadtree point-to-polyline join 

### DIFF
--- a/cpp/src/utility/point_to_nearest_polyline.cuh
+++ b/cpp/src/utility/point_to_nearest_polyline.cuh
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/types.hpp>
+
+namespace cuspatial {
+namespace detail {
+
+template <typename T>
+inline __device__ T point_to_poly_line_distance(T const px,
+                                                T const py,
+                                                cudf::size_type const ring_idx,
+                                                cudf::column_device_view const& ring_offsets,
+                                                cudf::column_device_view const& poly_points_x,
+                                                cudf::column_device_view const& poly_points_y)
+{
+  T distance_squared = std::numeric_limits<T>::max();
+  auto ring_begin    = ring_offsets.element<uint32_t>(ring_idx);
+  auto ring_end = ring_idx < ring_offsets.size() - 1 ? ring_offsets.element<uint32_t>(ring_idx + 1)
+                                                     : poly_points_x.size();
+  auto ring_len = ring_end - ring_begin;
+  for (auto point_idx = 0; point_idx < ring_len; ++point_idx) {
+    auto const i0  = ring_begin + ((point_idx + 0) % ring_len);
+    auto const i1  = ring_begin + ((point_idx + 1) % ring_len);
+    auto const x0  = poly_points_x.element<T>(i0);
+    auto const y0  = poly_points_y.element<T>(i0);
+    auto const x1  = poly_points_x.element<T>(i1);
+    auto const y1  = poly_points_y.element<T>(i1);
+    auto const dx0 = px - x0, dy0 = py - y0;
+    auto const dx1 = px - x1, dy1 = py - y1;
+    auto const dx2 = x1 - x0, dy2 = y1 - y0;
+    auto const d0 = dx0 * dx0 + dy0 * dy0;
+    auto const d1 = dx1 * dx1 + dy1 * dy1;
+    auto const d2 = dx2 * dx2 + dy2 * dy2;
+    auto const d3 = dx2 * dx0 + dy2 * dy0;
+    auto const r  = d3 * d3 / d2;
+    auto const d  = d3 <= 0 || r >= d2 ? min(d0, d1) : d0 - r;
+    if (d < distance_squared) { distance_squared = d; }
+  }
+
+  return sqrt(distance_squared);
+}
+
+}  // namespace detail
+}  // namespace cuspatial


### PR DESCRIPTION
Rewrites `quadtree_point_to_nearest_polyline` via thrust in the style of `quadtree_point_in_polygon` to get a 5x speed boost.

Benchmarked locally with NYC taxi 169M float32 points (RMM pool mode enabled):

```
quadtree_point_to_nearest_polyline (before)
1min ± 10.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

quadtree_point_to_nearest_polyline (after)
9.49 s ± 15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Timings for every routine in the benchmark after these changes:
```
quadtree_on_points
66.2 ms ± 64.3 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

polygon_bounding_boxes
322 µs ± 375 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)

join_quadtree_and_bounding_boxes
11.4 ms ± 8.19 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

quadtree_point_in_polygon
5.48 s ± 54.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

polyline_bounding_boxes
258 µs ± 2.37 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

join_quadtree_and_bounding_boxes
11.5 ms ± 17.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

quadtree_point_to_nearest_polyline
9.49 s ± 15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```