### PR TITLE
Remove use of libcudf's CUDA_HOST_DEVICE macro

### DIFF
--- a/cpp/src/spatial/lonlat_to_cartesian.cu
+++ b/cpp/src/spatial/lonlat_to_cartesian.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cuspatial/error.hpp>
+#include <cuspatial/types.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>
@@ -35,17 +36,14 @@ constexpr double earth_circumference_km            = 40000.0;
 constexpr double earth_circumference_km_per_degree = earth_circumference_km / 360.0;
 constexpr double deg_to_rad                        = M_PI / 180;
 
-CUDA_HOST_DEVICE_CALLABLE
-double midpoint(double a, double b) { return (a + b) / 2; }
+__device__ inline double midpoint(double a, double b) { return (a + b) / 2; }
 
-CUDA_HOST_DEVICE_CALLABLE
-double lon_to_x(double lon, double lat)
+__device__ inline double lon_to_x(double lon, double lat)
 {
   return lon * earth_circumference_km_per_degree * cos(lat * deg_to_rad);
 };
 
-CUDA_HOST_DEVICE_CALLABLE
-double lat_to_y(double lat) { return lat * earth_circumference_km_per_degree; };
+__device__ inline double lat_to_y(double lat) { return lat * earth_circumference_km_per_degree; };
 
 struct lonlat_to_cartesian_functor {
   template <typename T, typename... Args>

--- a/cpp/src/spatial/lonlat_to_cartesian.cu
+++ b/cpp/src/spatial/lonlat_to_cartesian.cu
@@ -15,7 +15,6 @@
  */
 
 #include <cuspatial/error.hpp>
-#include <cuspatial/types.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_device_view.cuh>


### PR DESCRIPTION
One file in libcuspatial used `CUDA_HOST_DEVICE` from cudf/types.hpp instead of just `__device__ inline`, which is all it needed.  rapidsai/cudf#9797 changed the name of the macro, which broke the build.

This trivial PR fixes it and removes that particular unnecessary dependency.