### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -11,7 +11,7 @@
 NEXT_FULL_TAG=$1
 
 # Get current version
-CURRENT_TAG=$(git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v')
+CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
 CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
 CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
 CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.