### PR TITLE
[skip-ci] Update 0.18 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,24 @@
 
 ## Bug Fixes
 
-# 0.18.0
+# cuSpatial 0.18.0 (24 Feb 2021)
 
-Please see https://github.com/rapidsai/cuspatial/releases/tag/branch-0.18-latest for the latest changes to this development branch.
+## Documentation 📖
+
+- Fix directed_hausdorff_distance space_offsets name + documentation (#332) @cwharris
+
+## New Features 🚀
+
+- New build process script changes &amp; gpuCI enhancements (#338) @raydouglass
+
+## Improvements 🛠️
+
+- Update stale GHA with exemptions &amp; new labels (#357) @mike-wendt
+- Add GHA to mark issues/prs as stale/rotten (#355) @Ethyling
+- Prepare Changelog for Automation (#345) @ajschmidt8
+- Pin gdal to 3.1.x (#339) @weiji14
+- Use simplified `rmm::exec_policy` (#331) @harrism
+- Upgrade to libcu++ on GitHub (#297) @trxcllnt
 
 # cuSpatial 0.17.0 (10 Dec 2020)
 


### PR DESCRIPTION
This PR updates the changelog with the latest automatic changelog entry from `branch-0.18`.

Merging this will close #361.

**Note:** This PR must be merged with a commit merge, not a squash merge. Do not use `@gpucibot merge` to merge this PR.