### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## 🐛 Bug Fixes
 
-- Always upload cuspatial packages ([#481](https://github.com/rapidsai/cuspatial/pull/481)) [@aydouglass](https://github.com/aydouglass)
-- Remove use of libcudf&#39;s CUDA_HOST_DEVICE maco ([#475](https://github.com/rapidsai/cuspatial/pull/475)) [@haism](https://github.com/haism)
+- Always upload cuspatial packages ([#481](https://github.com/rapidsai/cuspatial/pull/481)) [@raydouglass](https://github.com/raydouglass)
+- Remove use of libcudf&#39;s CUDA_HOST_DEVICE macro ([#475](https://github.com/rapidsai/cuspatial/pull/475)) [@harrism](https://github.com/harrism)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Pepae upload scipts fo Python 3.7 emoval ([#479](https://github.com/rapidsai/cuspatial/pull/479)) [@Ethyling](https://github.com/Ethyling)
-- Fix `test_pip_bitmap_column_to_binay_aay` test ([#472](https://github.com/rapidsai/cuspatial/pull/472)) [@Ethyling](https://github.com/Ethyling)
-- Fix impots tests syntax ([#471](https://github.com/rapidsai/cuspatial/pull/471)) [@Ethyling](https://github.com/Ethyling)
-- Remove `IncludeCategoies` fom `.clang-fomat` ([#470](https://github.com/rapidsai/cuspatial/pull/470)) [@codeepot](https://github.com/codeepot)
-- Fix Fowad-Mege Conflicts in #464 ([#466](https://github.com/rapidsai/cuspatial/pull/466)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Prepare upload scripts for Python 3.7 removal ([#479](https://github.com/rapidsai/cuspatial/pull/479)) [@Ethyling](https://github.com/Ethyling)
+- Fix `test_pip_bitmap_column_to_binary_array` test ([#472](https://github.com/rapidsai/cuspatial/pull/472)) [@Ethyling](https://github.com/Ethyling)
+- Fix imports tests syntax ([#471](https://github.com/rapidsai/cuspatial/pull/471)) [@Ethyling](https://github.com/Ethyling)
+- Remove `IncludeCategories` from `.clang-format` ([#470](https://github.com/rapidsai/cuspatial/pull/470)) [@codereport](https://github.com/codereport)
+- Fix Forward-Merge Conflicts in #464 ([#466](https://github.com/rapidsai/cuspatial/pull/466)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # cuSpatial 21.12.00 (9 Dec 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-# cuSpatial 22.02.00 (Date TBD)
+# cuSpatial 22.02.00 (2 Feb 2022)
 
-Please see https://github.com/rapidsai/cuspatial/releases/tag/v22.02.00a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Always upload cuspatial packages ([#481](https://github.com/rapidsai/cuspatial/pull/481)) [@aydouglass](https://github.com/aydouglass)
+- Remove use of libcudf&#39;s CUDA_HOST_DEVICE maco ([#475](https://github.com/rapidsai/cuspatial/pull/475)) [@haism](https://github.com/haism)
+
+## 🛠️ Impovements
+
+- Pepae upload scipts fo Python 3.7 emoval ([#479](https://github.com/rapidsai/cuspatial/pull/479)) [@Ethyling](https://github.com/Ethyling)
+- Fix `test_pip_bitmap_column_to_binay_aay` test ([#472](https://github.com/rapidsai/cuspatial/pull/472)) [@Ethyling](https://github.com/Ethyling)
+- Fix impots tests syntax ([#471](https://github.com/rapidsai/cuspatial/pull/471)) [@Ethyling](https://github.com/Ethyling)
+- Remove `IncludeCategoies` fom `.clang-fomat` ([#470](https://github.com/rapidsai/cuspatial/pull/470)) [@codeepot](https://github.com/codeepot)
+- Fix Fowad-Mege Conflicts in #464 ([#466](https://github.com/rapidsai/cuspatial/pull/466)) [@ajschmidt8](https://github.com/ajschmidt8)
 
 # cuSpatial 21.12.00 (9 Dec 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.