### PR TITLE
[FEA] Fuse `transform` and `copy_if` operations in `quadtree_point_in_polygon` 

### DIFF
--- a/cpp/include/cuspatial/detail/iterator.hpp
+++ b/cpp/include/cuspatial/detail/iterator.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+namespace cuspatial {
+namespace detail {
+
+template <typename UnaryFunction>
+inline auto make_counting_transform_iterator(cudf::size_type start, UnaryFunction f)
+{
+  return thrust::make_transform_iterator(thrust::make_counting_iterator(start), f);
+}
+}  // namespace detail
+}  // namespace cuspatial

--- a/cpp/src/join/quadtree_point_in_polygon.cu
+++ b/cpp/src/join/quadtree_point_in_polygon.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <indexing/construction/detail/utilities.cuh>
 #include <utility/point_in_polygon.cuh>
 
+#include <cuspatial/detail/iterator.hpp>
 #include <cuspatial/error.hpp>
 #include <cuspatial/spatial_join.hpp>
 
@@ -45,19 +46,13 @@ namespace cuspatial {
 namespace detail {
 namespace {
 
-template <typename UnaryFunction>
-inline auto make_counting_transform_iterator(cudf::size_type start, UnaryFunction f)
-{
-  return thrust::make_transform_iterator(thrust::make_counting_iterator(start), f);
-}
-
 template <typename T, typename QuadOffsetsIter>
 struct compute_poly_and_point_indices {
   QuadOffsetsIter quad_point_offsets;
   uint32_t const* point_offsets;
   uint32_t const* point_offsets_end;
   cudf::column_device_view const poly_indices;
-  
+
   inline thrust::tuple<uint32_t, uint32_t> __device__
   operator()(cudf::size_type const global_index) const
   {
@@ -169,7 +164,7 @@ struct compute_quadtree_point_in_polygon {
       //     pp_pairs.append((polygon, point))
       // ```
       //
-      auto global_to_poly_and_point_indices = make_counting_transform_iterator(
+      auto global_to_poly_and_point_indices = detail::make_counting_transform_iterator(
         0,
         compute_poly_and_point_indices<T, decltype(quad_offsets_iter)>{
           quad_offsets_iter,

--- a/cpp/src/join/quadtree_poly_filtering.cu
+++ b/cpp/src/join/quadtree_poly_filtering.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #include "detail/intersection.cuh"
 #include "detail/traversal.cuh"
 
+#include <cuspatial/detail/iterator.hpp>
 #include <cuspatial/error.hpp>
 #include <cuspatial/spatial_join.hpp>
 
@@ -38,12 +39,6 @@ namespace cuspatial {
 namespace detail {
 
 namespace {
-
-template <typename UnaryFunction>
-inline auto make_counting_transform_iterator(cudf::size_type start, UnaryFunction f)
-{
-  return thrust::make_transform_iterator(thrust::make_counting_iterator(start), f);
-}
 
 template <typename T>
 inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view const& quadtree,
@@ -103,10 +98,10 @@ inline std::unique_ptr<cudf::table> join_quadtree_and_bboxes(cudf::table_view co
     find_intersections(quadtree,
                        poly_bbox,
                        // The top-level node indices
-                       make_counting_transform_iterator(
+                       detail::make_counting_transform_iterator(
                          0, [=] __device__(auto i) { return i % num_top_level_leaves; }),
                        // The top-level poly indices
-                       make_counting_transform_iterator(
+                       detail::make_counting_transform_iterator(
                          0, [=] __device__(auto i) { return i / num_top_level_leaves; }),
                        make_current_level_iter(),  // intermediate intersections or parent quadrants
                                                    // found during traversal


### PR DESCRIPTION
Fuse `transform` and `copy_if` operations in `quadtree_point_in_polygon` for a modest performance improvement.

`branch-22.08`:
```
points in polygons (168,898,952 points, 788 polygons): 1.669s

(168898952 * 788 / 1669.1560840010643 * 1000) =
  79,736,326,309.862 (point-polygon pairs / second)
```

This PR:
```
points in polygons (168,898,952 points, 788 polygons): 1.569s

(168898952 * 788 / 1569.104240000248 * 1000) =
  84,820,607,059.209 (point-polygon pairs / second)
```