### PR TITLE
Remove `IncludeCategories` from `.clang-format`

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -72,15 +72,6 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None

--- a/cpp/src/io/shp/polygon_shapefile_reader.cpp
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cuspatial/error.hpp>
+
 #include <ogrsf_frmts.h>
 
 #include <cudf/types.hpp>

--- a/cpp/src/io/shp/polygon_shapefile_reader.cpp
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <ogrsf_frmts.h>
 #include <cuspatial/error.hpp>
+#include <ogrsf_frmts.h>
 
 #include <cudf/types.hpp>
 

--- a/cpp/tests/interpolate/cubic_spline_test.cpp
+++ b/cpp/tests/interpolate/cubic_spline_test.cpp
@@ -28,9 +28,9 @@
 #include <cuspatial/detail/cubic_spline.hpp>
 #include <cuspatial/error.hpp>
 
+#include <string>
 #include <sys/time.h>
 #include <time.h>
-#include <string>
 
 struct CubicSplineTest : public cudf::test::BaseFixture {
 };


### PR DESCRIPTION
It was recently noticed that the `IncludeCategories`:
```
IncludeCategories:
  - Regex:           '^<ext/.*\.h>'
    Priority:        2
  - Regex:           '^<.*\.h>'
    Priority:        1
  - Regex:           '^<.*'
    Priority:        2
  - Regex:           '.*'
    Priority:        3
```
In the `.clang-format` are not really necessary as `ext` has no meaning in RAPIDS. This PR removes these.

Note these changes are being made in all repos:
* `cudf`: https://github.com/rapidsai/cudf/pull/9876
* `rmm`: https://github.com/rapidsai/rmm/pull/933
* `cuml`: https://github.com/rapidsai/cuml/pull/4438
* `cugraph`: https://github.com/rapidsai/cugraph/pull/1987