### PR TITLE
Add missing rmm includes

### DIFF
--- a/cpp/include/cuspatial/constants.hpp
+++ b/cpp/include/cuspatial/constants.hpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <math.h>
-
 #pragma once
+
+#include <math.h>
 
 /**
  * @addtogroup cuspatial_constants

--- a/cpp/include/cuspatial/coordinate_transform.hpp
+++ b/cpp/include/cuspatial/coordinate_transform.hpp
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <cudf/types.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/cubic_spline.hpp
+++ b/cpp/include/cuspatial/cubic_spline.hpp
@@ -20,6 +20,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/cuda_utils.hpp
+++ b/cpp/include/cuspatial/cuda_utils.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
 #ifdef __CUDACC__
 #define CUSPATIAL_HOST_DEVICE __host__ __device__
 #else

--- a/cpp/include/cuspatial/cusparse_error.hpp
+++ b/cpp/include/cuspatial/cusparse_error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cusparse.h>
+
 #include <stdexcept>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/detail/cubic_spline.hpp
+++ b/cpp/include/cuspatial/detail/cubic_spline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
+
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <memory>
 

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <cuspatial/vec_2d.hpp>

--- a/cpp/include/cuspatial/detail/utility/traits.hpp
+++ b/cpp/include/cuspatial/detail/utility/traits.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
 #include <type_traits>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/distances/linestring_distance.hpp
+++ b/cpp/include/cuspatial/distances/linestring_distance.hpp
@@ -19,6 +19,8 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/error.hpp
+++ b/cpp/include/cuspatial/error.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <cuda.h>
+//#include <cuda.h>
 #include <cuda_runtime_api.h>
+
 #include <stdexcept>
 #include <string>
 

--- a/cpp/include/cuspatial/error.hpp
+++ b/cpp/include/cuspatial/error.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-//#include <cuda.h>
 #include <cuda_runtime_api.h>
 
 #include <stdexcept>

--- a/cpp/include/cuspatial/experimental/hausdorff.cuh
+++ b/cpp/include/cuspatial/experimental/hausdorff.cuh
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cudf/types.hpp>
-#include <memory>
 
 #include <rmm/cuda_stream_view.hpp>
 

--- a/cpp/include/cuspatial/hausdorff.hpp
+++ b/cpp/include/cuspatial/hausdorff.hpp
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <cudf/types.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/haversine.hpp
+++ b/cpp/include/cuspatial/haversine.hpp
@@ -16,10 +16,12 @@
 
 #pragma once
 
+#include <cuspatial/constants.hpp>
+
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cuspatial/constants.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace cuspatial {
 

--- a/cpp/include/cuspatial/point_in_polygon.hpp
+++ b/cpp/include/cuspatial/point_in_polygon.hpp
@@ -20,6 +20,8 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/point_quadtree.hpp
+++ b/cpp/include/cuspatial/point_quadtree.hpp
@@ -18,6 +18,8 @@
 
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/polygon_bounding_box.hpp
+++ b/cpp/include/cuspatial/polygon_bounding_box.hpp
@@ -18,6 +18,8 @@
 
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/polyline_bounding_box.hpp
+++ b/cpp/include/cuspatial/polyline_bounding_box.hpp
@@ -18,6 +18,8 @@
 
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/shapefile_reader.hpp
+++ b/cpp/include/cuspatial/shapefile_reader.hpp
@@ -19,6 +19,8 @@
 #include <cudf/column/column.hpp>
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 namespace cuspatial {
 
 /**

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -18,6 +18,8 @@
 
 #include <cudf/types.hpp>
 
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/spatial_window.hpp
+++ b/cpp/include/cuspatial/spatial_window.hpp
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <cudf/types.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+
 #include <memory>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/trajectory.hpp
+++ b/cpp/include/cuspatial/trajectory.hpp
@@ -17,8 +17,10 @@
 #pragma once
 
 #include <cudf/types.hpp>
-#include <memory>
+
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <memory>
 
 namespace cuspatial {
 

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -42,6 +42,7 @@
  *
  *          This module contains APIs that transforms cartesian and geodesic coordinates.
  *          @file coordinate_transform.hpp
+            @file coordinate_transform.cuh
  *      @}
  *      @defgroup distance Distance
  *      @{
@@ -49,7 +50,7 @@
  *
  *          @file linestring_distance.hpp
  *          @file hausdorff.hpp
- *          @file experimental/hausdorff.cuh
+ *          @file hausdorff.cuh
  *          @file haversine.hpp
  *          @file haversine.cuh
  *      @}


### PR DESCRIPTION
A recent change to libcudf removed a forward declaration and/or RMM header includes, and cuSpatial was errantly relying on these to get the definitions of `device_memory_resource` and `get_current_device_resource()`. 

This PR fixes that by adding missing includes of `rmm/mr/device/per_device_resource.hpp` in several files. It also generally cleans up include ordering and spacing, and adds a few missing copyright headers.