### PR TITLE
Remove lonlat_2d and cartesian_2d types

### DIFF
--- a/cpp/benchmarks/pairwise_linestring_distance.cu
+++ b/cpp/benchmarks/pairwise_linestring_distance.cu
@@ -80,7 +80,7 @@ std::tuple<rmm::device_vector<vec_2d<T>>, rmm::device_vector<int32_t>> generate_
   std::vector<vec_2d<T>> points(num_points);
 
   auto random_walk_func = [segment_length](vec_2d<T> const& prev, vec_2d<T> const& rad) {
-    return vec_2d<T>{prev.x + segment_length * rad.x, prev.y + segment_length * rad.y};
+    return prev + segment_length * rad;
   };
 
   thrust::exclusive_scan(

--- a/cpp/benchmarks/pairwise_linestring_distance.cu
+++ b/cpp/benchmarks/pairwise_linestring_distance.cu
@@ -64,24 +64,23 @@ using namespace cuspatial;
  *
  */
 template <typename T>
-std::tuple<rmm::device_vector<cartesian_2d<T>>, rmm::device_vector<int32_t>> generate_linestring(
-  int32_t num_strings, int32_t num_segments_per_string, T segment_length, cartesian_2d<T> init_xy)
+std::tuple<rmm::device_vector<vec_2d<T>>, rmm::device_vector<int32_t>> generate_linestring(
+  int32_t num_strings, int32_t num_segments_per_string, T segment_length, vec_2d<T> init_xy)
 {
   int32_t num_points = num_strings * (num_segments_per_string + 1);
 
   auto offset_iter = detail::make_counting_transform_iterator(
     0, [num_segments_per_string](auto i) { return i * num_segments_per_string; });
   auto rads_iter = detail::make_counting_transform_iterator(0, [](auto i) {
-    return cartesian_2d<T>{cos(static_cast<T>(i)), sin(static_cast<T>(i))};
+    return vec_2d<T>{cos(static_cast<T>(i)), sin(static_cast<T>(i))};
   });
 
   std::vector<int32_t> offsets(offset_iter, offset_iter + num_strings);
-  std::vector<cartesian_2d<T>> rads(rads_iter, rads_iter + num_points);
-  std::vector<cartesian_2d<T>> points(num_points);
+  std::vector<vec_2d<T>> rads(rads_iter, rads_iter + num_points);
+  std::vector<vec_2d<T>> points(num_points);
 
-  auto random_walk_func = [segment_length](cartesian_2d<T> const& prev,
-                                           cartesian_2d<T> const& rad) {
-    return cartesian_2d<T>{prev.x + segment_length * rad.x, prev.y + segment_length * rad.y};
+  auto random_walk_func = [segment_length](vec_2d<T> const& prev, vec_2d<T> const& rad) {
+    return vec_2d<T>{prev.x + segment_length * rad.x, prev.y + segment_length * rad.y};
   };
 
   thrust::exclusive_scan(

--- a/cpp/benchmarks/point_in_polygon.cu
+++ b/cpp/benchmarks/point_in_polygon.cu
@@ -41,8 +41,9 @@ auto constexpr num_rings_per_polygon = 1;  // only 1 ring for now
 template <typename T>
 vec_2d<T> random_point(vec_2d<T> minXY, vec_2d<T> maxXY)
 {
-  auto rand_point = vec_2d<T>{rand(), rand()} / static_cast<T>(RAND_MAX);
-  return minXY + (maxXY - minXY) * rand_point;
+  auto x = minXY.x + (maxXY.x - minXY.x) * rand() / static_cast<T>(RAND_MAX);
+  auto y = minXY.y + (maxXY.y - minXY.y) * rand() / static_cast<T>(RAND_MAX);
+  return vec_2d<T>{x, y};
 }
 
 /**
@@ -82,8 +83,10 @@ generate_polygon(int32_t num_sides, T radius, vec_2d<T> minXY, vec_2d<T> maxXY)
     auto center = random_point(minXY, maxXY);
     std::transform(it, it + num_sides + 1, begin, [num_sides, radius, center](int32_t j) {
       return center +
-             radius * vec_2d<T>{std::cos(2 * PI * (j % num_sides) / static_cast<T>(num_sides)),
-                                std::sin(2 * PI * (j % num_sides) / static_cast<T>(num_sides))};
+             radius *
+               vec_2d<T>{
+                 static_cast<T>(std::cos(2 * PI * (j % num_sides) / static_cast<T>(num_sides))),
+                 static_cast<T>(std::sin(2 * PI * (j % num_sides) / static_cast<T>(num_sides)))};
     });
   }
 

--- a/cpp/benchmarks/point_in_polygon.cu
+++ b/cpp/benchmarks/point_in_polygon.cu
@@ -39,11 +39,10 @@ auto constexpr num_rings_per_polygon = 1;  // only 1 ring for now
  * @brief Generate a random point within a window of [minXY, maxXY]
  */
 template <typename T>
-cartesian_2d<T> random_point(cartesian_2d<T> minXY, cartesian_2d<T> maxXY)
+vec_2d<T> random_point(vec_2d<T> minXY, vec_2d<T> maxXY)
 {
-  auto x = minXY.x + (maxXY.x - minXY.x) * rand() / static_cast<T>(RAND_MAX);
-  auto y = minXY.y + (maxXY.y - minXY.y) * rand() / static_cast<T>(RAND_MAX);
-  return cartesian_2d<T>{x, y};
+  auto rand_point = vec_2d<T>{rand(), rand()} / static_cast<T>(RAND_MAX);
+  return minXY + (maxXY - minXY) * rand_point;
 }
 
 /**
@@ -63,14 +62,12 @@ cartesian_2d<T> random_point(cartesian_2d<T> minXY, cartesian_2d<T> maxXY)
  *
  */
 template <typename T>
-std::tuple<rmm::device_vector<int32_t>,
-           rmm::device_vector<int32_t>,
-           rmm::device_vector<cartesian_2d<T>>>
-generate_polygon(int32_t num_sides, T radius, cartesian_2d<T> minXY, cartesian_2d<T> maxXY)
+std::tuple<rmm::device_vector<int32_t>, rmm::device_vector<int32_t>, rmm::device_vector<vec_2d<T>>>
+generate_polygon(int32_t num_sides, T radius, vec_2d<T> minXY, vec_2d<T> maxXY)
 {
   std::vector<int32_t> polygon_offsets(num_polygons);
   std::vector<int32_t> ring_offsets(num_polygons * num_rings_per_polygon);
-  std::vector<cartesian_2d<T>> polygon_points(31 * (num_sides + 1));
+  std::vector<vec_2d<T>> polygon_points(31 * (num_sides + 1));
 
   std::iota(polygon_offsets.begin(), polygon_offsets.end(), 0);
   std::iota(ring_offsets.begin(), ring_offsets.end(), 0);
@@ -84,11 +81,9 @@ generate_polygon(int32_t num_sides, T radius, cartesian_2d<T> minXY, cartesian_2
     auto begin  = i * num_sides + polygon_points.begin();
     auto center = random_point(minXY, maxXY);
     std::transform(it, it + num_sides + 1, begin, [num_sides, radius, center](int32_t j) {
-      return cartesian_2d<T>{
-        static_cast<T>(radius * std::cos(2 * PI * (j % num_sides) / static_cast<T>(num_sides)) +
-                       center.x),
-        static_cast<T>(radius * std::sin(2 * PI * (j % num_sides) / static_cast<T>(num_sides)) +
-                       center.y)};
+      return center +
+             radius * vec_2d<T>{std::cos(2 * PI * (j % num_sides) / static_cast<T>(num_sides)),
+                                std::sin(2 * PI * (j % num_sides) / static_cast<T>(num_sides))};
     });
   }
 
@@ -102,11 +97,11 @@ generate_polygon(int32_t num_sides, T radius, cartesian_2d<T> minXY, cartesian_2
  * @tparam T The floating point type for the coordinates
  */
 template <typename T>
-rmm::device_vector<cartesian_2d<T>> generate_points(int32_t num_test_points,
-                                                    cartesian_2d<T> minXY,
-                                                    cartesian_2d<T> maxXY)
+rmm::device_vector<vec_2d<T>> generate_points(int32_t num_test_points,
+                                              vec_2d<T> minXY,
+                                              vec_2d<T> maxXY)
 {
-  std::vector<cartesian_2d<T>> points(num_test_points);
+  std::vector<vec_2d<T>> points(num_test_points);
   std::generate(
     points.begin(), points.end(), [minXY, maxXY]() { return random_point(minXY, maxXY); });
   // Implicitly convert to device_vector
@@ -120,8 +115,8 @@ void point_in_polygon_benchmark(nvbench::state& state, nvbench::type_list<T>)
   cuspatial::rmm_pool_raii rmm_pool;
 
   std::srand(0);  // For reproducibility
-  auto const minXY = cartesian_2d<T>{-radius * 2, -radius * 2};
-  auto const maxXY = cartesian_2d<T>{radius * 2, radius * 2};
+  auto const minXY = vec_2d<T>{-radius * 2, -radius * 2};
+  auto const maxXY = vec_2d<T>{radius * 2, radius * 2};
 
   auto const num_test_points{state.get_int64("NumTestPoints")},
     num_sides_per_ring{state.get_int64("NumSidesPerRing")};

--- a/cpp/doc/libcuspatial_refactoring_guide.md
+++ b/cpp/doc/libcuspatial_refactoring_guide.md
@@ -229,7 +229,7 @@ inputs that implements the Haversine distance formula.
 The substance of the refactoring is making the libcudf-based API a wrapper around the header-only 
 API. This mostly involves replacing business logic implementation in the type-dispatched functor 
 with a call to the header-only API. We also need to convert disjoint latitude and longitude inputs 
-into `lonlat_2d<T>` structs. This is easily done using the `cuspatial::make_lonlat_iterator` utility
+into `lonlat_2d<T>` structs. This is easily done using the `cuspatial::make_vec_2d_iterator` utility
 provided in `type_utils.hpp`. 
 
 So, to refactor the libcudf-based API, we remove the following code.
@@ -259,8 +259,8 @@ thrust::transform(rmm::exec_policy(stream),
 And replace it with the following code.
 
 ```C++
-auto lonlat_a = cuspatial::make_lonlat_iterator(a_lon.begin<T>(), a_lat.begin<T>());
-auto lonlat_b = cuspatial::make_lonlat_iterator(b_lon.begin<T>(), b_lat.begin<T>());
+auto lonlat_a = cuspatial::make_vec_2d_iterator(a_lon.begin<T>(), a_lat.begin<T>());
+auto lonlat_b = cuspatial::make_vec_2d_iterator(b_lon.begin<T>(), b_lat.begin<T>());
 
 cuspatial::haversine_distance(lonlat_a,
                               lonlat_a + a_lon.size(),

--- a/cpp/include/cuspatial/detail/utility/traits.hpp
+++ b/cpp/include/cuspatial/detail/utility/traits.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 namespace cuspatial {

--- a/cpp/include/cuspatial/experimental/coordinate_transform.cuh
+++ b/cpp/include/cuspatial/experimental/coordinate_transform.cuh
@@ -33,9 +33,9 @@ namespace cuspatial {
  * @param[out] xy_first: beginning of range of output x/y coordinates.
  * @param[in]  stream: The CUDA stream on which to perform computations and allocate memory.
  *
- * All input iterators must have a `value_type` of `cuspatial::lonlat_2d<T>` (Lat/Lon coordinates),
- * and the output iterator must be able to accept for storage values of type
- * `cuspatial::cartesian_2d<T>` (Cartesian coordinates).
+ * All input iterators must have a `value_type` of `cuspatial::vec_2d<T>` (Lat/Lon coordinates),
+ * and the output iterator must be able to accept for storage values of type `cuspatial::vec_2d<T>`
+ * (Cartesian coordinates).
  *
  * @tparam InputIt Iterator over longitude/latitude locations. Must meet the requirements of
  * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
@@ -56,7 +56,7 @@ template <class InputIt, class OutputIt, class T>
 OutputIt lonlat_to_cartesian(InputIt lon_lat_first,
                              InputIt lon_lat_last,
                              OutputIt xy_first,
-                             lonlat_2d<T> origin,
+                             vec_2d<T> origin,
                              rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/coordinate_transform.cuh
+++ b/cpp/include/cuspatial/experimental/detail/coordinate_transform.cuh
@@ -53,16 +53,16 @@ __device__ inline T lat_to_y(T lat)
 
 template <typename T>
 struct to_cartesian_functor {
-  to_cartesian_functor(lonlat_2d<T> origin) : _origin(origin) {}
+  to_cartesian_functor(vec_2d<T> origin) : _origin(origin) {}
 
-  cartesian_2d<T> __device__ operator()(lonlat_2d<T> loc)
+  vec_2d<T> __device__ operator()(vec_2d<T> loc)
   {
-    return cartesian_2d<T>{lon_to_x(_origin.x - loc.x, midpoint(loc.y, _origin.y)),
-                           lat_to_y(_origin.y - loc.y)};
+    return vec_2d<T>{lon_to_x(_origin.x - loc.x, midpoint(loc.y, _origin.y)),
+                     lat_to_y(_origin.y - loc.y)};
   }
 
  private:
-  lonlat_2d<T> _origin{};
+  vec_2d<T> _origin{};
 };
 
 }  // namespace detail
@@ -71,7 +71,7 @@ template <class InputIt, class OutputIt, class T>
 OutputIt lonlat_to_cartesian(InputIt lon_lat_first,
                              InputIt lon_lat_last,
                              OutputIt xy_first,
-                             lonlat_2d<T> origin,
+                             vec_2d<T> origin,
                              rmm::cuda_stream_view stream)
 {
   static_assert(std::is_floating_point_v<T>,

--- a/cpp/include/cuspatial/experimental/detail/haversine.cuh
+++ b/cpp/include/cuspatial/experimental/detail/haversine.cuh
@@ -58,7 +58,7 @@ struct haversine_distance_functor {
 
 }  // namespace detail
 
-template <class LonLatItA, class LonLatItB, class OutputIt, class Location, class T>
+template <class LonLatItA, class LonLatItB, class OutputIt, class T>
 OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             LonLatItA a_lonlat_last,
                             LonLatItB b_lonlat_first,
@@ -66,15 +66,14 @@ OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             T const radius,
                             rmm::cuda_stream_view stream)
 {
-  using LocationA = detail::iterator_value_type<LonLatItA>;
-  using LocationB = detail::iterator_value_type<LonLatItB>;
-  static_assert(detail::is_same<vec_2d<T>, LocationA, LocationB>(),
+  static_assert(detail::is_same<vec_2d<T>,
+                                detail::iterator_value_type<LonLatItA>,
+                                detail::iterator_value_type<LonLatItB>>(),
                 "Inputs must be cuspatial::vec_2d");
   static_assert(
     detail::is_same_floating_point<T,
-                                   typename LocationA::value_type,
-                                   typename LocationB::value_type,
-                                   typename std::iterator_traits<OutputIt>::value_type>(),
+                                   typename detail::iterator_vec_base_type<LonLatItA>,
+                                   typename detail::iterator_value_type<OutputIt>>(),
     "All iterator types and radius must have the same floating-point coordinate value type.");
 
   CUSPATIAL_EXPECTS(radius > 0, "radius must be positive.");

--- a/cpp/include/cuspatial/experimental/detail/haversine.cuh
+++ b/cpp/include/cuspatial/experimental/detail/haversine.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuspatial/constants.hpp>
+#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
 #include <cuspatial/vec_2d.hpp>
 
@@ -24,7 +25,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 
@@ -36,12 +36,12 @@ template <typename T>
 struct haversine_distance_functor {
   haversine_distance_functor(T radius) : radius_(radius) {}
 
-  __device__ T operator()(lonlat_2d<T> point_a, lonlat_2d<T> point_b)
+  __device__ T operator()(vec_2d<T> lonlat_a, vec_2d<T> lonlat_b)
   {
-    auto ax = point_a.x * DEGREE_TO_RADIAN;
-    auto ay = point_a.y * DEGREE_TO_RADIAN;
-    auto bx = point_b.x * DEGREE_TO_RADIAN;
-    auto by = point_b.y * DEGREE_TO_RADIAN;
+    auto ax = lonlat_a.x * DEGREE_TO_RADIAN;
+    auto ay = lonlat_a.y * DEGREE_TO_RADIAN;
+    auto bx = lonlat_b.x * DEGREE_TO_RADIAN;
+    auto by = lonlat_b.y * DEGREE_TO_RADIAN;
 
     // haversine formula
     auto x        = (bx - ax) / 2;
@@ -66,15 +66,16 @@ OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             T const radius,
                             rmm::cuda_stream_view stream)
 {
-  using LocationB = typename std::iterator_traits<LonLatItB>::value_type;
+  using LocationA = detail::iterator_value_type<LonLatItA>;
+  using LocationB = detail::iterator_value_type<LonLatItB>;
+  static_assert(detail::is_same<vec_2d<T>, LocationA, LocationB>(),
+                "Inputs must be cuspatial::vec_2d");
   static_assert(
-    std::conjunction_v<std::is_same<lonlat_2d<T>, Location>, std::is_same<lonlat_2d<T>, LocationB>>,
-    "Inputs must be cuspatial::lonlat_2d");
-  static_assert(
-    std::conjunction_v<std::is_floating_point<T>,
-                       std::is_floating_point<typename LocationB::value_type>,
-                       std::is_floating_point<typename std::iterator_traits<OutputIt>::value_type>>,
-    "Haversine distance supports only floating-point coordinates.");
+    detail::is_same_floating_point<T,
+                                   typename LocationA::value_type,
+                                   typename LocationB::value_type,
+                                   typename std::iterator_traits<OutputIt>::value_type>(),
+    "All iterator types and radius must have the same floating-point coordinate value type.");
 
   CUSPATIAL_EXPECTS(radius > 0, "radius must be positive.");
 

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -157,7 +157,7 @@ void pairwise_linestring_distance(OffsetIterator linestring1_offsets_first,
 
   static_assert(detail::is_same<vec_2d<T>,
                                 typename detail::iterator_value_type<Cart2dItA>,
-                                typename detail::iterator_value_type<Cart2dItB>>,
+                                typename detail::iterator_value_type<Cart2dItB>>(),
                 "All input types must be cuspatial::vec_2d with the same value type");
 
   auto const num_linestring_pairs =

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -148,21 +148,17 @@ void pairwise_linestring_distance(OffsetIterator linestring1_offsets_first,
                                   OutputIt distances_first,
                                   rmm::cuda_stream_view stream)
 {
-  using T = typename std::iterator_traits<Cart2dItA>::value_type::value_type;
+  using T = typename detail::iterator_vec_base_type<Cart2dItA>;
 
-  static_assert(
-    detail::is_floating_point<T,
-                              typename std::iterator_traits<Cart2dItB>::value_type::value_type,
-                              typename std::iterator_traits<OutputIt>::value_type>(),
-    "Inputs and output must have floating point value type.");
+  static_assert(detail::is_same_floating_point<T,
+                                               typename detail::iterator_vec_base_type<Cart2dItB>,
+                                               typename detail::iterator_value_type<OutputIt>>(),
+                "Inputs and output must have the same floating point value type.");
 
-  static_assert(detail::is_same<T, typename std::iterator_traits<OutputIt>::value_type>(),
-                "Inputs and output must have the same value type.");
-
-  static_assert(detail::is_same<cartesian_2d<T>,
-                                typename std::iterator_traits<Cart2dItA>::value_type,
-                                typename std::iterator_traits<Cart2dItB>::value_type>(),
-                "All input types must be cuspatial::cartesian_2d with the same value type");
+  static_assert(detail::is_same<vec_2d<T>,
+                                typename detail::iterator_value_type<Cart2dItA>,
+                                typename detail::iterator_value_type<Cart2dItB>>,
+                "All input types must be cuspatial::vec_2d with the same value type");
 
   auto const num_linestring_pairs =
     thrust::distance(linestring1_offsets_first, linestring1_offsets_last);

--- a/cpp/include/cuspatial/experimental/detail/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_distance.cuh
@@ -36,21 +36,17 @@ OutputIt pairwise_point_distance(Cart2dItA points1_first,
                                  OutputIt distances_first,
                                  rmm::cuda_stream_view stream)
 {
-  using T = typename std::iterator_traits<Cart2dItA>::value_type::value_type;
+  using T = typename detail::iterator_vec_base_type<Cart2dItA>;
 
-  static_assert(
-    detail::is_floating_point<T,
-                              typename std::iterator_traits<Cart2dItB>::value_type::value_type,
-                              typename std::iterator_traits<OutputIt>::value_type>(),
-    "Inputs and output must be floating point types.");
+  static_assert(detail::is_same_floating_point<T,
+                                               typename detail::iterator_vec_base_type<Cart2dItB>,
+                                               typename detail::iterator_value_type<OutputIt>>(),
+                "Inputs and output must have the same floating point value type.");
 
-  static_assert(detail::is_same<T, typename std::iterator_traits<OutputIt>::value_type>(),
-                "Inputs and output must be the same types.");
-
-  static_assert(detail::is_same<cartesian_2d<T>,
-                                typename std::iterator_traits<Cart2dItA>::value_type,
-                                typename std::iterator_traits<Cart2dItB>::value_type>(),
-                "All Input types must be cuspatial::cartesian_2d with the same value type");
+  static_assert(detail::is_same<vec_2d<T>,
+                                typename detail::iterator_value_type<Cart2dItA>,
+                                typename detail::iterator_value_type<Cart2dItB>>,
+                "All Input types must be cuspatial::vec_2d with the same value type");
 
   return thrust::transform(rmm::exec_policy(stream),
                            points1_first,

--- a/cpp/include/cuspatial/experimental/detail/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_distance.cuh
@@ -45,7 +45,7 @@ OutputIt pairwise_point_distance(Cart2dItA points1_first,
 
   static_assert(detail::is_same<vec_2d<T>,
                                 typename detail::iterator_value_type<Cart2dItA>,
-                                typename detail::iterator_value_type<Cart2dItB>>,
+                                typename detail::iterator_value_type<Cart2dItB>>(),
                 "All Input types must be cuspatial::vec_2d with the same value type");
 
   return thrust::transform(rmm::exec_policy(stream),

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -170,10 +170,10 @@ OutputIt point_in_polygon(Cart2dItA test_points_first,
 
   static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
                 "Underlying type of Cart2dItA and Cart2dItB must be the same floating point type");
-  static_assert(detail::is_same<cartesian_2d<T>,
+  static_assert(detail::is_same<vec_2d<T>,
                                 detail::iterator_value_type<Cart2dItA>,
                                 detail::iterator_value_type<Cart2dItB>>(),
-                "Inputs must be cuspatial::cartesian_2d");
+                "Inputs must be cuspatial::vec_2d");
 
   static_assert(detail::is_integral<detail::iterator_value_type<OffsetIteratorA>,
                                     detail::iterator_value_type<OffsetIteratorB>>(),

--- a/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
@@ -89,10 +89,10 @@ void __global__ pairwise_point_linestring_distance(Cart2dItA points_first,
     // Note that the last point for the last linestring is guarded by the grid-stride loop.
     if (offsets_iter != linestring_offsets_last and *offsets_iter - 1 == idx) { continue; }
 
-    auto point_idx = thrust::distance(linestring_offsets_first, thrust::prev(offsets_iter));
-    cartesian_2d<T> const a = linestring_points_first[idx];
-    cartesian_2d<T> const b = linestring_points_first[idx + 1];
-    cartesian_2d<T> const c = points_first[point_idx];
+    auto point_idx    = thrust::distance(linestring_offsets_first, thrust::prev(offsets_iter));
+    vec_2d<T> const a = linestring_points_first[idx];
+    vec_2d<T> const b = linestring_points_first[idx + 1];
+    vec_2d<T> const c = points_first[point_idx];
 
     auto const distance_squared = point_to_segment_distance_squared(c, a, b);
 
@@ -117,10 +117,10 @@ void pairwise_point_linestring_distance(Cart2dItA points_first,
   static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
                 "Inputs must have same floating point value type.");
 
-  static_assert(detail::is_same<cartesian_2d<T>,
+  static_assert(detail::is_same<vec_2d<T>,
                                 detail::iterator_value_type<Cart2dItA>,
                                 detail::iterator_value_type<Cart2dItB>>(),
-                "Inputs must be cuspatial::cartesian_2d");
+                "Inputs must be cuspatial::vec_2d<T>");
 
   auto const num_pairs = thrust::distance(points_first, points_last);
 

--- a/cpp/include/cuspatial/experimental/haversine.cuh
+++ b/cpp/include/cuspatial/experimental/haversine.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuspatial/constants.hpp>
+#include <cuspatial/detail/utility/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -52,12 +53,10 @@ namespace cuspatial {
  * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
  * @tparam OutputIt Output iterator. Must meet the requirements of
  * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible and mutable.
- * @tparam Location The `value_type` of `LonLatItA` and `LonLatItB`. Must be
- * `cuspatial::lonlat_2d<T>`.
  * @tparam T The underlying coordinate type. Must be a floating-point type.
  *
  * @pre All iterators must have the same `Location` type, with  the same underlying floating-point
- * coordinate type (e.g. `cuspatial::lonlat_2d<float>`).
+ * coordinate type (e.g. `cuspatial::vec_2d<float>`).
  *
  * @return Output iterator to the element past the last distance computed.
  *
@@ -67,8 +66,7 @@ namespace cuspatial {
 template <class LonLatItA,
           class LonLatItB,
           class OutputIt,
-          class Location = typename std::iterator_traits<LonLatItA>::value_type,
-          class T        = typename Location::value_type>
+          class T = typename detail::iterator_vec_base_type<LonLatItA>>
 OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             LonLatItA a_lonlat_last,
                             LonLatItB b_lonlat_first,

--- a/cpp/include/cuspatial/experimental/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/linestring_distance.cuh
@@ -51,7 +51,7 @@ namespace cuspatial {
  * @param distances_first beginning iterator to output
  * @param stream The CUDA stream to use for device memory operations and kernel launches.
  *
- * @pre all input iterators for coordinates must have `cuspatial::cartesian_2d` type.
+ * @pre all input iterators for coordinates must have `cuspatial::vec_2d` type.
  * @pre all scalar types must be floating point types, and must be the same type for all input
  * iterators and output iterators.
  *

--- a/cpp/include/cuspatial/experimental/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/point_distance.cuh
@@ -38,7 +38,7 @@ namespace cuspatial {
  * @param stream The CUDA stream to use for device memory operations and kernel launches
  * @return Output iterator to one past the last element in the output range
  *
- * @pre all input iterators for coordinates must have a `value_type` of `cuspatial::cartesian_2d`.
+ * @pre all input iterators for coordinates must have a `value_type` of `cuspatial::vec_2d`.
  * @pre all scalar types must be floating point types, and must be the same type for all input
  * iterators and output iterators.
  *

--- a/cpp/include/cuspatial/experimental/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/point_in_polygon.cuh
@@ -82,10 +82,9 @@ namespace cuspatial {
  *        +-----------+   +------------------------+
  * ```
  *
- * @pre All point iterators must have the same `cartesian_2d` type, with  the same underlying
- * floating-point coordinate type (e.g. `cuspatial::cartesian_2d<float>`).
- * @pre All offset iterators must have the same `cartesian_2d` type, with  the same underlying
- * integeral type.
+ * @pre All point iterators must have the same `vec_2d` value type, with  the same underlying
+ * floating-point coordinate type (e.g. `cuspatial::vec_2d<float>`).
+ * @pre All offset iterators must have the same integral value type.
  * @pre Output iterator must be mutable and iterate on int32_t type.
  *
  * @throw cuspatial::logic_error if the number of polygons or rings exceeds 31.

--- a/cpp/include/cuspatial/experimental/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/point_linestring_distance.cuh
@@ -46,7 +46,7 @@ namespace cuspatial {
  * @param distances_first beginning the output range of distances
  * @param stream The CUDA stream to use for device memory operations and kernel launches.
  *
- * @pre all input iterators for coordinates must have `cuspatial::cartesian_2d` type.
+ * @pre all input iterators for coordinates must have `cuspatial::vec_2d` type.
  * @pre all scalar types must be floating point types, and must be the same type for all input
  * iterators and output iterators.
  *

--- a/cpp/include/cuspatial/experimental/type_utils.hpp
+++ b/cpp/include/cuspatial/experimental/type_utils.hpp
@@ -15,6 +15,7 @@
  */
 
 #include <cuspatial/detail/iterator.hpp>
+#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <thrust/iterator/transform_iterator.h>
@@ -32,7 +33,7 @@ namespace detail {
  * @internal
  * @brief Helper to convert a tuple of elements into a `vec_2d`
  */
-template <typename T, typename VectorType>
+template <typename T, typename VectorType = vec_2d<T>>
 struct tuple_to_vec_2d {
   __device__ VectorType operator()(thrust::tuple<T, T> const& pos)
   {
@@ -44,7 +45,7 @@ struct tuple_to_vec_2d {
  * @internal
  * @brief Helper to convert a `vec_2d` into a tuple of elements
  */
-template <typename T, typename VectorType>
+template <typename T, typename VectorType = vec_2d<T>>
 struct vec_2d_to_tuple {
   __device__ thrust::tuple<T, T> operator()(VectorType const& xy)
   {
@@ -65,7 +66,7 @@ struct vec_2d_to_tuple {
  * Interleaves x and y coordinates from separate iterators into a single iterator to x-y
  * coordinates.
  *
- * @tparam VectorType cuSpatial vector type, must be `vec_2d`, `lonlat_2d` or `cartesian_2d`
+ * @tparam VectorType cuSpatial vector type, must be `vec_2d`
  * @tparam FirstIter Iterator type to the first component of `vec_2d`. Must meet the requirements of
  * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
  * @tparam SecondIter Iterator type to the second component of `vec_2d`. Must meet the requirements
@@ -79,72 +80,15 @@ struct vec_2d_to_tuple {
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
  * "LegacyRandomAccessIterator"
  */
-template <typename VectorType, typename FirstIter, typename SecondIter>
+template <typename FirstIter, typename SecondIter>
 auto make_vec_2d_iterator(FirstIter first, SecondIter second)
 {
   using T = typename std::iterator_traits<FirstIter>::value_type;
-  static_assert(std::is_same_v<T, typename std::iterator_traits<SecondIter>::value_type>,
+  static_assert(detail::is_same<T, detail::iterator_value_type<SecondIter>>(),
                 "Iterator value_type mismatch");
 
   auto zipped = thrust::make_zip_iterator(thrust::make_tuple(first, second));
-  return thrust::make_transform_iterator(zipped, detail::tuple_to_vec_2d<T, VectorType>());
-}
-
-/**
- * @brief Create an iterator to `lonlat_2d` data from two input iterators.
- *
- * Interleaves longitude and latitude from separate iterators into a single iterator to lon/lat
- * coordinates.
- * @tparam FirstIter Iterator type to the first component (the longitude) of `lonlat_2d`. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam SecondIter Iterator type to the second component (the latitude) of `lonlat_2d`. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @param first Iterator to beginning of `lonlat_2d::x`
- * @param second Iterator to beginning of `lonlat_2d::y`
- * @return Iterator to `lonlat_2d`
- *
- * @pre `first` and `second` must iterate on same data type.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
- */
-template <typename FirstIter, typename SecondIter>
-auto make_vec_2d_iterator(FirstIter first, SecondIter second)
-{
-  using T = typename std::iterator_traits<FirstIter>::value_type;
-  return make_vec_2d_iterator<vec_2d<T>>(first, second);
-}
-
-template <typename FirstIter, typename SecondIter>
-auto make_lonlat_iterator(FirstIter first, SecondIter second)
-{
-  using T = typename std::iterator_traits<FirstIter>::value_type;
-  return make_vec_2d_iterator<lonlat_2d<T>>(first, second);
-}
-
-/**
- * @brief Create an iterator to `cartesian_2d` data from two input iterators.
- *
- * Interleaves x and y coordinates from separate iterators into a single iterator to x-y
- * coordinates.
- * @tparam FirstIter Iterator type to the first component of `cartesian_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam SecondIter Iterator type to the second component of `cartesian_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @param first Iterator to beginning of `cartesian_2d::x`
- * @param second Iterator to beginning of `cartesian_2d::y`
- * @return Iterator to `cartesian_2d`
- *
- * @pre `first` and `second` must iterate on same data type.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
- */
-template <typename FirstIter, typename SecondIter>
-auto make_cartesian_2d_iterator(FirstIter first, SecondIter second)
-{
-  using T = typename std::iterator_traits<FirstIter>::value_type;
-  return make_vec_2d_iterator<cartesian_2d<T>>(first, second);
+  return thrust::make_transform_iterator(zipped, detail::tuple_to_vec_2d<T>());
 }
 
 /**
@@ -154,7 +98,7 @@ auto make_cartesian_2d_iterator(FirstIter first, SecondIter second)
  * can be written interleaved x/y data. This allows using two separate arrays of
  * output data with APIs that expect an iterator to structured data.
  *
- * @tparam VectorType cuSpatial vector type, must be `vec_2d`, `lonlat_2d` or `cartesian_2d`
+ * @tparam VectorType cuSpatial vector type, must be `vec_2d`
  * @tparam FirstIter Iterator type to the first component of `vec_2d`. Must meet the
  * requirements of [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
  * @tparam SecondIter Iterator type to the second component of `vec_2d`. Must meet the
@@ -168,67 +112,12 @@ auto make_cartesian_2d_iterator(FirstIter first, SecondIter second)
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
  * "LegacyRandomAccessIterator"
  */
-template <typename VectorType, typename FirstIter, typename SecondIter>
+template <typename FirstIter, typename SecondIter>
 auto make_zipped_vec_2d_output_iterator(FirstIter first, SecondIter second)
 {
   using T         = typename std::iterator_traits<FirstIter>::value_type;
   auto zipped_out = thrust::make_zip_iterator(thrust::make_tuple(first, second));
-  return thrust::make_transform_output_iterator(zipped_out,
-                                                detail::vec_2d_to_tuple<T, VectorType>());
-}
-
-/**
- * @brief Create an output iterator to `lonlat_2d` from two output iterators.
- *
- * Creates an output iterator from separate iterators to longitude and latitude data
- * to which can be written interleaved longitude/latitude data. This allows using two
- * separate arrays of output data with APIs that expect an iterator to interleaved
- * data.
- *
- * @tparam FirstIter Iterator type to the first component of `lonlat_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
- * @tparam SecondIter Iterator type to the second component of `lonlat_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
- * @param first Iterator to beginning of longitude data.
- * @param second Iterator of beginning of latitude data.
- * @return Iterator to `lonlat_2d`
- *
- * @pre `first` and `second` must iterate on same data type.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
- */
-template <typename FirstIter, typename SecondIter>
-auto make_zipped_lonlat_output_iterator(FirstIter first, SecondIter second)
-{
-  using T = typename std::iterator_traits<FirstIter>::value_type;
-  return make_zipped_vec_2d_output_iterator<lonlat_2d<T>>(first, second);
-}
-
-/**
- * @brief Create an output iterator to `cartesian_2d` from two output iterators.
- *
- * Creates an output iterator from separate iterators to x and y data to which
- * can be written interleaved x/y data. This allows using two separate arrays of
- * output data with APIs that expect an iterator to structured data.
- * @tparam FirstIter Iterator type to the first component of `cartesian_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
- * @tparam SecondIter Iterator type to the second component of `cartesian_2d`. Must meet the
- * requirements of [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
- * @param first Iterator to beginning of `x` data.
- * @param second Iterator to beginning of `y` data.
- * @return Iterator to `cartesian_2d`
- *
- * @pre `first` and `second` must iterate on same data type.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
- */
-template <typename FirstIter, typename SecondIter>
-auto make_zipped_cartesian_2d_output_iterator(FirstIter first, SecondIter second)
-{
-  using T = typename std::iterator_traits<FirstIter>::value_type;
-  return make_zipped_vec_2d_output_iterator<cartesian_2d<T>>(first, second);
+  return thrust::make_transform_output_iterator(zipped_out, detail::vec_2d_to_tuple<T>());
 }
 
 template <typename T, typename VectorType = vec_2d<T>>
@@ -242,22 +131,6 @@ auto interleaved_iterator_to_vec_2d_iterator(Iter d_points_begin)
 {
   using T = typename std::iterator_traits<Iter>::value_type;
   return detail::make_counting_transform_iterator(0, interleaved_to_vec_2d<T>{d_points_begin});
-}
-
-template <typename Iter>
-auto interleaved_iterator_to_cartesian_2d_iterator(Iter d_points_begin)
-{
-  using T = typename std::iterator_traits<Iter>::value_type;
-  return detail::make_counting_transform_iterator(
-    0, interleaved_to_vec_2d<T, cartesian_2d<T>>{d_points_begin});
-}
-
-template <typename Iter>
-auto interleaved_iterator_to_lonlat_2d_iterator(Iter d_points_begin)
-{
-  using T = typename std::iterator_traits<Iter>::value_type;
-  return detail::make_counting_transform_iterator(
-    0, interleaved_to_vec_2d<T, lonlat_2d<T>>{d_points_begin});
 }
 
 /**

--- a/cpp/include/cuspatial/vec_2d.hpp
+++ b/cpp/include/cuspatial/vec_2d.hpp
@@ -42,26 +42,6 @@ struct alignas(2 * sizeof(T)) vec_2d {
 };
 
 /**
- * @brief A geographical Longitude/Latitude (LonLat) coordinate pair
- *
- * `x` is the longitude coordinate, `y` is the latitude coordinate.
- *
- * @tparam T the base type for the coordinates
- */
-template <typename T>
-struct alignas(2 * sizeof(T)) lonlat_2d : vec_2d<T> {
-};
-
-/**
- * @brief A Cartesian (x/y) coordinate pair.
- *
- * @tparam T the base type for the coordinates.
- */
-template <typename T>
-struct alignas(2 * sizeof(T)) cartesian_2d : vec_2d<T> {
-};
-
-/**
  * @brief Compare two 2D vectors for equality.
  */
 template <typename T>

--- a/cpp/src/spatial/haversine.cu
+++ b/cpp/src/spatial/haversine.cu
@@ -56,8 +56,8 @@ struct haversine_functor {
     auto mask_policy = cudf::mask_allocation_policy::NEVER;
     auto result      = cudf::allocate_like(a_lon, a_lon.size(), mask_policy, mr);
 
-    auto lonlat_a = cuspatial::make_lonlat_iterator(a_lon.begin<T>(), a_lat.begin<T>());
-    auto lonlat_b = cuspatial::make_lonlat_iterator(b_lon.begin<T>(), b_lat.begin<T>());
+    auto lonlat_a = cuspatial::make_vec_2d_iterator(a_lon.begin<T>(), a_lat.begin<T>());
+    auto lonlat_b = cuspatial::make_vec_2d_iterator(b_lon.begin<T>(), b_lat.begin<T>());
 
     cuspatial::haversine_distance(lonlat_a,
                                   lonlat_a + a_lon.size(),

--- a/cpp/src/spatial/linestring_distance.cu
+++ b/cpp/src/spatial/linestring_distance.cu
@@ -63,9 +63,9 @@ struct pairwise_linestring_distance_functor {
                                                mr);
 
     auto linestring1_coords_it =
-      make_cartesian_2d_iterator(linestring1_points_x.begin<T>(), linestring1_points_y.begin<T>());
+      make_vec_2d_iterator(linestring1_points_x.begin<T>(), linestring1_points_y.begin<T>());
     auto linestring2_coords_it =
-      make_cartesian_2d_iterator(linestring2_points_x.begin<T>(), linestring2_points_y.begin<T>());
+      make_vec_2d_iterator(linestring2_points_x.begin<T>(), linestring2_points_y.begin<T>());
 
     pairwise_linestring_distance(linestring1_offsets.begin(),
                                  linestring1_offsets.end(),

--- a/cpp/src/spatial/lonlat_to_cartesian.cu
+++ b/cpp/src/spatial/lonlat_to_cartesian.cu
@@ -63,12 +63,12 @@ struct lonlat_to_cartesian_functor {
     auto output_y =
       cudf::make_fixed_width_column(type, size, cudf::mask_state::UNALLOCATED, stream, mr);
 
-    auto lonlat_begin = cuspatial::make_lonlat_iterator(input_lon.begin<T>(), input_lat.begin<T>());
+    auto lonlat_begin = cuspatial::make_vec_2d_iterator(input_lon.begin<T>(), input_lat.begin<T>());
 
-    auto output_zip = cuspatial::make_zipped_cartesian_2d_output_iterator(
+    auto output_zip = cuspatial::make_zipped_vec_2d_output_iterator(
       output_x->mutable_view().begin<T>(), output_y->mutable_view().begin<T>());
 
-    auto origin = cuspatial::lonlat_2d<T>{origin_lon, origin_lat};
+    auto origin = cuspatial::vec_2d<T>{origin_lon, origin_lat};
 
     cuspatial::lonlat_to_cartesian(
       lonlat_begin, lonlat_begin + input_lon.size(), output_zip, origin, stream);

--- a/cpp/src/spatial/point_distance.cu
+++ b/cpp/src/spatial/point_distance.cu
@@ -48,8 +48,8 @@ struct pairwise_point_distance_functor {
                                                stream,
                                                mr);
 
-    auto points1_it = make_cartesian_2d_iterator(points1_x.begin<T>(), points1_y.begin<T>());
-    auto points2_it = make_cartesian_2d_iterator(points2_x.begin<T>(), points2_y.begin<T>());
+    auto points1_it = make_vec_2d_iterator(points1_x.begin<T>(), points1_y.begin<T>());
+    auto points2_it = make_vec_2d_iterator(points2_x.begin<T>(), points2_y.begin<T>());
 
     pairwise_point_distance(points1_it,
                             points1_it + points1_x.size(),

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -65,11 +65,11 @@ struct point_in_polygon_functor {
     if (results->size() == 0) { return results; }
 
     auto points_begin =
-      cuspatial::make_cartesian_2d_iterator(test_points_x.begin<T>(), test_points_y.begin<T>());
+      cuspatial::make_vec_2d_iterator(test_points_x.begin<T>(), test_points_y.begin<T>());
     auto polygon_offsets_begin = poly_offsets.begin<cudf::size_type>();
     auto ring_offsets_begin    = poly_ring_offsets.begin<cudf::size_type>();
     auto polygon_points_begin =
-      cuspatial::make_cartesian_2d_iterator(poly_points_x.begin<T>(), poly_points_y.begin<T>());
+      cuspatial::make_vec_2d_iterator(poly_points_x.begin<T>(), poly_points_y.begin<T>());
     auto results_begin = results->mutable_view().begin<int32_t>();
 
     cuspatial::point_in_polygon(points_begin,

--- a/cpp/src/spatial/point_linestring_distance.cu
+++ b/cpp/src/spatial/point_linestring_distance.cu
@@ -53,9 +53,9 @@ struct pairwise_point_linestring_distance_functor {
     auto output = cudf::make_numeric_column(
       points_xy.type(), num_pairs, cudf::mask_state::UNALLOCATED, stream, mr);
 
-    auto points_it = interleaved_iterator_to_cartesian_2d_iterator(points_xy.begin<T>());
+    auto points_it = interleaved_iterator_to_vec_2d_iterator(points_xy.begin<T>());
     auto linestring_points_it =
-      interleaved_iterator_to_cartesian_2d_iterator(linestring_points_xy.begin<T>());
+      interleaved_iterator_to_vec_2d_iterator(linestring_points_xy.begin<T>());
     auto output_begin = output->mutable_view().begin<T>();
 
     pairwise_point_linestring_distance(points_it,

--- a/cpp/src/spatial_window/spatial_window.cu
+++ b/cpp/src/spatial_window/spatial_window.cu
@@ -44,7 +44,7 @@ struct spatial_window_dispatch {
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
   {
-    auto points_begin = cuspatial::make_cartesian_2d_iterator(x.begin<T>(), y.begin<T>());
+    auto points_begin = cuspatial::make_vec_2d_iterator(x.begin<T>(), y.begin<T>());
 
     auto window_min =
       cuspatial::vec_2d<T>{static_cast<T>(window_min_x), static_cast<T>(window_min_y)};
@@ -63,7 +63,7 @@ struct spatial_window_dispatch {
     auto& output_x = cols[0];
     auto& output_y = cols[1];
 
-    auto output_zip = cuspatial::make_zipped_cartesian_2d_output_iterator(
+    auto output_zip = cuspatial::make_zipped_vec_2d_output_iterator(
       output_x->mutable_view().begin<T>(), output_y->mutable_view().begin<T>());
 
     cuspatial::copy_points_in_range(

--- a/cpp/tests/experimental/spatial/coordinate_transform_test.cu
+++ b/cpp/tests/experimental/spatial/coordinate_transform_test.cu
@@ -34,8 +34,8 @@ TYPED_TEST_CASE(LonLatToCartesianTest, TestTypes);
 TYPED_TEST(LonLatToCartesianTest, Empty)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{-90.66511046, 42.49197018};
 
@@ -57,8 +57,8 @@ TYPED_TEST(LonLatToCartesianTest, Empty)
 TYPED_TEST(LonLatToCartesianTest, Single)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{-90.66511046, 42.49197018};
 
@@ -80,8 +80,8 @@ TYPED_TEST(LonLatToCartesianTest, Single)
 TYPED_TEST(LonLatToCartesianTest, Extremes)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{0, 0};
 
@@ -109,8 +109,8 @@ TYPED_TEST(LonLatToCartesianTest, Extremes)
 TYPED_TEST(LonLatToCartesianTest, Multiple)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{-90.66511046, 42.49197018};
 
@@ -140,8 +140,8 @@ TYPED_TEST(LonLatToCartesianTest, Multiple)
 TYPED_TEST(LonLatToCartesianTest, OriginOutOfBounds)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{-181, -91};
 
@@ -160,7 +160,7 @@ TYPED_TEST(LonLatToCartesianTest, OriginOutOfBounds)
 
 template <typename T>
 struct identity_xform {
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
   __device__ Location operator()(Location const& loc) { return loc; };
 };
 
@@ -168,8 +168,8 @@ struct identity_xform {
 TYPED_TEST(LonLatToCartesianTest, TransformIterator)
 {
   using T    = TypeParam;
-  using Loc  = cuspatial::lonlat_2d<T>;
-  using Cart = cuspatial::cartesian_2d<T>;
+  using Loc  = cuspatial::vec_2d<T>;
+  using Cart = cuspatial::vec_2d<T>;
 
   auto origin = Loc{-90.66511046, 42.49197018};
 

--- a/cpp/tests/experimental/spatial/haversine_test.cu
+++ b/cpp/tests/experimental/spatial/haversine_test.cu
@@ -34,7 +34,7 @@ TYPED_TEST_CASE(HaversineTest, TestTypes);
 TYPED_TEST(HaversineTest, Empty)
 {
   using T        = TypeParam;
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
 
   auto a_lonlat = rmm::device_vector<Location>{};
   auto b_lonlat = rmm::device_vector<Location>{};
@@ -52,7 +52,7 @@ TYPED_TEST(HaversineTest, Empty)
 TYPED_TEST(HaversineTest, Zero)
 {
   using T        = TypeParam;
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
   using LocVec   = std::vector<Location>;
 
   auto a_lonlat = rmm::device_vector<Location>(1, Location{0, 0});
@@ -71,7 +71,7 @@ TYPED_TEST(HaversineTest, Zero)
 TYPED_TEST(HaversineTest, NegativeRadius)
 {
   using T        = TypeParam;
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
   using LocVec   = std::vector<Location>;
 
   auto a_lonlat = rmm::device_vector<Location>(LocVec({Location{1, 1}, Location{0, 0}}));
@@ -88,7 +88,7 @@ TYPED_TEST(HaversineTest, NegativeRadius)
 TYPED_TEST(HaversineTest, EquivalentPoints)
 {
   using T        = TypeParam;
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
 
   auto h_a_lonlat = std::vector<Location>({{-180, 0}, {180, 30}});
   auto h_b_lonlat = std::vector<Location>({{180, 0}, {-180, 30}});
@@ -110,7 +110,7 @@ TYPED_TEST(HaversineTest, EquivalentPoints)
 
 template <typename T>
 struct identity_xform {
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
   __device__ Location operator()(Location const& loc) { return loc; };
 };
 
@@ -118,7 +118,7 @@ struct identity_xform {
 TYPED_TEST(HaversineTest, TransformIterator)
 {
   using T        = TypeParam;
-  using Location = cuspatial::lonlat_2d<T>;
+  using Location = cuspatial::vec_2d<T>;
 
   auto h_a_lonlat = std::vector<Location>({{-180, 0}, {180, 30}});
   auto h_b_lonlat = std::vector<Location>({{180, 0}, {-180, 30}});

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -47,11 +47,11 @@ TYPED_TEST_CASE(PairwiseLinestringDistanceTest, TestTypes);
 TYPED_TEST(PairwiseLinestringDistanceTest, FromSeparateArrayInputs)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
-  auto a_cart2d = rmm::device_vector<cartesian_2d<T>>{
+  auto a_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
-  auto b_cart2d = rmm::device_vector<cartesian_2d<T>>{
+  auto b_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 1.0f}, {1.0f, 1.0f}, {2.0f, 1.0f}, {3.0f, 1.0f}, {4.0f, 1.0f}})};
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0}};
 
@@ -73,9 +73,9 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSeparateArrayInputs)
 TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
-  auto cart2ds = rmm::device_vector<cartesian_2d<T>>{
+  auto cart2ds = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0}};
 
@@ -96,18 +96,18 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
 TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   auto a_cart2d_x = rmm::device_vector<T>{std::vector<T>{0.0, 1.0, 2.0, 3.0, 4.0}};
   auto a_cart2d_y = rmm::device_vector<T>(5, 0.0);
 
-  auto a_begin = make_cartesian_2d_iterator(a_cart2d_x.begin(), a_cart2d_y.begin());
+  auto a_begin = make_vec_2d_iterator(a_cart2d_x.begin(), a_cart2d_y.begin());
   auto a_end   = a_begin + a_cart2d_x.size();
 
   auto b_cart2d_x = rmm::device_vector<T>{std::vector<T>{0.0, 1.0, 2.0, 3.0, 4.0}};
   auto b_cart2d_y = rmm::device_vector<T>(5, 1.0);
 
-  auto b_begin = make_cartesian_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
+  auto b_begin = make_vec_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
   auto b_end   = b_begin + b_cart2d_x.size();
 
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0}};
@@ -124,15 +124,15 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
 TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
-  auto a_cart2d = rmm::device_vector<cartesian_2d<T>>{
+  auto a_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
 
   auto b_cart2d_x = rmm::device_vector<T>{std::vector<T>{0.0, 1.0, 2.0, 3.0, 4.0}};
   auto b_cart2d_y = rmm::device_vector<T>(5, 1.0);
 
-  auto b_begin = make_cartesian_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
+  auto b_begin = make_vec_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
   auto b_end   = b_begin + b_cart2d_x.size();
 
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0}};
@@ -155,18 +155,18 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
 TYPED_TEST(PairwiseLinestringDistanceTest, FromLongInputs)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   auto num_points = 1000;
 
   auto a_cart2d_x_begin = thrust::make_constant_iterator(T{0.0});
   auto a_cart2d_y_begin = thrust::make_counting_iterator(T{0.0});
-  auto a_cart2d_begin   = make_cartesian_2d_iterator(a_cart2d_x_begin, a_cart2d_y_begin);
+  auto a_cart2d_begin   = make_vec_2d_iterator(a_cart2d_x_begin, a_cart2d_y_begin);
   auto a_cart2d_end     = a_cart2d_begin + num_points;
 
   auto b_cart2d_x_begin = thrust::make_constant_iterator(T{42.0});
   auto b_cart2d_y_begin = thrust::make_counting_iterator(T{0.0});
-  auto b_cart2d_begin   = make_cartesian_2d_iterator(b_cart2d_x_begin, b_cart2d_y_begin);
+  auto b_cart2d_begin   = make_vec_2d_iterator(b_cart2d_x_begin, b_cart2d_y_begin);
   auto b_cart2d_end     = b_cart2d_begin + num_points;
 
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 100, 200, 300, 400}};

--- a/cpp/tests/experimental/spatial/point_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_distance_test.cu
@@ -66,7 +66,7 @@ TYPED_TEST_CASE(PairwisePointDistanceTest, TestTypes);
 TYPED_TEST(PairwisePointDistanceTest, Empty)
 {
   using T         = TypeParam;
-  using Cart2D    = cartesian_2d<T>;
+  using Cart2D    = vec_2d<T>;
   using Cart2DVec = std::vector<Cart2D>;
 
   rmm::device_vector<Cart2D> points1{};
@@ -85,7 +85,7 @@ TYPED_TEST(PairwisePointDistanceTest, Empty)
 TYPED_TEST(PairwisePointDistanceTest, OnePair)
 {
   using T         = TypeParam;
-  using Cart2D    = cartesian_2d<T>;
+  using Cart2D    = vec_2d<T>;
   using Cart2DVec = std::vector<Cart2D>;
 
   rmm::device_vector<Cart2D> points1{Cart2DVec{{1.0, 1.0}}};
@@ -103,7 +103,7 @@ TYPED_TEST(PairwisePointDistanceTest, OnePair)
 
 template <typename T>
 struct RandomPointGenerator {
-  using Cart2D = cartesian_2d<T>;
+  using Cart2D = vec_2d<T>;
   thrust::minstd_rand rng{};
   thrust::random::normal_distribution<T> norm_dist{};
 
@@ -117,7 +117,7 @@ struct RandomPointGenerator {
 TYPED_TEST(PairwisePointDistanceTest, ManyRandom)
 {
   using T         = TypeParam;
-  using Cart2D    = cartesian_2d<T>;
+  using Cart2D    = vec_2d<T>;
   using Cart2DVec = std::vector<Cart2D>;
 
   std::size_t constexpr num_points = 1000;
@@ -151,7 +151,7 @@ TYPED_TEST(PairwisePointDistanceTest, ManyRandom)
 TYPED_TEST(PairwisePointDistanceTest, CompareWithShapely)
 {
   using T         = TypeParam;
-  using Cart2D    = cartesian_2d<T>;
+  using Cart2D    = vec_2d<T>;
   using Cart2DVec = std::vector<Cart2D>;
 
   std::vector<T> x1{
@@ -291,8 +291,8 @@ TYPED_TEST(PairwisePointDistanceTest, CompareWithShapely)
   rmm::device_vector<T> dx1(x1), dy1(y1), dx2(x2), dy2(y2);
   rmm::device_vector<T> got(dx1.size());
 
-  auto p1_begin = make_cartesian_2d_iterator(dx1.begin(), dy1.begin());
-  auto p2_begin = make_cartesian_2d_iterator(dx2.begin(), dy2.begin());
+  auto p1_begin = make_vec_2d_iterator(dx1.begin(), dy1.begin());
+  auto p2_begin = make_vec_2d_iterator(dx2.begin(), dy2.begin());
 
   auto ret_it = pairwise_point_distance(p1_begin, p1_begin + dx1.size(), p2_begin, got.begin());
 

--- a/cpp/tests/experimental/spatial/point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/point_in_polygon_test.cu
@@ -32,9 +32,9 @@ using namespace cuspatial;
 template <typename T>
 struct PointInPolygonTest : public ::testing::Test {
  public:
-  rmm::device_vector<cartesian_2d<T>> make_device_points(std::initializer_list<cartesian_2d<T>> pts)
+  rmm::device_vector<vec_2d<T>> make_device_points(std::initializer_list<vec_2d<T>> pts)
   {
-    return rmm::device_vector<cartesian_2d<T>>(pts.begin(), pts.end());
+    return rmm::device_vector<vec_2d<T>>(pts.begin(), pts.end());
   }
 
   rmm::device_vector<std::size_t> make_device_offsets(std::initializer_list<std::size_t> pts)
@@ -271,7 +271,7 @@ TYPED_TEST(PointInPolygonTest, 31PolygonSupport)
     thrust::make_transform_iterator(offsets_iter, PolyPointIteratorFunctorA<T>{});
   auto poly_point_ys_iter =
     thrust::make_transform_iterator(offsets_iter, PolyPointIteratorFunctorB<T>{});
-  auto poly_point_iter = make_cartesian_2d_iterator(poly_point_xs_iter, poly_point_ys_iter);
+  auto poly_point_iter = make_vec_2d_iterator(poly_point_xs_iter, poly_point_ys_iter);
 
   auto expected =
     std::vector<int32_t>({0b1111111111111111111111111111111, 0b0000000000000000000000000000000});

--- a/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
@@ -44,15 +44,15 @@ TYPED_TEST_CASE(PairwisePointLinestringDistanceTest, TestTypes);
 TYPED_TEST(PairwisePointLinestringDistanceTest, Empty)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   CartVec points{};
   std::vector<int> linestring_offsets{0};
   CartVec linestring_points{};
 
-  rmm::device_vector<cartesian_2d<T>> d_points(points);
+  rmm::device_vector<vec_2d<T>> d_points(points);
   rmm::device_vector<int> d_offsets(linestring_offsets);
-  rmm::device_vector<cartesian_2d<T>> d_linestring_points(linestring_points);
+  rmm::device_vector<vec_2d<T>> d_linestring_points(linestring_points);
 
   rmm::device_vector<T> got{};
 
@@ -72,16 +72,16 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, Empty)
 TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromVector)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   CartVec points{{0, 0}};
   std::vector<int> linestring_offsets{0, 3};
   CartVec linestring_points{{1, 1}, {2, 2}, {3, 3}};
   thrust::host_vector<T> expect(std::vector<T>{std::sqrt(T{2.0})});
 
-  rmm::device_vector<cartesian_2d<T>> d_points(points);
+  rmm::device_vector<vec_2d<T>> d_points(points);
   rmm::device_vector<int> d_offsets(linestring_offsets);
-  rmm::device_vector<cartesian_2d<T>> d_linestring_points(linestring_points);
+  rmm::device_vector<vec_2d<T>> d_linestring_points(linestring_points);
 
   rmm::device_vector<T> got(points.size());
 
@@ -99,16 +99,16 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromVector)
 TYPED_TEST(PairwisePointLinestringDistanceTest, TwoPairFromVector)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   CartVec points{{0, 0}, {0, 0}};
   std::vector<int> linestring_offsets{0, 3, 6};
   CartVec linestring_points{{1, 1}, {2, 2}, {3, 3}, {-1, -1}, {-2, -2}, {-3, -3}};
   thrust::host_vector<T> expect(std::vector<T>{std::sqrt(T{2.0}), std::sqrt(T{2.0})});
 
-  rmm::device_vector<cartesian_2d<T>> d_points(points);
+  rmm::device_vector<vec_2d<T>> d_points(points);
   rmm::device_vector<int> d_offsets(linestring_offsets);
-  rmm::device_vector<cartesian_2d<T>> d_linestring_points(linestring_points);
+  rmm::device_vector<vec_2d<T>> d_linestring_points(linestring_points);
 
   rmm::device_vector<T> got(points.size());
 
@@ -137,12 +137,12 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ManyPairsFromIterators)
 
   auto linestring_points_x = thrust::make_counting_iterator(T{0.0});
   auto linestring_points_y = thrust::make_constant_iterator(T{1.0});
-  auto linestring_points   = make_cartesian_2d_iterator(linestring_points_x, linestring_points_y);
+  auto linestring_points   = make_vec_2d_iterator(linestring_points_x, linestring_points_y);
   auto offsets = detail::make_counting_transform_iterator(0, times_three_functor<int32_t>{});
 
   auto points_x = detail::make_counting_transform_iterator(T{0.0}, times_three_functor<T>{});
   auto points_y = thrust::make_constant_iterator(T{0.0});
-  auto points   = make_cartesian_2d_iterator(points_x, points_y);
+  auto points   = make_vec_2d_iterator(points_x, points_y);
 
   std::vector<T> expect(num_pairs, T{1.0});
   rmm::device_vector<T> got(num_pairs);
@@ -161,7 +161,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ManyPairsFromIterators)
 TYPED_TEST(PairwisePointLinestringDistanceTest, FiftyPairsCompareWithShapely)
 {
   using T       = TypeParam;
-  using CartVec = std::vector<cartesian_2d<T>>;
+  using CartVec = std::vector<vec_2d<T>>;
 
   // All point coordinates are confined in [-1e9, 0] inverval
   auto d_points_x = rmm::device_vector<T>(std::vector<T>{
@@ -292,9 +292,9 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, FiftyPairsCompareWithShapely)
 
   auto offsets = detail::make_counting_transform_iterator(0, times_three_functor<int32_t>{});
 
-  auto points = make_cartesian_2d_iterator(d_points_x.begin(), d_points_y.begin());
+  auto points = make_vec_2d_iterator(d_points_x.begin(), d_points_y.begin());
   auto linestring_points =
-    make_cartesian_2d_iterator(d_linestring_points_x.begin(), d_linestring_points_y.begin());
+    make_vec_2d_iterator(d_linestring_points_x.begin(), d_linestring_points_y.begin());
 
   rmm::device_vector<T> got(d_points_x.size());
 


### PR DESCRIPTION
Closes #653.  Removes `lonlat_2d<T>` and `cartesian_2d` structs and related iterator factories and replaces all usage of these structs with their base class `vec_2d<T>. See #653 for discussion / motivation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
