### PR TITLE
Update cuspatial to use `rmm::cuda_stream_default` everywhere

### DIFF
--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -355,13 +355,14 @@ std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_
   if (x.is_empty() || y.is_empty()) {
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.reserve(5);
-    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<uint8_t>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<bool>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
-    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, 0, mr));
-    return std::make_pair(detail::make_fixed_width_column<uint32_t>(0, 0, mr),
-                          std::make_unique<cudf::table>(std::move(cols)));
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, rmm::cuda_stream_default, mr));
+    cols.push_back(detail::make_fixed_width_column<uint8_t>(0, rmm::cuda_stream_default, mr));
+    cols.push_back(detail::make_fixed_width_column<bool>(0, rmm::cuda_stream_default, mr));
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, rmm::cuda_stream_default, mr));
+    cols.push_back(detail::make_fixed_width_column<uint32_t>(0, rmm::cuda_stream_default, mr));
+    return std::make_pair(
+      detail::make_fixed_width_column<uint32_t>(0, rmm::cuda_stream_default, mr),
+      std::make_unique<cudf::table>(std::move(cols)));
   }
   return detail::quadtree_on_points(
     x, y, x_min, x_max, y_min, y_max, scale, max_depth, min_size, rmm::cuda_stream_default, mr);

--- a/cpp/tests/trajectory/trajectory_utilities.cuh
+++ b/cpp/tests/trajectory/trajectory_utilities.cuh
@@ -63,8 +63,12 @@ std::unique_ptr<cudf::table> make_test_trajectories_table(
     cudf::timestamp_ms{duration_ms{2500000000000}}    // Mon, 22 Mar 2049 04:26:40 GMT
   );
 
-  auto sorted = cudf::detail::sort_by_key(
-    cudf::table_view{{id, x, y, ts}}, cudf::table_view{{id, ts}}, {}, {}, 0, mr);
+  auto sorted = cudf::detail::sort_by_key(cudf::table_view{{id, x, y, ts}},
+                                          cudf::table_view{{id, ts}},
+                                          {},
+                                          {},
+                                          rmm::cuda_stream_default,
+                                          mr);
 
   return sorted;
 }


### PR DESCRIPTION
Updates necessary due to https://github.com/rapidsai/rmm/pull/740.