### PR TITLE
Add libcuspatial-tests package

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -39,10 +39,6 @@ fi
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -22,29 +22,19 @@ if [ -z "$MY_UPLOAD_KEY" ]; then
 fi
 
 ################################################################################
-# SETUP - Get conda file output locations
-################################################################################
-
-gpuci_logger "Get conda file output locations"
-export LIBCUSPATIAL_FILE=`conda build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcuspatial  --output`
-export CUSPATIAL_FILE=`conda build --croot ${CONDA_BLD_DIR} conda/recipes/cuspatial --python=$PYTHON --output`
-
-################################################################################
 # UPLOAD - Conda packages
 ################################################################################
 
 gpuci_logger "Starting conda uploads"
 
 if [[ "$BUILD_LIBCUSPATIAL" == "1" && "$UPLOAD_LIBCUSPATIAL" == "1" ]]; then
-  LABEL_OPTION="--label main"
-  echo "LABEL_OPTION=${LABEL_OPTION}"
-  test -e ${LIBCUSPATIAL_FILE}
+  LIBCUSPATIAL_FILES=$(conda build --no-build-id --croot ${CONDA_BLD_DIR} conda/recipes/libcuspatial --output)
   echo "Upload libcuspatial"
-  echo ${LIBCUSPATIAL_FILE}
-  gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${LIBCUSPATIAL_FILE} --no-progress
+  gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing --no-progress ${LIBCUSPATIAL_FILES}
 fi
 
 if [[ "$BUILD_CUSPATIAL" == "1" && "$UPLOAD_CUSPATIAL" == "1" ]]; then
+  CUSPATIAL_FILE=$(conda build --croot ${CONDA_BLD_DIR} conda/recipes/cuspatial --python=$PYTHON --output)
   LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
   test -e ${CUSPATIAL_FILE}

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -21,7 +21,7 @@ build:
     - CUDAHOSTCXX
 
 requirements:
-  build:
+  host:
     - python
     - cython >=0.29,<0.30
     - setuptools

--- a/conda/recipes/libcuspatial/build.sh
+++ b/conda/recipes/libcuspatial/build.sh
@@ -1,8 +1,4 @@
-# Copyright (c) 2018-2019, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 # build cuspatial with verbose output
-if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-    ./build.sh -v libcuspatial --allgpuarch
-else
-    ./build.sh -v libcuspatial tests --allgpuarch
-fi
+./build.sh -v libcuspatial tests --allgpuarch -n

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -1,0 +1,8 @@
+cmake_version:
+  - ">=3.20.1"
+
+gdal_version:
+  - ">=3.3.0,<3.4.0a0"
+
+gtest_version:
+  - "1.10.0"

--- a/conda/recipes/libcuspatial/install_libcuspatial.sh
+++ b/conda/recipes/libcuspatial/install_libcuspatial.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copyright (c) 2022, NVIDIA CORPORATION.
+
+cmake --install cpp/build

--- a/conda/recipes/libcuspatial/install_libcuspatial_tests.sh
+++ b/conda/recipes/libcuspatial/install_libcuspatial_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copyright (c) 2022, NVIDIA CORPORATION.
+
+cmake --install cpp/build --component testing

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -1,20 +1,18 @@
 # Copyright (c) 2018, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
-{% set minor_version =  version.split('.')[0] + '.' + version.split('.')[1] %}
-{% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
+{% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set cuda_version = '.'.join(environ.get('CUDA', '11.5').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
+{% set cuda_spec = ">=" + cuda_major ~ ",<" + (cuda_major | int + 1) ~ ".0a0" %} # i.e. >=11,<12.0a0
 
 package:
-  name: libcuspatial
-  version: {{ version }}
+  name: libcuspatial-split
 
 source:
   git_url: ../../..
 
 build:
-  number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -31,27 +29,50 @@ build:
     - SCCACHE_BUCKET=rapids-sccache
     - SCCACHE_REGION=us-west-2
     - SCCACHE_IDLE_TIMEOUT=32768
-  run_exports:
-    - {{ pin_subpackage("libcuspatial", max_pin="x.x") }}
 
 requirements:
   build:
-    - cmake >=3.20.1
+    - cmake {{ cmake_version }}
   host:
     - libcudf {{ minor_version }}.*
     - librmm {{ minor_version }}.*
     - cudatoolkit {{ cuda_version }}.*
-    - gdal >=3.3.0,<3.4.0a0
-  run:
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - gdal {{ gdal_version }}
 
-test:
-  commands:
-    - test -f $PREFIX/lib/libcuspatial.so
-
-about:
-  home: http://rapids.ai/
-  license: Apache-2.0
-  license_family: Apache
-  license_file: LICENSE
-  summary: libcuspatial library
+outputs:
+  - name: libcuspatial
+    version: {{ version }}
+    script: install_libcuspatial.sh
+    build:
+      number: {{ GIT_DESCRIBE_NUMBER }}
+      string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      run_exports:
+        - {{ pin_subpackage("libcuspatial", max_pin="x.x") }}
+    requirements:
+      build:
+        - cmake {{ cmake_version }}
+      run:
+        - cudatoolkit {{ cuda_spec }}
+    test:
+      commands:
+        - test -f $PREFIX/lib/libcuspatial.so
+    about:
+      home: http://rapids.ai/
+      license: Apache-2.0
+      license_family: Apache
+      license_file: LICENSE
+      summary: libcuspatial library
+  - name: libcuspatial-tests
+    version: {{ version }}
+    script: install_libcuspatial_tests.sh
+    build:
+      number: {{ GIT_DESCRIBE_NUMBER }}
+      string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    requirements:
+      build:
+        - cmake {{ cmake_version }}
+      run:
+        - cudatoolkit {{ cuda_spec }}
+        - gmock {{ gtest_version }}
+        - gtest {{ gtest_version }}
+        - {{ pin_subpackage('libcuspatial', exact=True) }}


### PR DESCRIPTION
Add a `libcuspatial-tests` package to the `libcuspatial` recipe:
- This is a prerequisite for removing "Project Flash" from our build/CI scripts.
- The `libcuspatial-tests` package was added as an additional output to the existing `libcuspatial` recipe (which was renamed to `libcuspatial-split`)

