### PR TITLE
Improve point_in_polygon documentation regarding poly_ring_offsets

### DIFF
--- a/cpp/include/cuspatial/point_in_polygon.hpp
+++ b/cpp/include/cuspatial/point_in_polygon.hpp
@@ -47,6 +47,9 @@ namespace cuspatial {
  * defined by the format), and does _not_ verify whether the input adheres to the shapefile format.
  * @note Overlapping rings negate each other. This behavior is not limited to a single negation,
  * allowing for "islands" within the same polygon.
+ * @note `poly_ring_offsets` must contain only the rings that make up the polygons indexed by
+ * `poly_offsets`. If there are rings in `poly_ring_offsets` that are not part of the polygons in
+ * `poly_offsets`, results are likely to be incorrect and behavior is undefined.
  *
  *   poly w/two rings         poly w/four rings
  * +-----------+          +------------------------+

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -217,9 +217,9 @@ def point_in_polygon(
 
     note
     poly_ring_offsets must contain only the rings that make up the polygons
-    indexed by poly_offsets. If there are rings in poly_ring_offsets that are not
-    part of the polygons in poly_offsets, results are likely to be incorrect and
-    behavior is undefined.
+    indexed by poly_offsets. If there are rings in poly_ring_offsets that
+    are not part of the polygons in poly_offsets, results are likely to be
+    incorrect and behavior is undefined.
 
     Returns
     -------

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -215,6 +215,11 @@ def point_in_polygon(
     input Series x and y will not be index aligned, but computed as
     sequential arrays.
 
+    note
+    poly_ring_offsets must contain only the rings that make up the polygons indexed by 
+    poly_offsets. If there are rings in poly_ring_offsets that are not part of the polygons in
+    poly_offsets, results are likely to be incorrect and behavior is undefined.
+
     Returns
     -------
     result : cudf.DataFrame

--- a/python/cuspatial/cuspatial/core/gis.py
+++ b/python/cuspatial/cuspatial/core/gis.py
@@ -216,9 +216,10 @@ def point_in_polygon(
     sequential arrays.
 
     note
-    poly_ring_offsets must contain only the rings that make up the polygons indexed by 
-    poly_offsets. If there are rings in poly_ring_offsets that are not part of the polygons in
-    poly_offsets, results are likely to be incorrect and behavior is undefined.
+    poly_ring_offsets must contain only the rings that make up the polygons
+    indexed by poly_offsets. If there are rings in poly_ring_offsets that are not
+    part of the polygons in poly_offsets, results are likely to be incorrect and
+    behavior is undefined.
 
     Returns
     -------


### PR DESCRIPTION
Partially addresses #492.

Adds notes to the Python and C++ documentation explaining that behavior is undefined if there are rings in `poly_ring_offsets` that are not referenced by `poly_offsets`