### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/environments/cuspatial_dev_cuda11.0.yml
+++ b/conda/environments/cuspatial_dev_cuda11.0.yml
@@ -13,5 +13,5 @@ dependencies:
   - geopandas>=0.9.0,<0.10.0a0
   - cmake>=3.20.1
   - cython>=0.29,<0.30
-  - gtest
-  - gmock
+  - gtest=1.10.0
+  - gmock=1.10.0

--- a/conda/environments/cuspatial_dev_cuda11.1.yml
+++ b/conda/environments/cuspatial_dev_cuda11.1.yml
@@ -13,5 +13,5 @@ dependencies:
   - geopandas>=0.9.0,<0.10.0a0
   - cmake>=3.20.1
   - cython>=0.29,<0.30
-  - gtest
-  - gmock
+  - gtest=1.10.0
+  - gmock=1.10.0

--- a/conda/environments/cuspatial_dev_cuda11.2.yml
+++ b/conda/environments/cuspatial_dev_cuda11.2.yml
@@ -13,5 +13,5 @@ dependencies:
   - geopandas>=0.9.0,<0.10.0a0
   - cmake>=3.20.1
   - cython>=0.29,<0.30
-  - gtest
-  - gmock
+  - gtest=1.10.0
+  - gmock=1.10.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.