### PR TITLE
Update `libcuspatial` recipe to output `libcuspatial_tests` package

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -39,10 +39,6 @@ fi
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -28,9 +28,6 @@ cd "$WORKSPACE"
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
 
 ################################################################################
 # SETUP - Check environment


### PR DESCRIPTION
This PR updates the `libcuspatial` recipe to include a new output, `libcuspatial_tests`. `libcuspatial_tests` is a `conda` package that includes all of the binaries for `libcuspatial`'s tests and benchmarks. This PR is a prerequisite for deprecating Project Flash.

This also updates the CI scripts to use the new package for tests.