### PR TITLE
Fix various issues with CMake exports

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -94,6 +94,7 @@ include(cmake/Modules/ConfigureCUDA.cmake)
 # find gdal
 rapids_find_package(
     GDAL REQUIRED
+    GLOBAL_TARGETS GDAL::GDAL
     BUILD_EXPORT_SET cuspatial-exports
     INSTALL_EXPORT_SET cuspatial-exports
 )

--- a/cpp/cmake/thirdparty/CUSPATIAL_GetCUDF.cmake
+++ b/cpp/cmake/thirdparty/CUSPATIAL_GetCUDF.cmake
@@ -29,6 +29,8 @@ function(find_and_configure_cudf VERSION)
     rapids_cpm_find(
       cudf ${VERSION}
       GLOBAL_TARGETS cudf::cudf cudf::cudftestutil
+      BUILD_EXPORT_SET cuspatial-exports
+      INSTALL_EXPORT_SET cuspatial-exports
       CPM_ARGS
       GIT_REPOSITORY https://github.com/rapidsai/cudf.git
       GIT_TAG branch-${MAJOR_AND_MINOR}

--- a/cpp/cmake/thirdparty/CUSPATIAL_GetCUDF.cmake
+++ b/cpp/cmake/thirdparty/CUSPATIAL_GetCUDF.cmake
@@ -26,9 +26,16 @@ function(find_and_configure_cudf VERSION)
         set(MAJOR_AND_MINOR "${VERSION}")
     endif()
 
+    set(global_targets cudf::cudf)
+    set(find_package_args "")
+    if(BUILD_TESTS)
+      list(APPEND global_targets cudf::cudftestutil)
+      set(find_package_args "COMPONENTS testing")
+    endif()
+
     rapids_cpm_find(
       cudf ${VERSION}
-      GLOBAL_TARGETS cudf::cudf cudf::cudftestutil
+      GLOBAL_TARGETS "${global_targets}"
       BUILD_EXPORT_SET cuspatial-exports
       INSTALL_EXPORT_SET cuspatial-exports
       CPM_ARGS
@@ -36,7 +43,7 @@ function(find_and_configure_cudf VERSION)
       GIT_TAG branch-${MAJOR_AND_MINOR}
       GIT_SHALLOW TRUE
       OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
-      FIND_PACKAGE_ARGUMENTS "COMPONENTS testing"
+      FIND_PACKAGE_ARGUMENTS "${find_package_args}"
     )
 endfunction()
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuSpatial :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR contains three fixes to how libcuspatial handles dependencies to enable its inclusion into other projects:
1. GDAL is now exported as a global target so that consumers automatically see the library in addition to inheriting the dependency.
2. cudf is now part of the build and export set for libcuspatial so that consumers can inherit the dependency.
3. cudftestutil is included in the export set and exported as a global target iff cuspatial is being built with tests. This change ensures that when tests are not being built cuspatial can be built against a libcudf that also does not have tests built.