### PR TITLE
Add CMake `install` rule for tests

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -40,8 +40,16 @@ target_include_directories(cuspatial_benchmark_common
 function(ConfigureBench CMAKE_BENCH_NAME)
     add_executable(${CMAKE_BENCH_NAME} ${ARGN})
     set_target_properties(${CMAKE_BENCH_NAME}
-        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/gbenchmarks>")
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/gbenchmarks>"
+                   INSTALL_RPATH "\$ORIGIN/../../../lib"
+        )
     target_link_libraries(${CMAKE_BENCH_NAME} PRIVATE benchmark::benchmark_main cuspatial_benchmark_common)
+    install(
+        TARGETS ${CMAKE_BENCH_NAME}
+        COMPONENT testing
+        DESTINATION bin/benchmarks/libcuspatial
+        EXCLUDE_FROM_ALL
+    )
 endfunction(ConfigureBench)
 
 ###################################################################################################

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,17 +25,25 @@ function(ConfigureTest CMAKE_TEST_NAME)
     target_include_directories(${CMAKE_TEST_NAME}
                 PRIVATE "$<BUILD_INTERFACE:${CUSPATIAL_SOURCE_DIR}>"
                         "$<BUILD_INTERFACE:${CUSPATIAL_SOURCE_DIR}/src>")
-    set_target_properties(${CMAKE_TEST_NAME}
-        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/gtests>")
+    set_target_properties(
+        ${CMAKE_TEST_NAME}
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/gtests>"
+                   INSTALL_RPATH "\$ORIGIN/../lib"
+    )
     target_link_libraries(${CMAKE_TEST_NAME} GTest::gtest_main GTest::gmock_main cudf::cudftestutil cuspatial)
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
+    install(
+        TARGETS ${CMAKE_TEST_NAME}
+        COMPONENT testing
+        EXCLUDE_FROM_ALL
+    )
 endfunction(ConfigureTest)
 
 ###################################################################################################
 ### test sources ##################################################################################
 ###################################################################################################
 
- ConfigureTest(CUBIC_SPLINE_TEST
+ConfigureTest(CUBIC_SPLINE_TEST
     interpolate/cubic_spline_test.cpp)
 
 ConfigureTest(COORDINATE_TRANSFORM_TEST

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -28,13 +28,14 @@ function(ConfigureTest CMAKE_TEST_NAME)
     set_target_properties(
         ${CMAKE_TEST_NAME}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/gtests>"
-                   INSTALL_RPATH "\$ORIGIN/../lib"
+                   INSTALL_RPATH "\$ORIGIN/../../../lib"
     )
     target_link_libraries(${CMAKE_TEST_NAME} GTest::gtest_main GTest::gmock_main cudf::cudftestutil cuspatial)
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
     install(
         TARGETS ${CMAKE_TEST_NAME}
         COMPONENT testing
+        DESTINATION bin/gtests/libcuspatial
         EXCLUDE_FROM_ALL
     )
 endfunction(ConfigureTest)


### PR DESCRIPTION
This PR adds a CMake `install` rule for test targets. This step is a prerequisite to being able to package tests in their own `conda` package, which will enable us to deprecate _Project Flash_.