### PR TITLE
Eliminate literals passed to device_uvector::set_element_async

### DIFF
--- a/cpp/src/join/detail/traversal.cuh
+++ b/cpp/src/join/detail/traversal.cuh
@@ -72,7 +72,8 @@ descend_quadtree(LengthsIter counts,
   thrust::inclusive_scan(
     rmm::exec_policy(stream), parent_counts, parent_counts + num_quads, parent_offsets.begin() + 1);
 
-  parent_offsets.set_element_async(0, 0, stream);
+  uint32_t init{0};
+  parent_offsets.set_element_async(0, init, stream);
 
   auto num_children = parent_offsets.back_element(stream);  // synchronizes stream
 

--- a/cpp/src/join/quadtree_point_in_polygon.cu
+++ b/cpp/src/join/quadtree_point_in_polygon.cu
@@ -134,7 +134,8 @@ struct compute_quadtree_point_in_polygon {
                            local_point_offsets.begin() + 1);
 
     // Ensure local point offsets starts at 0
-    local_point_offsets.set_element_async(0, 0, stream);
+    uint32_t init{0};
+    local_point_offsets.set_element_async(0, init, stream);
 
     // The last element is the total number of points to test against any polygon.
     auto num_total_points = local_point_offsets.back_element(stream);


### PR DESCRIPTION
After rapidsai/rmm#725 is merged, this PR updates cuspatial to eliminate passing literal values to `device_uvector::set_element_async`.