### PR TITLE
Fix out of bounds access in spline interpolation

### DIFF
--- a/python/cuspatial/cuspatial/core/interpolate.py
+++ b/python/cuspatial/cuspatial/core/interpolate.py
@@ -184,7 +184,7 @@ class CubicSpline:
                 self.groups = groups.astype("int32")
             else:
                 self.groups = Series(
-                    cp.repeat(cp.array(0), len(self.t))
+                    cp.repeat(cp.array(0), len(coordinates))
                 ).astype("int32")
             result = _cubic_spline_fit(
                 coordinates, self.groups, self.prefix, self.t, self.c


### PR DESCRIPTION
<!--

Thank you for contributing to cuSpatial :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
The cubic spline API supports fitting many splines at once. Each spline's coefficients are stored on construction of the `CubicSpline` object, and when users then specify a set of points at which to evaluate that spline they can specify which spline to evaluate for each of the input points. When a user does not specify that information, the call operator defaults to assuming that only a single spline exists and interpolates all the data using that spline by setting all input points to use spline 0. Currently, however, the code for that creating that default list only making it as long as the number of knots in the spline instead of making it as long as the set of input points to evaluate the spline at. This leads to out of bounds memory accesses when that curve is fit.