### PR TITLE
Update DEFAULT_CUDA_VER in ci/cpu/prebuild.sh

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 
-ARCH=$(arch)
-if [ "${ARCH}" = "x86_64" ]; then
-  DEFAULT_CUDA_VER="11.0"
-elif [ "${ARCH}" = "aarch64" ]; then
-  DEFAULT_CUDA_VER="11.2"
-else
-  echo "Unsupported arch ${ARCH}"
-  exit 1
-fi
+DEFAULT_CUDA_VER="11.5"
 
 #Upload cuspatial once per PYTHON
 if [[ "$CUDA" == "${DEFAULT_CUDA_VER}" ]]; then


### PR DESCRIPTION
Now that we only do `11.5` builds for RAPIDS, the `DEFAULT_CUDA_VER` variable in `ci/cpu/prebuild.sh` should be set to `11.5` so that the rest of the logic in the file works correctly.