### PR TITLE
Change build.sh to find C++ library by default and avoid shadowing CMAKE_ARGS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -116,9 +116,9 @@ if hasArg tests; then
 fi
 
 # Append `-DFIND_CUSPATIAL_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-#if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
-#    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
-#fi
+if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
+fi
 
 # If clean given, run it prior to any other steps
 if hasArg clean; then

--- a/build.sh
+++ b/build.sh
@@ -115,6 +115,11 @@ if hasArg tests; then
     BUILD_TESTS=ON
 fi
 
+# Append `-DFIND_CUSPATIAL_CPP=ON` to CMAKE_ARGS unless a user specified the option.
+if [[ ${CMAKE_ARGS} != *"DFIND_CUSPATIAL_CPP"* ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
+fi
+
 # If clean given, run it prior to any other steps
 if hasArg clean; then
     # If the dirs to clean are mounted dirs in a container, the

--- a/build.sh
+++ b/build.sh
@@ -68,12 +68,12 @@ function cmakeArgs {
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error
-        CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
-        if [[ -n ${CMAKE_ARGS} ]]; then
-            # Remove the full  CMAKE_ARGS argument from list of args so that it passes validArgs function
-            ARGS=${ARGS//$CMAKE_ARGS/}
+        EXTRA_CMAKE_ARGS=$(echo $ARGS | { grep -Eo "\-\-cmake\-args=\".+\"" || true; })
+        if [[ -n ${EXTRA_CMAKE_ARGS} ]]; then
+            # Remove the full  EXTRA_CMAKE_ARGS argument from list of args so that it passes validArgs function
+            ARGS=${ARGS//$EXTRA_CMAKE_ARGS/}
             # Filter the full argument down to just the extra string that will be added to cmake call
-            CMAKE_ARGS=$(echo $CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
+            EXTRA_CMAKE_ARGS=$(echo $EXTRA_CMAKE_ARGS | grep -Eo "\".+\"" | sed -e 's/^"//' -e 's/"$//')
         fi
     fi
 }
@@ -115,9 +115,9 @@ if hasArg tests; then
     BUILD_TESTS=ON
 fi
 
-# Append `-DFIND_CUSPATIAL_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
-    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
+# Append `-DFIND_CUSPATIAL_CPP=ON` to EXTRA_CMAKE_ARGS unless a user specified the option.
+if [[ "${EXTRA_CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
 fi
 
 # If clean given, run it prior to any other steps
@@ -153,7 +153,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libcuspatial; then
           -DBUILD_TESTS=${BUILD_TESTS} \
           -DDISABLE_DEPRECATION_WARNING=${BUILD_DISABLE_DEPRECATION_WARNING} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          ${CMAKE_ARGS} \
+          ${EXTRA_CMAKE_ARGS} \
           ..
 
     cmake --build . -j ${PARALLEL_LEVEL} ${VERBOSE_FLAG}
@@ -167,8 +167,8 @@ fi
 if (( ${NUMARGS} == 0 )) || hasArg cuspatial; then
 
     cd ${REPODIR}/python/cuspatial
-    python setup.py build_ext -j${PARALLEL_LEVEL:-1} --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${CMAKE_ARGS}
+    python setup.py build_ext -j${PARALLEL_LEVEL:-1} --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${EXTRA_CMAKE_ARGS}
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py install --single-version-externally-managed --record=record.txt -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${CMAKE_ARGS}
+        python setup.py install --single-version-externally-managed --record=record.txt -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${EXTRA_CMAKE_ARGS}
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -116,7 +116,7 @@ if hasArg tests; then
 fi
 
 # Append `-DFIND_CUSPATIAL_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-if [[ ${CMAKE_ARGS} != *"DFIND_CUSPATIAL_CPP"* ]]; then
+if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -169,6 +169,6 @@ if (( ${NUMARGS} == 0 )) || hasArg cuspatial; then
     cd ${REPODIR}/python/cuspatial
     python setup.py build_ext -j${PARALLEL_LEVEL:-1} --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${CMAKE_ARGS}
     if [[ ${INSTALL_TARGET} != "" ]]; then
-        python setup.py install --single-version-externally-managed --record=record.txt -- ${CMAKE_ARGS}
+        python setup.py install --single-version-externally-managed --record=record.txt -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUSPATIAL_BUILD_DIR} ${CMAKE_ARGS}
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -116,9 +116,9 @@ if hasArg tests; then
 fi
 
 # Append `-DFIND_CUSPATIAL_CPP=ON` to CMAKE_ARGS unless a user specified the option.
-if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
-    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
-fi
+#if [[ "${CMAKE_ARGS}" != *"DFIND_CUSPATIAL_CPP"* ]]; then
+#    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_CUSPATIAL_CPP=ON"
+#fi
 
 # If clean given, run it prior to any other steps
 if hasArg clean; then

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -77,7 +77,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
 
     gpuci_logger "Build cuSpatial"
     cd "$WORKSPACE"
-    ./build.sh clean libcuspatial cuspatial tests --cmake-args=\"-DFIND_CUSPATIAL_CPP=ON\"
+    ./build.sh clean libcuspatial cuspatial tests
 
     ###############################################################################
     # TEST - Run libcuspatial and cuSpatial Unit Tests

--- a/conda/recipes/cuspatial/build.sh
+++ b/conda/recipes/cuspatial/build.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh cuspatial --cmake-args=\"-DFIND_CUSPATIAL_CPP=ON\"
+./build.sh cuspatial

--- a/conda/recipes/cuspatial/build.sh
+++ b/conda/recipes/cuspatial/build.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh cuspatial
+./build.sh cuspatial --cmake-args=\"-DFIND_CUSPATIAL_CPP=ON\"

--- a/conda/recipes/cuspatial/build.sh
+++ b/conda/recipes/cuspatial/build.sh
@@ -1,5 +1,8 @@
 
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
+# Ignore conda-provided CMAKE_ARGS for the Python build.
+unset CMAKE_ARGS
+
 # This assumes the script is executed from the root of the repo directory
-./build.sh cuspatial --cmake-args=\"-DFIND_CUSPATIAL_CPP=ON\"
+./build.sh cuspatial


### PR DESCRIPTION
<!--

Thank you for contributing to cuSpatial :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Discussions with the team indicated a general preference for having build.sh default to finding the C++ library by default (and erroring if one is not found) rather than building a new copy of libcuspatial when building cuspatial Python. This PR also avoids shadowing the `CMAKE_ARGS` environment variable in build.sh, which is important for conda-forge compatibility.