### PR TITLE
Fix usage of assert_columns* APIs.

### DIFF
--- a/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
+++ b/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
@@ -26,6 +26,8 @@
 
 using namespace cudf::test;
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 std::string get_shapefile_path(std::string filename)
 {
   const char* cuspatial_home = std::getenv("CUSPATIAL_HOME");
@@ -51,10 +53,10 @@ void test(std::string const& shapefile_name,
   auto expected_poly_point_xs = wrapper<double>(xs.begin(), xs.end());
   auto expected_poly_point_ys = wrapper<double>(ys.begin(), ys.end());
 
-  expect_columns_equivalent(expected_poly_offsets, polygon_columns.at(0)->view(), true);
-  expect_columns_equivalent(expected_ring_offsets, polygon_columns.at(1)->view(), true);
-  expect_columns_equivalent(expected_poly_point_xs, polygon_columns.at(2)->view(), true);
-  expect_columns_equivalent(expected_poly_point_ys, polygon_columns.at(3)->view(), true);
+  expect_columns_equivalent(expected_poly_offsets, polygon_columns.at(0)->view(), verbosity);
+  expect_columns_equivalent(expected_ring_offsets, polygon_columns.at(1)->view(), verbosity);
+  expect_columns_equivalent(expected_poly_point_xs, polygon_columns.at(2)->view(), verbosity);
+  expect_columns_equivalent(expected_poly_point_ys, polygon_columns.at(3)->view(), verbosity);
 }
 
 struct PolygonShapefileReaderTest : public BaseFixture {

--- a/cpp/tests/join/point_in_polygon_test_large.cpp
+++ b/cpp/tests/join/point_in_polygon_test_large.cpp
@@ -49,6 +49,8 @@
  * and popc. Thrust primitives to divide quadrants into sub-blocks are also tested.
  */
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 template <typename T>
 struct PIPRefineTestLarge : public cudf::test::BaseFixture {
 };
@@ -271,17 +273,17 @@ TYPED_TEST(PIPRefineTestLarge, TestLarge)
     fixed_width_column_wrapper<uint32_t>(expected_poly_indices.begin(),
                                          expected_poly_indices.end()),
     fixed_width_column_wrapper<uint32_t>(actual_poly_indices.begin(), actual_poly_indices.end()),
-    true);
+    verbosity);
 
   cudf::test::expect_columns_equal(
     fixed_width_column_wrapper<uint32_t>(expected_point_indices.begin(),
                                          expected_point_indices.end()),
     fixed_width_column_wrapper<uint32_t>(actual_point_indices.begin(), actual_point_indices.end()),
-    true);
+    verbosity);
 
   cudf::test::expect_columns_equal(
     fixed_width_column_wrapper<uint32_t>(expected_point_lengths.begin(),
                                          expected_point_lengths.end()),
     fixed_width_column_wrapper<uint32_t>(actual_point_lengths.begin(), actual_point_lengths.end()),
-    true);
+    verbosity);
 }

--- a/cpp/tests/spatial/coordinate_transform_test.cu
+++ b/cpp/tests/spatial/coordinate_transform_test.cu
@@ -27,6 +27,8 @@
 
 using namespace cudf::test;
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 template <typename T>
 struct LonLatToCartesianTest : public BaseFixture {
 };
@@ -48,8 +50,8 @@ TYPED_TEST(LonLatToCartesianTest, Single)
   auto expected_lon = fixed_width_column_wrapper<T>({-0.01126195531216838});
   auto expected_lat = fixed_width_column_wrapper<T>({-0.21375777777718794});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, Extremes)
@@ -66,8 +68,8 @@ TYPED_TEST(LonLatToCartesianTest, Extremes)
     fixed_width_column_wrapper<T>({0.0, 0.0, 20000.0, -20000.0, -5000.0, 14142.13562373095192015});
   auto expected_lat = fixed_width_column_wrapper<T>({10000.0, -10000.0, 0.0, 0.0, 0.0, 10000.0});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, Multiple)
@@ -85,8 +87,8 @@ TYPED_TEST(LonLatToCartesianTest, Multiple)
   auto expected_lat = fixed_width_column_wrapper<T>(
     {-0.21375777777718794, 0.05002000000015667, 0.06113111111163663, -0.20586888888847929});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, Empty)
@@ -102,8 +104,8 @@ TYPED_TEST(LonLatToCartesianTest, Empty)
   auto expected_lon = fixed_width_column_wrapper<T>({});
   auto expected_lat = fixed_width_column_wrapper<T>({});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, NullableNoNulls)
@@ -119,8 +121,8 @@ TYPED_TEST(LonLatToCartesianTest, NullableNoNulls)
   auto expected_lon = fixed_width_column_wrapper<T>({-0.01126195531216838});
   auto expected_lat = fixed_width_column_wrapper<T>({-0.21375777777718794});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, NullabilityMixedNoNulls)
@@ -136,8 +138,8 @@ TYPED_TEST(LonLatToCartesianTest, NullabilityMixedNoNulls)
   auto expected_lon = fixed_width_column_wrapper<T>({-0.01126195531216838});
   auto expected_lat = fixed_width_column_wrapper<T>({-0.21375777777718794});
 
-  expect_columns_equivalent(expected_lon, res_pair.first->view(), true);
-  expect_columns_equivalent(expected_lat, res_pair.second->view(), true);
+  expect_columns_equivalent(expected_lon, res_pair.first->view(), verbosity);
+  expect_columns_equivalent(expected_lat, res_pair.second->view(), verbosity);
 }
 
 TYPED_TEST(LonLatToCartesianTest, NullableWithNulls)

--- a/cpp/tests/spatial/hausdorff_test.cpp
+++ b/cpp/tests/spatial/hausdorff_test.cpp
@@ -32,6 +32,8 @@
 using namespace cudf;
 using namespace test;
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 template <typename T, uint32_t num_spaces, uint32_t elements_per_space>
 void generic_hausdorff_test(rmm::mr::device_memory_resource* mr)
 {
@@ -74,7 +76,7 @@ TYPED_TEST(HausdorffTest, Empty)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HausdorffTest, Simple)
@@ -89,7 +91,7 @@ TYPED_TEST(HausdorffTest, Simple)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HausdorffTest, SingleTrajectorySinglePoint)
@@ -104,7 +106,7 @@ TYPED_TEST(HausdorffTest, SingleTrajectorySinglePoint)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HausdorffTest, TwoShortSpaces)
@@ -119,7 +121,7 @@ TYPED_TEST(HausdorffTest, TwoShortSpaces)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HausdorffTest, TwoShortSpaces2)
@@ -142,7 +144,7 @@ TYPED_TEST(HausdorffTest, TwoShortSpaces2)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HausdorffTest, 500Spaces100Points)
@@ -208,5 +210,5 @@ TYPED_TEST(HausdorffTest, ThreeSpacesLengths543)
 
   auto actual = cuspatial::directed_hausdorff_distance(x, y, space_offsets, this->mr());
 
-  expect_columns_equivalent(expected, actual->view(), true);
+  expect_columns_equivalent(expected, actual->view(), verbosity);
 }

--- a/cpp/tests/spatial/haversine_test.cpp
+++ b/cpp/tests/spatial/haversine_test.cpp
@@ -29,6 +29,8 @@
 
 using namespace cudf::test;
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 template <typename T>
 struct HaversineTest : public BaseFixture {
 };
@@ -50,7 +52,7 @@ TYPED_TEST(HaversineTest, Empty)
 
   auto actual = cuspatial::haversine_distance(a_lon, a_lat, b_lon, b_lat);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HaversineTest, Zero)
@@ -66,7 +68,7 @@ TYPED_TEST(HaversineTest, Zero)
 
   auto actual = cuspatial::haversine_distance(a_lon, a_lat, b_lon, b_lat);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HaversineTest, EquivalentPoints)
@@ -82,7 +84,7 @@ TYPED_TEST(HaversineTest, EquivalentPoints)
 
   auto actual = cuspatial::haversine_distance(a_lon, a_lat, b_lon, b_lat);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(HaversineTest, MismatchSize)

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -38,6 +38,8 @@ struct PointInPolygonTest : public BaseFixture {
 using TestTypes = FloatingPointTypes;
 TYPED_TEST_CASE(PointInPolygonTest, TestTypes);
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 TYPED_TEST(PointInPolygonTest, Empty)
 {
   using T = TypeParam;
@@ -54,7 +56,7 @@ TYPED_TEST(PointInPolygonTest, Empty)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, OnePolygonOneRing)
@@ -73,7 +75,7 @@ TYPED_TEST(PointInPolygonTest, OnePolygonOneRing)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, TwoPolygonsOneRingEach)
@@ -92,7 +94,7 @@ TYPED_TEST(PointInPolygonTest, TwoPolygonsOneRingEach)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, OnePolygonTwoRings)
@@ -113,7 +115,7 @@ TYPED_TEST(PointInPolygonTest, OnePolygonTwoRings)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, EdgesOfSquare)
@@ -141,7 +143,7 @@ TYPED_TEST(PointInPolygonTest, EdgesOfSquare)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, CornersOfSquare)
@@ -169,7 +171,7 @@ TYPED_TEST(PointInPolygonTest, CornersOfSquare)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, 31PolygonSupport)
@@ -214,7 +216,7 @@ TYPED_TEST(PointInPolygonTest, 31PolygonSupport)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 template <typename T>
@@ -364,7 +366,7 @@ TYPED_TEST(PointInPolygonTest, SelfClosingLoopLeftEdgeMissing)
   auto expected      = wrapper<int32_t>({0b0, 0b1, 0b0});
   auto actual        = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }
 
 TYPED_TEST(PointInPolygonTest, SelfClosingLoopRightEdgeMissing)
@@ -380,5 +382,5 @@ TYPED_TEST(PointInPolygonTest, SelfClosingLoopRightEdgeMissing)
   auto expected      = wrapper<int32_t>({0b0, 0b1, 0b0});
   auto actual        = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
-  expect_columns_equal(expected, actual->view(), true);
+  expect_columns_equal(expected, actual->view(), verbosity);
 }

--- a/cpp/tests/spatial_window/spatial_window_test.cpp
+++ b/cpp/tests/spatial_window/spatial_window_test.cpp
@@ -27,6 +27,8 @@
 
 #include <type_traits>
 
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
+
 template <typename T>
 struct SpatialWindowTest : public cudf::test::BaseFixture {
 };
@@ -49,8 +51,8 @@ TYPED_TEST(SpatialWindowTest, SimpleTest)
 
   auto result = cuspatial::points_in_spatial_window(1.5, 5.5, 1.5, 5.5, points_x, points_y);
 
-  cudf::test::expect_columns_equivalent(result->get_column(0), expected_points_x, true);
-  cudf::test::expect_columns_equivalent(result->get_column(1), expected_points_y, true);
+  cudf::test::expect_columns_equivalent(result->get_column(0), expected_points_x, verbosity);
+  cudf::test::expect_columns_equivalent(result->get_column(1), expected_points_y, verbosity);
 }
 
 // Test that windows with min/max reversed still work
@@ -68,8 +70,8 @@ TYPED_TEST(SpatialWindowTest, ReversedWindow)
 
   auto result = cuspatial::points_in_spatial_window(5.5, 1.5, 5.5, 1.5, points_x, points_y);
 
-  cudf::test::expect_columns_equivalent(result->get_column(0), expected_points_x, true);
-  cudf::test::expect_columns_equivalent(result->get_column(1), expected_points_y, true);
+  cudf::test::expect_columns_equivalent(result->get_column(0), expected_points_x, verbosity);
+  cudf::test::expect_columns_equivalent(result->get_column(1), expected_points_y, verbosity);
 }
 
 struct SpatialWindowErrorTest : public cudf::test::BaseFixture {


### PR DESCRIPTION
<!--

Thank you for contributing to cuSpatial :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
rapidsai/cudf#8666 modified `cudf::test` APIs to accept a verbosity enum as a parameter to control output, which is backwards incompatible with the previously boolean parameter.