### PR TITLE
Use conda compilers

### DIFF
--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -1,0 +1,8 @@
+c_compiler_version:
+  - 9
+
+cxx_compiler_version:
+  - 9
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -16,11 +16,13 @@ build:
   string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
   host:
     - python
     - cython >=0.29,<0.30

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -1,3 +1,12 @@
+c_compiler_version:
+  - 9
+
+cxx_compiler_version:
+  - 9
+
+cuda_compiler:
+  - nvcc
+
 cmake_version:
   - ">=3.20.1"
 
@@ -6,3 +15,6 @@ gdal_version:
 
 gtest_version:
   - "1.10.0"
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -14,9 +14,6 @@ source:
 
 build:
   script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
     - PARALLEL_LEVEL
     - VERSION_SUFFIX
     - PROJECT_FLASH
@@ -33,6 +30,11 @@ build:
 requirements:
   build:
     - cmake {{ cmake_version }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }} {{ cuda_version }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
   host:
     - libcudf {{ minor_version }}.*
     - librmm {{ minor_version }}.*
@@ -48,6 +50,9 @@ outputs:
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       run_exports:
         - {{ pin_subpackage("libcuspatial", max_pin="x.x") }}
+      ignore_run_exports_from:
+        - nvcc_linux-64 # [linux64]
+        - nvcc_linux-aarch64 # [aarch64]
     requirements:
       build:
         - cmake {{ cmake_version }}
@@ -70,6 +75,9 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      ignore_run_exports_from:
+        - nvcc_linux-64 # [linux64]
+        - nvcc_linux-aarch64 # [aarch64]
     requirements:
       build:
         - cmake {{ cmake_version }}


### PR DESCRIPTION
This PR enables the usage of conda compilers to build conda packages. This is required to use `mambabuild`