### PR TITLE
Update sphinx config [skip ci]

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,4 +199,4 @@ nbsphinx_allow_errors = True
 
 
 def setup(app):
-    app.add_stylesheet("params.css")
+    app.add_css_file("params.css")


### PR DESCRIPTION
According to [this issue](https://github.com/sphinx-doc/sphinx/issues/7747), `add_stylesheet` has been replaced with `add_css_file`. This has caused some errors in recent doc builds. This PR replaces `add_stylesheet` with `add_css_file`.
