### PR TITLE
Add clang-format to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,5 +26,19 @@ repos:
                 name: flake8-cython
                 args: ["--config=python/cuspatial/.flake8.cython"]
                 types: [cython]
+      - repo: local
+        hooks:
+              - id: clang-format
+                # Using the pre-commit stage to simplify invocation of all
+                # other hooks simultaneously (via any other hook stage).  This
+                # can be removed if we also move to running clang-format
+                # entirely through pre-commit.
+                stages: [commit]
+                name: clang-format
+                description: Format files with ClangFormat.
+                entry: clang-format -i
+                language: system
+                files: \.(cu|cuh|h|hpp|cpp|inl)$
+                args: ['-fallback-style=none']
 default_language_version:
       python: python3


### PR DESCRIPTION
This PR adds clang format to pre-commit hook.

closes #503 