### PR TITLE
Update `conda` recipes for Enhanced Compatibility effort

### DIFF
--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 package:
   name: libcuspatial
@@ -13,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -40,7 +41,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
     - gdal >=3.3.0,<3.4.0a0
   run:
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 
 test:
   commands:


### PR DESCRIPTION
This PR updates the `conda` recipe build strings and `cudatoolkit` version specifications as part of the Enhanced Compatibility efforts.

The build strings have been updated to only include the major CUDA version (i.e. `librmm-21.12.00a-cuda11_gc781527_12.tar.bz2`) and the `cudatoolkit` version specifications will now be formatted like `cudatoolkit >=x,<y.0a0` (i.e. `cudatoolkit >=11,<12.0a0`).

Moving forward, we'll build the packages with a single CUDA version (i.e. `11.4`) and test them in environments with different CUDA versions (i.e. `11.0`, `11.2`, `11.4`, etc.).
