### PR TITLE
Bump `gdal` version

### DIFF
--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -9,3 +9,6 @@ cuda_compiler:
 
 sysroot_version:
   - "2.17"
+
+gdal_version:
+  - ">=3.4.3,<3.4.4a0"

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - python
     - cudf {{ minor_version }}.*
     - rmm {{ minor_version }}.*
-    - gdal >=3.3.0,<3.4.0a0
+    - gdal {{ gdal_version }}
     - geopandas >=0.11.0
 
 test:            # [linux64]

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.20.1"
 
 gdal_version:
-  - ">=3.3.0,<3.4.0a0"
+  - ">=3.4.3,<3.4.4a0"
 
 gtest_version:
   - "1.10.0"


### PR DESCRIPTION
This PR bumps the version of `gdal` that's being used in an attempt to resolve some conda-solve issues in our images.