### PR TITLE
Update CMake, fix testing use of assert_eq, and correct metadata copying

### DIFF
--- a/conda/environments/cuspatial_dev_cuda11.0.yml
+++ b/conda/environments/cuspatial_dev_cuda11.0.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.0
   - gdal>=3.0.2
   - geopandas>=0.9.0,<0.10.0a0
-  - cmake>=3.18
+  - cmake>=3.20.1
   - cython>=0.29,<0.30
   - gtest
   - gmock

--- a/conda/environments/cuspatial_dev_cuda11.1.yml
+++ b/conda/environments/cuspatial_dev_cuda11.1.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.1
   - gdal>=3.0.2
   - geopandas>=0.9.0,<0.10.0a0
-  - cmake>=3.18
+  - cmake>=3.20.1
   - cython>=0.29,<0.30
   - gtest
   - gmock

--- a/conda/environments/cuspatial_dev_cuda11.2.yml
+++ b/conda/environments/cuspatial_dev_cuda11.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.2
   - gdal>=3.0.2
   - geopandas>=0.9.0,<0.10.0a0
-  - cmake>=3.18
+  - cmake>=3.20.1
   - cython>=0.29,<0.30
   - gtest
   - gmock

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -33,7 +33,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.18
+    - cmake >=3.20.1
   host:
     - libcudf {{ minor_version }}.*
     - librmm {{ minor_version }}.*

--- a/python/cuspatial/cuspatial/geometry/geocolumn.py
+++ b/python/cuspatial/cuspatial/geometry/geocolumn.py
@@ -1,24 +1,22 @@
 # Copyright (c) 2021 NVIDIA CORPORATION
-
 import numbers
-import numpy as np
-
 from itertools import repeat
-from shapely.geometry import (
-    Point,
-    MultiPoint,
-    LineString,
-    MultiLineString,
-    Polygon,
-    MultiPolygon,
-)
 from typing import TypeVar, Union
 
+import numpy as np
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
+
 import cudf
-from cudf.core.column import ColumnBase, NumericalColumn
+from cudf.core.column import NumericalColumn
 
 from cuspatial.geometry.geoarrowbuffers import GeoArrowBuffers
-
 
 T = TypeVar("T", bound="GeoColumn")
 
@@ -199,10 +197,6 @@ class GeoColumn(NumericalColumn):
             self._geo.copy(deep), self._meta.copy(), self.data.copy()
         )
         return result
-
-    def _copy_type_metadata(self: T, other: ColumnBase) -> ColumnBase:
-        self._data = other.data
-        return self
 
 
 class GeoColumnLocIndexer:

--- a/python/cuspatial/cuspatial/geometry/geodataframe.py
+++ b/python/cuspatial/cuspatial/geometry/geodataframe.py
@@ -92,7 +92,8 @@ class GeoDataFrame(cudf.DataFrame):
 
 
 class _GeoSeriesUtility:
-    def _from_data(self, new_data, name=None, index=False):
+    @classmethod
+    def _from_data(cls, new_data, name=None, index=False):
         new_column = new_data.columns[0]
         if is_geometry_type(new_column):
             return GeoSeries(new_column, name=name, index=index)

--- a/python/cuspatial/cuspatial/geometry/geodataframe.py
+++ b/python/cuspatial/cuspatial/geometry/geodataframe.py
@@ -90,6 +90,44 @@ class GeoDataFrame(cudf.DataFrame):
                 result.obj.drop(col, axis=1, inplace=True)
         return result
 
+    def _copy_type_metadata(self, other, include_index: bool = True):
+        """
+        Copy type metadata from each column of `other` to the corresponding
+        column of `self`.
+        See `ColumnBase._with_type_metadata` for more information.
+        """
+        for name, col, other_col in zip(
+            self._data.keys(), self._data.values(), other._data.values()
+        ):
+            # libcudf APIs lose all information about GeoColumns, operating
+            # solely on the underlying base data. Therefore, our only recourse
+            # is to recreate a new GeoColumn with the same underlying data.
+            # Since there's no easy way to create a GeoColumn from a
+            # NumericalColumn, we're forced to do so manually.
+            if isinstance(other_col, GeoColumn):
+                col = GeoColumn(
+                    other_col._geo, other_col._meta, cudf.Index(col)
+                )
+
+            self._data.set_by_label(
+                name, col._with_type_metadata(other_col.dtype), validate=False
+            )
+
+        if include_index:
+            if self._index is not None and other._index is not None:
+                self._index._copy_type_metadata(other._index)
+                # When other._index is a CategoricalIndex, there is
+                if isinstance(
+                    other._index, cudf.core.index.CategoricalIndex
+                ) and not isinstance(
+                    self._index, cudf.core.index.CategoricalIndex
+                ):
+                    self._index = cudf.core.index.Index._from_table(
+                        self._index
+                    )
+
+        return self
+
 
 class _GeoSeriesUtility:
     @classmethod

--- a/python/cuspatial/cuspatial/tests/test_from_geopandas.py
+++ b/python/cuspatial/cuspatial/tests/test_from_geopandas.py
@@ -11,7 +11,7 @@ from shapely.geometry import (
 )
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_geoarrowbuffers.py
+++ b/python/cuspatial/cuspatial/tests/test_geoarrowbuffers.py
@@ -12,7 +12,7 @@ from shapely.geometry import (
 )
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 from cuspatial.geometry.geocolumn import GeoColumn
 from cuspatial import (

--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -14,7 +14,7 @@ from shapely.geometry import (
 )
 from shapely.affinity import rotate
 
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -14,7 +14,7 @@ from shapely.geometry import (
 )
 from shapely.affinity import rotate
 
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_hausdorff_distance.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_indexing.py
+++ b/python/cuspatial/cuspatial/tests/test_indexing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_lonlat_to_cartesian.py
+++ b/python/cuspatial/cuspatial/tests/test_lonlat_to_cartesian.py
@@ -3,7 +3,7 @@
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_pip.py
+++ b/python/cuspatial/cuspatial/tests/test_pip.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 from cuspatial.utils import gis_utils

--- a/python/cuspatial/cuspatial/tests/test_points_in_spatial_window.py
+++ b/python/cuspatial/cuspatial/tests/test_points_in_spatial_window.py
@@ -3,7 +3,7 @@
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_polygon_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polygon_bounding_boxes.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
+++ b/python/cuspatial/cuspatial/tests/test_polyline_bounding_boxes.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_shapefile_reader.py
+++ b/python/cuspatial/cuspatial/tests/test_shapefile_reader.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_spatial_join.py
+++ b/python/cuspatial/cuspatial/tests/test_spatial_join.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_spline_fit.py
+++ b/python/cuspatial/cuspatial/tests/test_spline_fit.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 import cupy as cp
 
 import cuspatial

--- a/python/cuspatial/cuspatial/tests/test_trajectory.py
+++ b/python/cuspatial/cuspatial/tests/test_trajectory.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.tests.utils import assert_eq
+from cudf.testing._utils import assert_eq
 
 import cuspatial
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuSpatial :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR contains three distinct changes required to get cuspatial builds working and tests passing again:
1. RMM switched to rapids-cmake (rapidsai/rmm#800), which requires CMake 3.20.1, so this PR includes the required updates for that.
2. The Arrow upgrade in cudf also moved the location of testing utilities (rapidsai/cudf#7495). Long term cuspatial needs to move away from use of the testing utilities, which are not part of cudf's public API, but we are currently blocked by rapidsai/cudf#8646, so this PR just imports the internal `assert_eq` method as a stopgap to get tests passing.
3. The changes in rapidsai/cudf#8373 altered the way that metadata was propagated to libcudf outputs from previously existing cuDF Python objects. The new code paths require cuspatial to override metadata copying at the GeoDataFrame rather than the GeoColumn level in order to ensure that information about column types is lost in the libcudf round trip and the metadata copying functions are now called on the output DataFrame rather than the input one.

This PR supersedes #427, #428, and #429, all of which can now be closed.

