### PR TITLE
FIX Sync version update script with CMakeLists and update version in …

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -30,7 +30,7 @@ function sed_runner() {
 }
 
 # cpp update
-sed_runner 's/'"CUDA_SPATIAL VERSION .* LANGUAGES"'/'"CUDA_SPATIAL VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"CUSPATIAL VERSION .* LANGUAGES"'/'"CUSPATIAL VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
 
 # RTD update
 sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
   set(CUSPATIAL_BUILD_FOR_DETECTED_ARCHS TRUE)
 endif()
 
-project(CUSPATIAL VERSION 21.08.00 LANGUAGES C CXX)
+project(CUSPATIAL VERSION 21.10.00 LANGUAGES C CXX)
 
 # Needed because GoogleBenchmark changes the state of FindThreads.cmake,
 # causing subsequent runs to have different values for the `Threads::Threads` target.

--- a/python/cuspatial/setup.py
+++ b/python/cuspatial/setup.py
@@ -57,7 +57,7 @@ extensions = [
         library_dirs=[get_python_lib()],
         libraries=["cudf", "cuspatial"],
         language="c++",
-        extra_compile_args=["-std=c++14"],
+        extra_compile_args=["-std=c++17"],
     )
 ]
 


### PR DESCRIPTION
Updates the `update-version.sh` release script to match the naming convention used in CMakeLists, also updates the value manually since this should've been done on new branch creation.

This should fix the issue where `cuspatial` will attempt to find `cudf 21.08` instead of `cudf 21.10`.