### PR TITLE
[FIX] Fix compile error in distance benchmark

### DIFF
--- a/cpp/benchmarks/pairwise_linestring_distance.cu
+++ b/cpp/benchmarks/pairwise_linestring_distance.cu
@@ -77,7 +77,8 @@ std::tuple<rmm::device_vector<cartesian_2d<T>>, rmm::device_vector<int32_t>> gen
   std::vector<cartesian_2d<T>> rads(rads_iter, rads_iter + num_points);
   std::vector<cartesian_2d<T>> points(num_points);
 
-  auto random_walk_func = [segment_length](auto const& prev, auto const& rad) {
+  auto random_walk_func = [segment_length](cartesian_2d<T> const& prev,
+                                           cartesian_2d<T> const& rad) {
     return cartesian_2d<T>{prev.x + segment_length * rad.x, prev.y + segment_length * rad.y};
   };
 


### PR DESCRIPTION
This PR fixes the following compile error:
```
pairwise_linestring_distance.cu (80): error: too many initializer values
          detected during:
            instantiation of "std::tuple<rmm::device_vector<cuspatial::cartesian_2d<T>>, rmm::device_vector<int32_t>> generate_linestring(int32_t, int32_t, T, cuspatial::cartesian_2d<T>) [with T=float]" 
```