### PR TITLE
[FEA] Integrate `GeoSeries` with `read_polygon_shapefile`

### DIFF
--- a/cpp/include/cuspatial/shapefile_reader.hpp
+++ b/cpp/include/cuspatial/shapefile_reader.hpp
@@ -23,6 +23,8 @@
 
 namespace cuspatial {
 
+typedef enum class winding_order : bool { CLOCKWISE, COUNTER_CLOCKWISE } winding_order;
+
 /**
  * @addtogroup io
  * @{
@@ -32,6 +34,8 @@ namespace cuspatial {
  * @brief read polygon data from an ESRI Shapefile.
  *
  * @param[in] filename: ESRI Shapefile file path (usually ends in .shp)
+ * @param[in] outer_ring_winding: the ordering of the outer ring of polygon vertices; clockwise or
+ * counter-clockwise
  * @param[in] mr:       Optional, The resource to use to allocate the returned data
  *
  * @return Vector of 4 columns representing one or more polygons:
@@ -45,7 +49,8 @@ namespace cuspatial {
  **/
 std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
   std::string const& filename,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+  const winding_order outer_ring_winding = winding_order::COUNTER_CLOCKWISE,
+  rmm::mr::device_memory_resource* mr    = rmm::mr::get_current_device_resource());
 
 /**
  * @} // end of doxygen group

--- a/cpp/src/io/shp/polygon_shapefile_reader.cu
+++ b/cpp/src/io/shp/polygon_shapefile_reader.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cuspatial/error.hpp>
+#include <cuspatial/shapefile_reader.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/types.hpp>
@@ -48,14 +49,17 @@ std::tuple<std::vector<cudf::size_type>,
            std::vector<cudf::size_type>,
            std::vector<double>,
            std::vector<double>>
-read_polygon_shapefile(std::string const& filename);
+read_polygon_shapefile(std::string const& filename, cuspatial::winding_order outer_ring_winding);
 
 std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
-  std::string const& filename, rmm::cuda_stream_view stream, rmm::mr::device_memory_resource* mr)
+  std::string const& filename,
+  cuspatial::winding_order outer_ring_winding,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr)
 {
   CUSPATIAL_EXPECTS(not filename.empty(), "Filename cannot be empty.");
 
-  auto poly_vectors = detail::read_polygon_shapefile(filename);
+  auto poly_vectors = detail::read_polygon_shapefile(filename, outer_ring_winding);
 
   auto polygon_offsets = make_column<cudf::size_type>(std::get<0>(poly_vectors), stream, mr);
   auto ring_offsets    = make_column<cudf::size_type>(std::get<1>(poly_vectors), stream, mr);
@@ -86,9 +90,11 @@ std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
 }  // namespace detail
 
 std::vector<std::unique_ptr<cudf::column>> read_polygon_shapefile(
-  std::string const& filename, rmm::mr::device_memory_resource* mr)
+  std::string const& filename,
+  cuspatial::winding_order outer_ring_winding,
+  rmm::mr::device_memory_resource* mr)
 {
-  return detail::read_polygon_shapefile(filename, rmm::cuda_stream_default, mr);
+  return detail::read_polygon_shapefile(filename, outer_ring_winding, rmm::cuda_stream_default, mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
+++ b/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
@@ -15,7 +15,10 @@
  */
 
 #include <cuspatial/error.hpp>
+#include <cuspatial/point_in_polygon.hpp>
 #include <cuspatial/shapefile_reader.hpp>
+
+#include <rmm/device_vector.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -45,8 +48,30 @@ void test(std::string const& shapefile_name,
           std::vector<double> xs,
           std::vector<double> ys)
 {
-  auto shape_filename  = get_shapefile_path(shapefile_name);
-  auto polygon_columns = cuspatial::read_polygon_shapefile(shape_filename);
+  auto shape_filename = get_shapefile_path(shapefile_name);
+  auto polygon_columns =
+    cuspatial::read_polygon_shapefile(shape_filename, cuspatial::winding_order::COUNTER_CLOCKWISE);
+
+  auto expected_poly_offsets  = wrapper<cudf::size_type>(poly_offsets.begin(), poly_offsets.end());
+  auto expected_ring_offsets  = wrapper<cudf::size_type>(ring_offsets.begin(), ring_offsets.end());
+  auto expected_poly_point_xs = wrapper<double>(xs.begin(), xs.end());
+  auto expected_poly_point_ys = wrapper<double>(ys.begin(), ys.end());
+
+  expect_columns_equivalent(expected_poly_offsets, polygon_columns.at(0)->view(), verbosity);
+  expect_columns_equivalent(expected_ring_offsets, polygon_columns.at(1)->view(), verbosity);
+  expect_columns_equivalent(expected_poly_point_xs, polygon_columns.at(2)->view(), verbosity);
+  expect_columns_equivalent(expected_poly_point_ys, polygon_columns.at(3)->view(), verbosity);
+}
+
+void test_reverse(std::string const& shapefile_name,
+                  std::vector<cudf::size_type> poly_offsets,
+                  std::vector<cudf::size_type> ring_offsets,
+                  std::vector<double> xs,
+                  std::vector<double> ys)
+{
+  auto shape_filename = get_shapefile_path(shapefile_name);
+  auto polygon_columns =
+    cuspatial::read_polygon_shapefile(shape_filename, cuspatial::winding_order::CLOCKWISE);
 
   auto expected_poly_offsets  = wrapper<cudf::size_type>(poly_offsets.begin(), poly_offsets.end());
   auto expected_ring_offsets  = wrapper<cudf::size_type>(ring_offsets.begin(), ring_offsets.end());
@@ -70,9 +95,14 @@ TEST_F(PolygonShapefileReaderTest, NonExistentFile)
 
 TEST_F(PolygonShapefileReaderTest, ZeroPolygons) { test("empty_poly.shp", {}, {}, {}, {}); }
 
+TEST_F(PolygonShapefileReaderTest, OnePolygonReversed)
+{
+  test_reverse("one_poly.shp", {0}, {0}, {-10, 5, 5, -10, -10}, {-10, -10, 5, 5, -10});
+}
+
 TEST_F(PolygonShapefileReaderTest, OnePolygon)
 {
-  test("one_poly.shp", {0}, {0}, {-10, 5, 5, -10, -10}, {-10, -10, 5, 5, -10});
+  test("one_poly.shp", {0}, {0}, {-10, -10, 5, 5, -10}, {-10, 5, 5, -10, -10});
 }
 
 TEST_F(PolygonShapefileReaderTest, TwoPolygons)
@@ -80,6 +110,24 @@ TEST_F(PolygonShapefileReaderTest, TwoPolygons)
   test("two_polys.shp",
        {0, 1},
        {0, 5},
-       {-10, 5, 5, -10, -10, 0, 10, 10, 0, 0},
-       {-10, -10, 5, 5, -10, 0, 0, 10, 10, 0});
+       {-10, -10, 5, 5, -10, 0, 0, 10, 10, 0},
+       {-10, 5, 5, -10, -10, 0, 10, 10, 0, 0});
+}
+
+TEST_F(PolygonShapefileReaderTest, OnePointInPolygon)
+{
+  auto shape_filename  = get_shapefile_path("one_poly.shp");
+  auto polygon_columns = cuspatial::read_polygon_shapefile(shape_filename);
+
+  auto polygons = polygon_columns.at(0)->view();
+  auto rings    = polygon_columns.at(1)->view();
+  auto xs       = polygon_columns.at(2)->view();
+  auto ys       = polygon_columns.at(3)->view();
+  fixed_width_column_wrapper<double> test_xs({0.0});
+  fixed_width_column_wrapper<double> test_ys({0.0});
+  fixed_width_column_wrapper<int32_t> expected({true});
+
+  auto ret = cuspatial::point_in_polygon(test_xs, test_ys, polygons, rings, xs, ys);
+
+  expect_columns_equivalent(ret->view(), expected);
 }

--- a/python/cuspatial/cuspatial/_lib/cpp/shapefile_reader.pxd
+++ b/python/cuspatial/cuspatial/_lib/cpp/shapefile_reader.pxd
@@ -1,12 +1,19 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 from cudf._lib.cpp.column.column cimport column
 
+ctypedef bool winding_order_type_t
 
 cdef extern from "cuspatial/shapefile_reader.hpp" namespace "cuspatial" nogil:
     cdef vector[unique_ptr[column]] \
-        read_polygon_shapefile(const string filename) except +
+        read_polygon_shapefile(
+            const string filename, winding_order outer_ring_winding
+    ) except +
+    ctypedef enum winding_order "cuspatial::winding_order":
+        COUNTER_CLOCKWISE "cuspatial::winding_order::COUNTER_CLOCKWISE",
+        CLOCKWISE "cuspatial::winding_order::CLOCKWISE"

--- a/python/cuspatial/cuspatial/_lib/shapefile_reader.pyx
+++ b/python/cuspatial/cuspatial/_lib/shapefile_reader.pyx
@@ -1,5 +1,8 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION.
 
+from enum import IntEnum
+
+from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
 from libcpp.utility cimport move
@@ -9,14 +12,24 @@ from cudf._lib.column cimport Column, column
 
 from cuspatial._lib.cpp.shapefile_reader cimport (
     read_polygon_shapefile as cpp_read_polygon_shapefile,
+    winding_order,
+    winding_order_type_t,
 )
 
 
-cpdef read_polygon_shapefile(object filepath):
+class WindingOrder(IntEnum):
+    COUNTER_CLOCKWISE = <winding_order_type_t> winding_order.COUNTER_CLOCKWISE,
+    CLOCKWISE = <winding_order_type_t> winding_order.CLOCKWISE
+
+
+cpdef read_polygon_shapefile(object filepath, object winding):
     cdef string c_string = str(filepath).encode()
     cdef vector[unique_ptr[column]] c_result
+    cdef winding_order winding_value = <winding_order>(
+        <winding_order_type_t>(winding.value)
+    )
     with nogil:
-        c_result = move(cpp_read_polygon_shapefile(c_string))
+        c_result = move(cpp_read_polygon_shapefile(c_string, winding_value))
     return (
         Column.from_unique_ptr(move(c_result[0])),
         Column.from_unique_ptr(move(c_result[1])),

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2021-2022 NVIDIA CORPORATION
 from typing import Tuple, TypeVar
 
+import cupy as cp
 import pyarrow as pa
 
 import cudf
-from cudf.core.column import ColumnBase
+from cudf.core.column import ColumnBase, as_column
 
 from cuspatial.core._column.geometa import GeoMeta
 
@@ -30,23 +31,105 @@ class GeoColumn(ColumnBase):
         data: Tuple,
         meta: GeoMeta = None,
         shuffle_order: cudf.Index = None,
+        from_read_polygon_shapefile=False,
     ):
-        if (
-            not isinstance(data[0], cudf.Series)
-            or not isinstance(data[1], cudf.Series)
-            or not isinstance(data[2], cudf.Series)
-            or not isinstance(data[3], cudf.Series)
+        if from_read_polygon_shapefile:
+            """
+            A cudf.ListSeries needs four levels of nesting to represent
+            a polygon shapefile. The rings_offsets and polygons_offsets
+            have already been computed in the `read_polygon_shapefile`
+            function. In order to convert it into an arrow list<...>
+            we need a set of offsets buffers for each point tuple, and
+            an offsets buffer for the 1-offset multipolygons.
+
+            Coordinates: List of length 2 offsets: [0, 2, 4, ... n/2]
+            Rings: List of polygon ring offsets
+            Polygons: Offset into rings of each polygon
+            Multipolygons: List of length 1 offsets: No multipolygons
+
+            Finally, each set of offsets must have the length of the
+            array appended to the end, as Arrow offset lists are length
+            n + 1 but our original shapefile code offset lists are only
+            length n.
+            """
+            polygons_col = data[0].astype("int32")
+            rings_col = data[1].astype("int32")
+            coordinates = (
+                data[2].stack().astype("float64").reset_index(drop=True)
+            )
+            """
+            Store a fixed-size offsets buffer of even numbers:
+            0   0
+            1   2
+            2   4
+            ...
+            Up to the size of the original input.
+            """
+            coordinate_offsets = as_column(
+                cp.arange(len(coordinates) + 1, step=2), dtype="int32"
+            )
+            rings_offsets = cudf.concat(
+                [
+                    cudf.Series(rings_col),
+                    cudf.Series([len(coordinate_offsets) - 1], dtype="int32"),
+                ]
+            ).reset_index(drop=True)
+            polygons_offsets = cudf.concat(
+                [
+                    cudf.Series(polygons_col),
+                    cudf.Series([len(polygons_col)], dtype="int32"),
+                ]
+            ).reset_index(drop=True)
+            coords = cudf.core.column.ListColumn(
+                size=len(coordinate_offsets) - 1,
+                dtype=cudf.ListDtype(coordinates.dtype),
+                children=(coordinate_offsets, coordinates._column),
+            )
+            rings = cudf.core.column.ListColumn(
+                size=len(rings_offsets) - 1,
+                dtype=cudf.ListDtype(coords.dtype),
+                children=(rings_offsets._column, coords),
+            )
+            polygons = cudf.core.column.ListColumn(
+                size=len(polygons_offsets) - 1,
+                dtype=cudf.ListDtype(rings.dtype),
+                children=(polygons_offsets._column, rings),
+            )
+            mpolygons = cudf.core.column.ListColumn(
+                size=len(polygons_offsets) - 1,
+                dtype=cudf.ListDtype(polygons.dtype),
+                children=(
+                    as_column(cp.arange(len(polygons) + 1), dtype="int32"),
+                    polygons,
+                ),
+            )
+            self.points = cudf.Series([])
+            self.points.name = "points"
+            self.mpoints = cudf.Series([])
+            self.mpoints.name = "mpoints"
+            self.lines = cudf.Series([])
+            self.lines.name = "lines"
+            self.polygons = cudf.Series(mpolygons)
+            self.polygons.name = "polygons"
+            self._meta = meta
+
+        elif (
+            isinstance(data[0], cudf.Series)
+            and isinstance(data[1], cudf.Series)
+            and isinstance(data[2], cudf.Series)
+            and isinstance(data[3], cudf.Series)
         ):
-            raise TypeError("All Tuple arguments must be cudf.ListSeries")
-        self._meta = GeoMeta(meta)
-        self.points = data[0]
-        self.points.name = "points"
-        self.mpoints = data[1]
-        self.mpoints.name = "mpoints"
-        self.lines = data[2]
-        self.lines.name = "lines"
-        self.polygons = data[3]
-        self.polygons.name = "polygons"
+            self._meta = GeoMeta(meta)
+            self.points = data[0]
+            self.points.name = "points"
+            self.mpoints = data[1]
+            self.mpoints.name = "mpoints"
+            self.lines = data[2]
+            self.lines.name = "lines"
+            self.polygons = data[3]
+            self.polygons.name = "polygons"
+        else:
+            raise TypeError("All four Tuple arguments must be cudf.ListSeries")
         base = cudf.core.column.column.arange(0, len(self), dtype="int32").data
         super().__init__(base, size=len(self), dtype="int32")
         if shuffle_order is not None:

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -52,12 +52,6 @@ class GeoSeries(cudf.Series):
         name=None,
         nan_as_null=True,
     ):
-        # Condition index
-        if isinstance(data, (gpGeoSeries, GeoSeries)):
-            if index is None:
-                index = data.index
-        if index is None:
-            index = cudf.RangeIndex(0, len(data))
         # Condition data
         if isinstance(data, pd.Series):
             data = gpGeoSeries(data)
@@ -72,10 +66,40 @@ class GeoSeries(cudf.Series):
             adapter = GeoPandasReader(data)
             pandas_meta = GeoMeta(adapter.get_geopandas_meta())
             column = GeoColumn(adapter._get_geotuple(), pandas_meta)
+        elif isinstance(data, Tuple):
+            # This must be a Polygon Tuple returned by
+            # cuspatial.read_polygon_shapefile
+            # TODO: If an index is passed in, it needs to be reflected
+            # in the column, because otherwise .iloc indexing will ignore
+            # it.
+            column = GeoColumn(
+                data,
+                GeoMeta(
+                    {
+                        "input_types": cp.repeat(
+                            cp.array(
+                                [Feature_Enum.POLYGON.value], dtype="int8"
+                            ),
+                            len(data[0]),
+                        ),
+                        "union_offsets": cp.arange(
+                            len(data[0]), dtype="int32"
+                        ),
+                    }
+                ),
+                from_read_polygon_shapefile=True,
+            )
+
         else:
             raise TypeError(
                 f"Incompatible object passed to GeoSeries ctor {type(data)}"
             )
+        # Condition index
+        if isinstance(data, (gpGeoSeries, GeoSeries)):
+            if index is None:
+                index = data.index
+        if index is None:
+            index = cudf.RangeIndex(0, len(column))
         super().__init__(column, index, dtype, name, nan_as_null)
 
     @property
@@ -288,7 +312,7 @@ class GeoSeries(cudf.Series):
         """
         if nullable is True:
             raise ValueError("GeoSeries doesn't support <NA> yet")
-        final_union_slice = self[0 : len(self)]
+        final_union_slice = self.iloc[0 : len(self._column)]
         return gpGeoSeries(
             final_union_slice.to_shapely(),
             index=self.index.to_pandas(),

--- a/python/cuspatial/cuspatial/io/shapefile.py
+++ b/python/cuspatial/cuspatial/io/shapefile.py
@@ -3,11 +3,14 @@
 from cudf import DataFrame, Series
 
 from cuspatial._lib.shapefile_reader import (
+    WindingOrder,
     read_polygon_shapefile as cpp_read_polygon_shapefile,
 )
 
 
-def read_polygon_shapefile(filename):
+def read_polygon_shapefile(
+    filename, outer_ring_order=WindingOrder.COUNTER_CLOCKWISE
+):
     """
     Reads polygon geometry from an ESRI shapefile into GPU memory.
 
@@ -15,6 +18,8 @@ def read_polygon_shapefile(filename):
     ----------
     filename : str, pathlike
         ESRI Shapefile file path (usually ends in ``.shp``)
+    winding_order : WindingOrder(Enum)
+        COUNTER_CLOCKWISE: ESRI Format, or CLOCKWISE: Simple Feature
 
     Returns
     -------
@@ -30,7 +35,7 @@ def read_polygon_shapefile(filename):
             y : cudf.Series(dtype=np.float64)
                 y-components of each polygon's points
     """
-    result = cpp_read_polygon_shapefile(filename)
+    result = cpp_read_polygon_shapefile(filename, outer_ring_order)
     f_pos = Series(result[0], name="f_pos")
     r_pos = Series(result[1], name="r_pos")
     return (f_pos, r_pos, DataFrame({"x": result[2], "y": result[3]}))

--- a/python/cuspatial/cuspatial/tests/test_shapefile_reader.py
+++ b/python/cuspatial/cuspatial/tests/test_shapefile_reader.py
@@ -8,6 +8,7 @@ import pytest
 import cudf
 
 import cuspatial
+from cuspatial.io.shapefile import WindingOrder
 
 shapefiles_path = os.path.join(
     os.environ["CUSPATIAL_HOME"], "test_fixtures", "shapefiles"
@@ -42,6 +43,28 @@ def test_zero_polygons():
     )
 
 
+def test_one_polygon_reversed():
+    f_pos, r_pos, points = cuspatial.read_polygon_shapefile(
+        os.path.join(shapefiles_path, "one_poly.shp"),
+        outer_ring_order=WindingOrder.CLOCKWISE,
+    )
+    cudf.testing.assert_series_equal(
+        f_pos, cudf.Series([0], dtype=np.int32, name="f_pos")
+    )
+    cudf.testing.assert_series_equal(
+        r_pos, cudf.Series([0], dtype=np.int32, name="r_pos")
+    )
+    cudf.testing.assert_frame_equal(
+        points,
+        cudf.DataFrame(
+            {
+                "x": cudf.Series([-10, 5, 5, -10, -10], dtype=np.float64),
+                "y": cudf.Series([-10, -10, 5, 5, -10], dtype=np.float64),
+            }
+        ),
+    )
+
+
 def test_one_polygon():
     f_pos, r_pos, points = cuspatial.read_polygon_shapefile(
         os.path.join(shapefiles_path, "one_poly.shp")
@@ -56,8 +79,34 @@ def test_one_polygon():
         points,
         cudf.DataFrame(
             {
-                "x": cudf.Series([-10, 5, 5, -10, -10], dtype=np.float64),
-                "y": cudf.Series([-10, -10, 5, 5, -10], dtype=np.float64),
+                "x": cudf.Series([-10, -10, 5, 5, -10], dtype=np.float64),
+                "y": cudf.Series([-10, 5, 5, -10, -10], dtype=np.float64),
+            }
+        ),
+    )
+
+
+def test_two_polygons_reversed():
+    f_pos, r_pos, points = cuspatial.read_polygon_shapefile(
+        os.path.join(shapefiles_path, "two_polys.shp"),
+        outer_ring_order=WindingOrder.CLOCKWISE,
+    )
+    cudf.testing.assert_series_equal(
+        f_pos, cudf.Series([0, 1], dtype=np.int32, name="f_pos")
+    )
+    cudf.testing.assert_series_equal(
+        r_pos, cudf.Series([0, 5], dtype=np.int32, name="r_pos")
+    )
+    cudf.testing.assert_frame_equal(
+        points,
+        cudf.DataFrame(
+            {
+                "x": cudf.Series(
+                    [-10, 5, 5, -10, -10, 0, 10, 10, 0, 0], dtype=np.float64
+                ),
+                "y": cudf.Series(
+                    [-10, -10, 5, 5, -10, 0, 0, 10, 10, 0], dtype=np.float64
+                ),
             }
         ),
     )
@@ -78,10 +127,10 @@ def test_two_polygons():
         cudf.DataFrame(
             {
                 "x": cudf.Series(
-                    [-10, 5, 5, -10, -10, 0, 10, 10, 0, 0], dtype=np.float64
+                    [-10, -10, 5, 5, -10, 0, 0, 10, 10, 0], dtype=np.float64
                 ),
                 "y": cudf.Series(
-                    [-10, -10, 5, 5, -10, 0, 0, 10, 10, 0], dtype=np.float64
+                    [-10, 5, 5, -10, -10, 0, 10, 10, 0, 0], dtype=np.float64
                 ),
             }
         ),


### PR DESCRIPTION
This useful PR adds a `GeoSeries` constructor for the tuple returned by `read_polygon_shapefile`. Now users can say

```py
geoseries = cuspatial.GeoSeries(cuspatial.read_polygon_shapefile('the_shapefile'))
```

and load the data directly into GeoArrow.

This PR touches many files because I add a `reversed` argument to python and C++ so that the user can swap back and forth if they desire. This was required because the original implementation was reverse-ordering the polygons, which does not match GeoPandas results when reading a shapefile. Now it does, and is tested in both configurations.

Closes #668.