### PR TITLE
Add Missing Thrust Headers for Thrust 1.17

### DIFF
--- a/cpp/benchmarks/pairwise_linestring_distance.cu
+++ b/cpp/benchmarks/pairwise_linestring_distance.cu
@@ -25,7 +25,9 @@
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/scan.h>
 
 #include <memory>
 

--- a/cpp/benchmarks/points_in_range.cu
+++ b/cpp/benchmarks/points_in_range.cu
@@ -31,6 +31,7 @@
 #include <thrust/random/linear_congruential_engine.h>
 #include <thrust/random/normal_distribution.h>
 #include <thrust/random/uniform_int_distribution.h>
+#include <thrust/tabulate.h>
 
 #include <memory>
 

--- a/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
+++ b/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
@@ -24,7 +24,12 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/advance.h>
 #include <thrust/binary_search.h>
+#include <thrust/distance.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/memory.h>
 
 #include <cuda/atomic>
 

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -26,8 +26,12 @@
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/binary_search.h>
+#include <thrust/distance.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/memory.h>
 
 #include <iterator>
 #include <limits>

--- a/cpp/include/cuspatial/experimental/detail/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_distance.cuh
@@ -23,6 +23,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/transform.h>
+
 #include <type_traits>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/experimental/detail/points_in_range.cuh
+++ b/cpp/include/cuspatial/experimental/detail/points_in_range.cuh
@@ -23,6 +23,10 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/iterator/iterator_traits.h>
+
 #include <type_traits>
 
 namespace cuspatial {

--- a/cpp/src/join/detail/point.cuh
+++ b/cpp/src/join/detail/point.cuh
@@ -18,6 +18,7 @@
 
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
+#include <thrust/execution_policy.h>
 
 namespace cuspatial {
 namespace detail {

--- a/cpp/src/join/quadtree_point_to_nearest_polyline.cu
+++ b/cpp/src/join/quadtree_point_to_nearest_polyline.cu
@@ -34,6 +34,7 @@
 
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
+#include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/trajectory/trajectory_distances_and_speeds.cu
+++ b/cpp/src/trajectory/trajectory_distances_and_speeds.cu
@@ -32,6 +32,7 @@
 #include <thrust/adjacent_difference.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>

--- a/cpp/tests/experimental/spatial/coordinate_transform_test.cu
+++ b/cpp/tests/experimental/spatial/coordinate_transform_test.cu
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <thrust/iterator/transform_iterator.h>
+
 template <typename T>
 struct LonLatToCartesianTest : public ::testing::Test {
 };

--- a/cpp/tests/experimental/spatial/hausdorff_test.cu
+++ b/cpp/tests/experimental/spatial/hausdorff_test.cu
@@ -21,6 +21,8 @@
 #include <rmm/device_vector.hpp>
 
 #include <thrust/host_vector.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <gmock/gmock.h>

--- a/cpp/tests/experimental/spatial/point_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_distance_test.cu
@@ -24,9 +24,12 @@
 
 #include <thrust/generate.h>
 #include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
 #include <thrust/random/linear_congruential_engine.h>
 #include <thrust/random/normal_distribution.h>
+#include <thrust/transform.h>
 #include <thrust/tuple.h>
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
This PR cherry-picked @bdice 45787e8 to include missing headers after updating CI to thrust 1.17, because the original PR that includes this commit may take extra time. This should unblock CI.