### PR TITLE
Use conda to build python packages during GPU tests

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -27,6 +27,7 @@ export HOME="$WORKSPACE"
 cd "$WORKSPACE"
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
+unset GIT_DESCRIBE_TAG
 
 ################################################################################
 # SETUP - Check environment
@@ -41,12 +42,6 @@ nvidia-smi
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
-gpuci_mamba_retry install "cudf=${MINOR_VERSION}.*" "cudatoolkit=$CUDA_REL" \
-    "rapids-build-env=$MINOR_VERSION.*"
-
-# https://docs.rapids.ai/maintainers/depmgmt/
-# gpuci_mamba_retry remove --force rapids-build-env
-# gpuci_mamba_retry install "your-pkg=1.0.0"
 
 gpuci_logger "Check versions"
 python --version
@@ -66,11 +61,19 @@ gpuci_logger "Clone cudf"
 git clone https://github.com/rapidsai/cudf.git -b branch-$MINOR_VERSION ${CUDF_HOME}
 cd $CUDF_HOME
 git submodule update --init --remote --recursive
+cd "${WORKSPACE}"
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
     # BUILD - Build libcuspatial and cuSpatial from source
     ################################################################################
+    gpuci_mamba_retry install "cudf=${MINOR_VERSION}.*" \
+        "cudatoolkit=$CUDA_REL" \
+        "rapids-build-env=$MINOR_VERSION.*"
+
+    # https://docs.rapids.ai/maintainers/depmgmt/
+    # gpuci_mamba_retry remove --force rapids-build-env
+    # gpuci_mamba_retry install "your-pkg=1.0.0"
 
     gpuci_logger "Build cuSpatial"
     cd "$WORKSPACE"
@@ -113,7 +116,14 @@ else
     gpuci_logger "Check GPU usage"
     nvidia-smi
 
+    gpuci_logger "Installing libcuspatial and libcuspatial-tests"
     gpuci_mamba_retry install -c "${CONDA_ARTIFACT_PATH}" libcuspatial libcuspatial-tests
+
+    gpuci_logger "Building and installing cuspatial"
+    export CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
+    export VERSION_SUFFIX=""
+    gpuci_conda_retry build --croot "${CONDA_BLD_DIR}" -c "${CONDA_ARTIFACT_PATH}" -c "${CONDA_BLD_DIR}" conda/recipes/cuspatial
+    gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" -c "${CONDA_ARTIFACT_PATH}" cuspatial
 
     gpuci_logger "Running googletests"
     for gt in "${CONDA_PREFIX}/bin/gtests/libcuspatial/"*; do
@@ -127,12 +137,8 @@ else
         fi
     done
 
-    cd "$WORKSPACE/python"
-
-    gpuci_logger "Building cuspatial"
-    "$WORKSPACE/build.sh" -v cuspatial
-
     gpuci_logger "Run pytests"
+    cd "$WORKSPACE/python/cuspatial/cuspatial"
     py.test --cache-clear --junitxml="$WORKSPACE/junit-cuspatial.xml" -v
 
     EXITCODE=$?


### PR DESCRIPTION
This PR convert the `from sources` build we are doing in GPU test job to a `conda build`. This is done for the following reasons:
- This is required step to improve the Ops CI/CD setup to a more convenient pipeline
- This is required to start using `conda` compilers and `mamba` to build RAPIDS packages
- This prevent us from manually managing and installing the dependencies in GPU job
- This ensure the packages can be installed
- This ensure the tests are running and working against the package content and not the build results. Currently the Python packages are not tested.

This may increase the global pipeline time, but the usage of `mamba` should resolve this as `mamba` is faster than `conda` to build packages