### PR TITLE
Update CUDA version in build scripts

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #Upload cuspatial once per PYTHON
-if [[ "$CUDA" == "10.1" ]]; then
+if [[ "$CUDA" == "11.0" ]]; then
     export UPLOAD_CUSPATIAL=1
 else
     export UPLOAD_CUSPATIAL=0


### PR DESCRIPTION
I traced the `cuxfilter` build error shown below ([link](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci-v0.20/job/cuxfilter/job/branches/job/cuxfilter-cpu-branch-build/32/console)) back to this `UPLOAD_CUSPATIAL` env var not being set. After further investigation, it looks like this `CUDA` version in the conditional statement needs to be updated.

This should get some `0.20` packages [uploaded to conda](https://anaconda.org/rapidsai-nightly/cuspatial/files) for `cuspatial`.


![image](https://user-images.githubusercontent.com/7400326/114922505-c1df8180-9df9-11eb-850f-11c5c1ee9437.png)
