### PR TITLE
Move rmm::device_buffer instead of copying

### DIFF
--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -41,7 +41,7 @@ std::unique_ptr<cudf::column> make_column(std::vector<T> source,
   auto tid    = cudf::type_to_id<T>();
   auto type   = cudf::data_type{tid};
   auto buffer = rmm::device_buffer(source.data(), sizeof(T) * source.size(), stream, mr);
-  return std::make_unique<cudf::column>(type, source.size(), buffer);
+  return std::make_unique<cudf::column>(type, source.size(), std::move(buffer));
 }
 
 std::tuple<std::vector<cudf::size_type>,


### PR DESCRIPTION
Simple PR that adds a `std::move` around passing a device_buffer into a column factory. This will be necessary once rapidsai/rmm/#775 is merged.
