### PR TITLE
cuspatial installed CMake files use the same destination as libcuspatial

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -225,7 +225,7 @@ endif()
 
 include(GNUInstallDirs)
 
-set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/cuspatial)
+set(INSTALL_CONFIGDIR lib/cmake/cuspatial)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME cuspatial)
 
 install(TARGETS cuspatial


### PR DESCRIPTION
Previously on CentOS machines the CMake files would be placed into `lib64`, and `libcuspatial` would be in `lib` breaking everything. Since Conda only supports packages in `lib` ensure everything is placed there no matter
the distro.
