### PR TITLE
[skip ci] Fix Broken Link in NYC Taxi Notebook

### DIFF
--- a/notebooks/nyc_taxi_years_correlation.ipynb
+++ b/notebooks/nyc_taxi_years_correlation.ipynb
@@ -58,9 +58,9 @@
     }
    ],
    "source": [
-    "!if [ ! -f \"tzones_lonlat.json\" ]; then curl \"https://data.cityofnewyork.us/api/geospatial/d3c5-ddgc?method=export&format=GeoJSON\" -o tzones_lonlat.json; else echo \"tzones_lonlat.json found\"; fi\n",
-    "!if [ ! -f \"taxi2016.csv\" ]; then curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2016-01.csv -o taxi2016.csv; else echo \"taxi2016.csv found\"; fi   \n",
-    "!if [ ! -f \"taxi2017.csv\" ]; then curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2017-01.csv -o taxi2017.csv; else echo \"taxi2017.csv found\"; fi"
+    "!if [ ! -f \"tzones_lonlat.json\" ]; then curl 'https://data.cityofnewyork.us/api/geospatial/d3c5-ddgc?method=export&format=GeoJSON' -o tzones_lonlat.json; else echo \"tzones_lonlat.json found\"; fi\n",
+    "!if [ ! -f \"taxi2016.csv\" ]; then curl 'https://storage.googleapis.com/anaconda-public-data/nyc-taxi/csv/2016/yellow_tripdata_2016-01.csv' -o taxi2016.csv; else echo \"taxi2016.csv found\"; fi\n",
+    "!if [ ! -f \"taxi2017.csv\" ]; then curl 'https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2017-01.parquet' -o taxi2017.csv; else echo \"taxi2017.csv found\"; fi"
    ]
   },
   {
@@ -78,7 +78,9 @@
    "outputs": [],
    "source": [
     "taxi2016 = cudf.read_csv(\"taxi2016.csv\")\n",
-    "taxi2017 = cudf.read_csv(\"taxi2017.csv\")"
+    "taxi2016 = taxi2016.astype({\"tpep_pickup_datetime\": \"datetime64[us]\", \"tpep_dropoff_datetime\": \"datetime64[us]\"})\n",
+    "\n",
+    "taxi2017 = cudf.read_parquet(\"taxi2017.csv\")"
    ]
   },
   {
@@ -96,7 +98,7 @@
     {
      "data": {
       "text/plain": [
-       "{'DOLocationID', 'PULocationID'}"
+       "{'DOLocationID', 'PULocationID', 'airport_fee', 'congestion_surcharge'}"
       ]
      },
      "execution_count": 4,
@@ -121,7 +123,16 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_4526/2205681195.py:2: UserWarning: Column names longer than 10 characters will be truncated when saved to ESRI Shapefile.\n",
+      "  tzones.to_file('cu_taxi_zones.shp')\n"
+     ]
+    }
+   ],
    "source": [
     "tzones = gpd.GeoDataFrame.from_file('tzones_lonlat.json')\n",
     "tzones.to_file('cu_taxi_zones.shp')"
@@ -181,8 +192,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.2 s, sys: 6.27 s, total: 17.5 s\n",
-      "Wall time: 17.7 s\n"
+      "CPU times: user 22.6 s, sys: 14.6 s, total: 37.2 s\n",
+      "Wall time: 37.2 s\n"
      ]
     }
    ],
@@ -227,7 +238,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.10632302994054163\n"
+      "0.10632302994054166\n"
      ]
     }
    ],
@@ -275,8 +286,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.6013696841885884\n",
-      "0.5822576814239405\n"
+      "0.601369302655919\n",
+      "0.5822614630778491\n"
      ]
     }
    ],
@@ -320,7 +331,7 @@
      "output_type": "stream",
      "text": [
       "         VendorID tpep_pickup_datetime tpep_dropoff_datetime  passenger_count  \\\n",
-      "542479          1  2017-01-15 17:33:37   2017-01-15 17:35:32                1   \n",
+      "4487880         1  2017-01-15 17:33:37   2017-01-15 17:35:32                1   \n",
       "159122          1  2016-01-01 04:19:02   2016-01-01 04:25:09                3   \n",
       "180769          2  2016-01-01 06:40:21   2016-01-01 06:41:09                2   \n",
       "4871707         1  2016-01-15 01:07:34   2016-01-15 01:11:50                1   \n",
@@ -329,7 +340,7 @@
       "9259375         1  2016-01-23 10:58:21   2016-01-23 11:20:08                1   \n",
       "\n",
       "         trip_distance  RatecodeID store_and_fwd_flag  PULocationID  \\\n",
-      "542479             0.0           5                  N           204   \n",
+      "4487880            0.0           5                  N           204   \n",
       "159122             1.5           1                  N           204   \n",
       "180769             0.0           5                  N           204   \n",
       "4871707            1.2           1                  N           204   \n",
@@ -337,34 +348,43 @@
       "9039663            0.0           5                  N           204   \n",
       "9259375            4.8           1                  N           204   \n",
       "\n",
-      "         DOLocationID  payment_type  ...  extra  mta_tax  tip_amount  \\\n",
-      "542479            204             1  ...    0.0      0.0        10.0   \n",
-      "159122            204             2  ...    0.5      0.5         0.0   \n",
-      "180769            204             1  ...    0.0      0.5         0.0   \n",
-      "4871707           117             1  ...    0.5      0.5         0.0   \n",
-      "7766271           204             1  ...    0.0      0.0         0.0   \n",
-      "9039663           204             1  ...    0.0      0.0        10.0   \n",
-      "9259375            77             2  ...    0.0      0.5         0.0   \n",
+      "         DOLocationID  payment_type  ...  tip_amount  tolls_amount  \\\n",
+      "4487880           204             1  ...        10.0           0.0   \n",
+      "159122            204             2  ...         0.0           0.0   \n",
+      "180769            204             1  ...         0.0           0.0   \n",
+      "4871707           117             1  ...         0.0           0.0   \n",
+      "7766271           204             1  ...         0.0           0.0   \n",
+      "9039663           204             1  ...        10.0           0.0   \n",
+      "9259375            77             2  ...         0.0           0.0   \n",
       "\n",
-      "         tolls_amount  improvement_surcharge  total_amount  pickup_longitude  \\\n",
-      "542479            0.0                    0.3        103.22              null   \n",
-      "159122            0.0                    0.3          8.30      -73.83747864   \n",
-      "180769            0.0                    0.3         70.80      -73.83963776   \n",
-      "4871707           0.0                    0.3          7.30      -73.82751465   \n",
-      "7766271           0.0                    0.3         91.10      -73.83338165   \n",
-      "9039663           0.0                    0.3         94.14       -73.8551712   \n",
-      "9259375           0.0                    0.3         19.30      -73.84205627   \n",
+      "         improvement_surcharge  total_amount  congestion_surcharge  \\\n",
+      "4487880                    0.3        103.22                  <NA>   \n",
+      "159122                     0.3          8.30                  <NA>   \n",
+      "180769                     0.3         70.80                  <NA>   \n",
+      "4871707                    0.3          7.30                  <NA>   \n",
+      "7766271                    0.3         91.10                  <NA>   \n",
+      "9039663                    0.3         94.14                  <NA>   \n",
+      "9259375                    0.3         19.30                  <NA>   \n",
       "\n",
-      "        pickup_latitude dropoff_longitude dropoff_latitude  \n",
-      "542479             null              null             null  \n",
-      "159122      40.57971573      -73.85549164      40.57531738  \n",
-      "180769      40.57685089      -73.83963776      40.57685089  \n",
-      "4871707     40.58262253       -73.8052063      40.58834839  \n",
-      "7766271     40.58089828      -73.83340454      40.58086777  \n",
-      "9039663     40.57473373      -73.85518646      40.57474899  \n",
-      "9259375     40.57816315      -73.76178741      40.59595871  \n",
+      "        airport_fee pickup_longitude pickup_latitude dropoff_longitude  \\\n",
+      "4487880        <NA>             <NA>            <NA>              <NA>   \n",
+      "159122         <NA>     -73.83747864     40.57971573      -73.85549164   \n",
+      "180769         <NA>     -73.83963776     40.57685089      -73.83963776   \n",
+      "4871707        <NA>     -73.82751465     40.58262253       -73.8052063   \n",
+      "7766271        <NA>     -73.83338165     40.58089828      -73.83340454   \n",
+      "9039663        <NA>      -73.8551712     40.57473373      -73.85518646   \n",
+      "9259375        <NA>     -73.84205627     40.57816315      -73.76178741   \n",
       "\n",
-      "[7 rows x 21 columns]\n"
+      "        dropoff_latitude  \n",
+      "4487880             <NA>  \n",
+      "159122       40.57531738  \n",
+      "180769       40.57685089  \n",
+      "4871707      40.58834839  \n",
+      "7766271      40.58086777  \n",
+      "9039663      40.57474899  \n",
+      "9259375      40.59595871  \n",
+      "\n",
+      "[7 rows x 23 columns]\n"
      ]
     }
    ],
@@ -390,7 +410,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -404,7 +424,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes both broken links for the NYC 2016 and NYC 2017 datasets and reran the notebooks under 22.08.