### PR TITLE
Set `install_rpath` for libcuspatial

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(cuspatial SHARED
 
 set_target_properties(cuspatial
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
+               INSTALL_RPATH                       "\$ORIGIN"
                # set target compile options
                CXX_STANDARD                        14
                CXX_STANDARD_REQUIRED               ON


### PR DESCRIPTION
Fix issue where conda installed `libcuspatial` can't find other conda-installed libraries like GDAL.

Related issue in cuDF: https://github.com/rapidsai/cudf/pull/7863