### PR TITLE
Fix `21.06` CHANGELOG.md entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # cuSpatial 21.06.00 (9 Jun 2021)
 
-## 🚀 New Featues
+## 🚀 New Features
 
-- `fom_geopandas` convets GeoPandas GeoSeies objects into cuspatial GeoAow fom. ([#300](https://github.com/rapidsai/cuspatial/pull/300)) [@thomcom](https://github.com/thomcom)
+- `from_geopandas` converts GeoPandas GeoSeries objects into cuspatial GeoArrow form. ([#300](https://github.com/rapidsai//pull/300)) [@thomcom](https://github.com/thomcom)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Update envionment vaiable used to detemine `cuda_vesion` ([#407](https://github.com/rapidsai/cuspatial/pull/407)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update `CHANGELOG.md` links fo calve ([#404](https://github.com/rapidsai/cuspatial/pull/404)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Move mm::device_buffe instead of copying ([#403](https://github.com/rapidsai/cuspatial/pull/403)) [@haism](https://github.com/haism)
-- Update docs build scipt ([#402](https://github.com/rapidsai/cuspatial/pull/402)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update cuspatial vesion fo calve, fix CMake FindPackage cudf ([#401](https://github.com/rapidsai/cuspatial/pull/401)) [@txcllnt](https://github.com/txcllnt)
-- Impove pefomance of quadtee point-to-polyline join ([#362](https://github.com/rapidsai/cuspatial/pull/362)) [@txcllnt](https://github.com/txcllnt)
+- Update environment variable used to determine `cuda_version` ([#407](https://github.com/rapidsai//pull/407)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links for calver ([#404](https://github.com/rapidsai//pull/404)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Move rmm::device_buffer instead of copying ([#403](https://github.com/rapidsai//pull/403)) [@harrism](https://github.com/harrism)
+- Update docs build script ([#402](https://github.com/rapidsai//pull/402)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update cuspatial version for calver, fix CMake FindPackage cudf ([#401](https://github.com/rapidsai//pull/401)) [@trxcllnt](https://github.com/trxcllnt)
+- Improve performance of quadtree point-to-polyline join ([#362](https://github.com/rapidsai//pull/362)) [@trxcllnt](https://github.com/trxcllnt)
 
 # cuSpatial 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
This PR fixes the `21.06` changelog entries, which was malformed (missing some `r` characters) from an erroneous `sed` command.
