### PR TITLE
Fix build from changes in rapidsai/cudf#8528

### DIFF
--- a/python/cuspatial/cuspatial/geometry/geodataframe.py
+++ b/python/cuspatial/cuspatial/geometry/geodataframe.py
@@ -90,9 +90,30 @@ class GeoDataFrame(cudf.DataFrame):
                 result.obj.drop(col, axis=1, inplace=True)
         return result
 
+    # @classmethod
+    # def _from_data(cls, data, index = None, columns = None, ):
+    #     return cudf.DataFrame._from_data(data, index, columns)
+
+    @classmethod
+    def _from_data(
+        cls,
+        data,
+        index = None,
+        columns = None,
+    ):
+        out = cls.__new__(cls)
+        out._data = data
+        if index is None:
+            index = cudf.Index(range(data.nrows))
+        out._index = index
+        if columns is not None:
+            out.columns = columns
+        return out
+
 
 class _GeoSeriesUtility:
-    def _from_data(self, new_data, name=None, index=False):
+    @classmethod
+    def _from_data(cls, new_data, name=None, index=False):
         new_column = new_data.columns[0]
         if is_geometry_type(new_column):
             return GeoSeries(new_column, name=name, index=index)

--- a/python/cuspatial/cuspatial/geometry/geodataframe.py
+++ b/python/cuspatial/cuspatial/geometry/geodataframe.py
@@ -90,26 +90,6 @@ class GeoDataFrame(cudf.DataFrame):
                 result.obj.drop(col, axis=1, inplace=True)
         return result
 
-    # @classmethod
-    # def _from_data(cls, data, index = None, columns = None, ):
-    #     return cudf.DataFrame._from_data(data, index, columns)
-
-    @classmethod
-    def _from_data(
-        cls,
-        data,
-        index = None,
-        columns = None,
-    ):
-        out = cls.__new__(cls)
-        out._data = data
-        if index is None:
-            index = cudf.Index(range(data.nrows))
-        out._index = index
-        if columns is not None:
-            out.columns = columns
-        return out
-
 
 class _GeoSeriesUtility:
     @classmethod


### PR DESCRIPTION
rapidsai/cudf#8528 introduced some changes which broke the cuspatial build. ~specifically `cudf.DataFrame._from_data` was change to a `@classmethod`~ cudf no longer accidentally treats `_from_data` as an instance method, which is bad behavior cuspatial was depending on. To fix this, adjustments need to be made to `cuspatial.GeoDataFrame` and some associated utilities.

PR is WIP, but so far fixes all but one failing test.