### PR TITLE
Bump cuspatial python version in scikit-build

### DIFF
--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -14,9 +14,9 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-set(cuspatial_version 22.06.00)
+set(cuspatial_version 22.08.00)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.06/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 


### PR DESCRIPTION
Since `python/cuspatial/CMakeLists.txt` was just introduced in the last release and is forward merged to this one, version bumper was not run on this file. Thus this is manually bumped. In future release this should be handled by https://github.com/rapidsai/cuspatial/blob/47ba833a139466028c8a756cc865b7c76d8ec586/ci/release/update-version.sh#L42