### PR TITLE
fix -Werror=sign-compare causing debug builds to fail

### DIFF
--- a/cpp/src/spatial/hausdorff.cu
+++ b/cpp/src/spatial/hausdorff.cu
@@ -78,8 +78,9 @@ struct hausdorff_functor {
     auto const num_spaces  = static_cast<uint32_t>(space_offsets.size());
     auto const num_results = static_cast<uint64_t>(num_spaces) * static_cast<uint64_t>(num_spaces);
 
-    CUSPATIAL_EXPECTS(num_results < std::numeric_limits<cudf::size_type>::max(),
-                      "Matrix of spaces must be less than 2^31");
+    CUSPATIAL_EXPECTS(
+      num_results < static_cast<uint64_t>(std::numeric_limits<cudf::size_type>::max()),
+      "Matrix of spaces must be less than 2^31");
 
     if (num_results == 0) {
       return cudf::make_empty_column(cudf::data_type{cudf::type_to_id<T>()});


### PR DESCRIPTION
Fixes this error that curiously only shows up when `CMAKE_BUILD_TYPE=Debug`:
```
cpp/src/spatial/hausdorff.cu:81:18: error: comparison of integer expressions of different signedness: 'const long unsigned int' and 'int' [-Werror=sign-compare]
cc1plus: all warnings being treated as errors
```