### PR TITLE
Update conda recipes pinning of repo dependencies

### DIFF
--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
@@ -24,7 +24,7 @@ requirements:
     - setuptools
     - cudf {{ minor_version }}.*
     - rmm {{ minor_version }}.*
-    - libcuspatial {{ version }}.*
+    - libcuspatial {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
   run:
     - python
     - cudf {{ minor_version }}.*


### PR DESCRIPTION
Ensure all conda packages created in this repo that depend on other packages are all version pinned to the same build number. This way it prevents a conda solve from picking mismatched versions of `cuspatial` and `libcuspatial` that can break this repo during builds and testing.