### PR TITLE
Expand expect_vector_equivalent to handle std::vector of vec_2d<T> and move traits out of detail

### DIFF
--- a/cpp/doc/DEVELOPER_GUIDE.md
+++ b/cpp/doc/DEVELOPER_GUIDE.md
@@ -362,7 +362,7 @@ An example function is helpful.
 template <class LonLatItA,
           class LonLatItB,
           class OutputIt,
-          class T        = typename detail::iterator_vec_base_type<LonLatItA>>
+          class T        = typename cuspatial::iterator_vec_base_type<LonLatItA>>
 OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             LonLatItA a_lonlat_last,
                             LonLatItB b_lonlat_first,

--- a/cpp/doc/libcuspatial_refactoring_guide.md
+++ b/cpp/doc/libcuspatial_refactoring_guide.md
@@ -197,8 +197,8 @@ OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             rmm::cuda_stream_view stream)
 {
   static_assert(is_same<vec_2d<T>,
-                                iterator_value_type<LonLatItA>,
-                                iterator_value_type<LonLatItB>>(),
+                                cuspatial::iterator_value_type<LonLatItA>,
+                                cuspatial::iterator_value_type<LonLatItB>>(),
                 "Inputs must be cuspatial::vec_2d");
   static_assert(
     is_same_floating_point<T,

--- a/cpp/doc/libcuspatial_refactoring_guide.md
+++ b/cpp/doc/libcuspatial_refactoring_guide.md
@@ -134,7 +134,7 @@ This is the existing API, unchanged by refactoring. Here is the existing
 template <class LonLatItA,
           class LonLatItB,
           class OutputIt,
-          class T = typename detail::iterator_vec_base_type<LonLatItA>>
+          class T = typename cuspatial::iterator_vec_base_type<LonLatItA>>
 OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             LonLatItA a_lonlat_last,
                             LonLatItB b_lonlat_first,
@@ -196,14 +196,14 @@ OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             T const radius,
                             rmm::cuda_stream_view stream)
 {
-  static_assert(detail::is_same<vec_2d<T>,
-                                detail::iterator_value_type<LonLatItA>,
-                                detail::iterator_value_type<LonLatItB>>(),
+  static_assert(is_same<vec_2d<T>,
+                                iterator_value_type<LonLatItA>,
+                                iterator_value_type<LonLatItB>>(),
                 "Inputs must be cuspatial::vec_2d");
   static_assert(
-    detail::is_same_floating_point<T,
-                                   typename detail::iterator_vec_base_type<LonLatItA>,
-                                   typename detail::iterator_value_type<OutputIt>>(),
+    is_same_floating_point<T,
+                                   typename cuspatial::iterator_vec_base_type<LonLatItA>,
+                                   typename cuspatial::iterator_value_type<OutputIt>>(),
     "All iterator types and radius must have the same floating-point coordinate value type.");
 
   CUSPATIAL_EXPECTS(radius > 0, "radius must be positive.");

--- a/cpp/include/cuspatial/experimental/detail/coordinate_transform.cuh
+++ b/cpp/include/cuspatial/experimental/detail/coordinate_transform.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuspatial/constants.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -74,8 +75,8 @@ OutputIt lonlat_to_cartesian(InputIt lon_lat_first,
                              vec_2d<T> origin,
                              rmm::cuda_stream_view stream)
 {
-  static_assert(std::is_floating_point_v<T>,
-                "lonlat_to_cartesian supports only floating-point coordinates.");
+  static_assert(is_same_floating_point<T, iterator_vec_base_type<InputIt>>(),
+                "Origin and input must have the same base floating point type.");
 
   CUSPATIAL_EXPECTS(origin.x >= -180 && origin.x <= 180 && origin.y >= -90 && origin.y <= 90,
                     "origin must have valid longitude [-180, 180] and latitude [-90, 90]");

--- a/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
+++ b/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cuspatial/detail/utility/device_atomics.cuh>
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -150,7 +150,7 @@ OutputIt directed_hausdorff_distance(PointIt points_first,
 
   static_assert(std::is_convertible_v<Point, cuspatial::vec_2d<T>>,
                 "Input points must be convertible to cuspatial::vec_2d");
-  static_assert(detail::is_floating_point<T, OutputT>(),
+  static_assert(is_floating_point<T, OutputT>(),
                 "Hausdorff supports only floating-point coordinates.");
   static_assert(std::is_integral_v<Index>, "Indices must be integral");
 

--- a/cpp/include/cuspatial/experimental/detail/haversine.cuh
+++ b/cpp/include/cuspatial/experimental/detail/haversine.cuh
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <cuspatial/constants.hpp>
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -66,14 +66,13 @@ OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             T const radius,
                             rmm::cuda_stream_view stream)
 {
-  static_assert(detail::is_same<vec_2d<T>,
-                                detail::iterator_value_type<LonLatItA>,
-                                detail::iterator_value_type<LonLatItB>>(),
-                "Inputs must be cuspatial::vec_2d");
   static_assert(
-    detail::is_same_floating_point<T,
-                                   typename detail::iterator_vec_base_type<LonLatItA>,
-                                   typename detail::iterator_value_type<OutputIt>>(),
+    is_same<vec_2d<T>, iterator_value_type<LonLatItA>, iterator_value_type<LonLatItB>>(),
+    "Inputs must be cuspatial::vec_2d");
+  static_assert(
+    is_same_floating_point<T,
+                           typename cuspatial::iterator_vec_base_type<LonLatItA>,
+                           typename cuspatial::iterator_value_type<OutputIt>>(),
     "All iterator types and radius must have the same floating-point coordinate value type.");
 
   CUSPATIAL_EXPECTS(radius > 0, "radius must be positive.");

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -18,8 +18,8 @@
 
 #include <cuspatial/detail/utility/device_atomics.cuh>
 #include <cuspatial/detail/utility/linestring.cuh>
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -148,16 +148,16 @@ void pairwise_linestring_distance(OffsetIterator linestring1_offsets_first,
                                   OutputIt distances_first,
                                   rmm::cuda_stream_view stream)
 {
-  using T = typename detail::iterator_vec_base_type<Cart2dItA>;
+  using T = typename cuspatial::iterator_vec_base_type<Cart2dItA>;
 
-  static_assert(detail::is_same_floating_point<T,
-                                               typename detail::iterator_vec_base_type<Cart2dItB>,
-                                               typename detail::iterator_value_type<OutputIt>>(),
+  static_assert(is_same_floating_point<T,
+                                       typename cuspatial::iterator_vec_base_type<Cart2dItB>,
+                                       typename cuspatial::iterator_value_type<OutputIt>>(),
                 "Inputs and output must have the same floating point value type.");
 
-  static_assert(detail::is_same<vec_2d<T>,
-                                typename detail::iterator_value_type<Cart2dItA>,
-                                typename detail::iterator_value_type<Cart2dItB>>(),
+  static_assert(is_same<vec_2d<T>,
+                        typename cuspatial::iterator_value_type<Cart2dItA>,
+                        typename cuspatial::iterator_value_type<Cart2dItB>>(),
                 "All input types must be cuspatial::vec_2d with the same value type");
 
   auto const num_linestring_pairs =

--- a/cpp/include/cuspatial/experimental/detail/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_distance.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -36,16 +36,16 @@ OutputIt pairwise_point_distance(Cart2dItA points1_first,
                                  OutputIt distances_first,
                                  rmm::cuda_stream_view stream)
 {
-  using T = typename detail::iterator_vec_base_type<Cart2dItA>;
+  using T = typename cuspatial::iterator_vec_base_type<Cart2dItA>;
 
-  static_assert(detail::is_same_floating_point<T,
-                                               typename detail::iterator_vec_base_type<Cart2dItB>,
-                                               typename detail::iterator_value_type<OutputIt>>(),
+  static_assert(is_same_floating_point<T,
+                                       typename cuspatial::iterator_vec_base_type<Cart2dItB>,
+                                       typename cuspatial::iterator_value_type<OutputIt>>(),
                 "Inputs and output must have the same floating point value type.");
 
-  static_assert(detail::is_same<vec_2d<T>,
-                                typename detail::iterator_value_type<Cart2dItA>,
-                                typename detail::iterator_value_type<Cart2dItB>>(),
+  static_assert(is_same<vec_2d<T>,
+                        typename cuspatial::iterator_value_type<Cart2dItA>,
+                        typename cuspatial::iterator_value_type<Cart2dItB>>(),
                 "All Input types must be cuspatial::vec_2d with the same value type");
 
   return thrust::transform(rmm::exec_policy(stream),

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -161,25 +161,24 @@ OutputIt point_in_polygon(Cart2dItA test_points_first,
                           OutputIt output,
                           rmm::cuda_stream_view stream)
 {
-  using T = detail::iterator_vec_base_type<Cart2dItA>;
+  using T = iterator_vec_base_type<Cart2dItA>;
 
   auto const num_test_points = std::distance(test_points_first, test_points_last);
   auto const num_polys       = std::distance(polygon_offsets_first, polygon_offsets_last);
   auto const num_rings       = std::distance(poly_ring_offsets_first, poly_ring_offsets_last);
   auto const num_poly_points = std::distance(polygon_points_first, polygon_points_last);
 
-  static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
+  static_assert(is_same_floating_point<T, iterator_vec_base_type<Cart2dItB>>(),
                 "Underlying type of Cart2dItA and Cart2dItB must be the same floating point type");
-  static_assert(detail::is_same<vec_2d<T>,
-                                detail::iterator_value_type<Cart2dItA>,
-                                detail::iterator_value_type<Cart2dItB>>(),
-                "Inputs must be cuspatial::vec_2d");
+  static_assert(
+    is_same<vec_2d<T>, iterator_value_type<Cart2dItA>, iterator_value_type<Cart2dItB>>(),
+    "Inputs must be cuspatial::vec_2d");
 
-  static_assert(detail::is_integral<detail::iterator_value_type<OffsetIteratorA>,
-                                    detail::iterator_value_type<OffsetIteratorB>>(),
+  static_assert(cuspatial::is_integral<iterator_value_type<OffsetIteratorA>,
+                                       iterator_value_type<OffsetIteratorB>>(),
                 "OffsetIterators must point to integral type.");
 
-  static_assert(std::is_same_v<detail::iterator_value_type<OutputIt>, int32_t>,
+  static_assert(std::is_same_v<iterator_value_type<OutputIt>, int32_t>,
                 "OutputIt must point to 32 bit integer type.");
 
   CUSPATIAL_EXPECTS(num_polys <= std::numeric_limits<int32_t>::digits,

--- a/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
@@ -18,8 +18,8 @@
 
 #include <cuspatial/detail/utility/device_atomics.cuh>
 #include <cuspatial/detail/utility/linestring.cuh>
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -169,15 +169,14 @@ OutputIt pairwise_point_linestring_distance(OffsetIteratorA point_geometry_offse
                                             OutputIt distances_first,
                                             rmm::cuda_stream_view stream)
 {
-  using T = detail::iterator_vec_base_type<Cart2dItA>;
+  using T = iterator_vec_base_type<Cart2dItA>;
 
-  static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
+  static_assert(is_same_floating_point<T, iterator_vec_base_type<Cart2dItB>>(),
                 "Inputs must have same floating point value type.");
 
-  static_assert(detail::is_same<vec_2d<T>,
-                                detail::iterator_value_type<Cart2dItA>,
-                                detail::iterator_value_type<Cart2dItB>>(),
-                "Inputs must be cuspatial::vec_2d");
+  static_assert(
+    is_same<vec_2d<T>, iterator_value_type<Cart2dItA>, iterator_value_type<Cart2dItB>>(),
+    "Inputs must be cuspatial::vec_2d");
 
   auto const num_pairs =
     thrust::distance(point_geometry_offset_first, point_geometry_offset_last) - 1;

--- a/cpp/include/cuspatial/experimental/detail/points_in_range.cuh
+++ b/cpp/include/cuspatial/experimental/detail/points_in_range.cuh
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -63,7 +63,7 @@ typename thrust::iterator_traits<InputIt>::difference_type count_points_in_range
 {
   using Point = typename std::iterator_traits<InputIt>::value_type;
 
-  static_assert(detail::is_convertible_to<cuspatial::vec_2d<T>, Point>(),
+  static_assert(cuspatial::is_convertible_to<cuspatial::vec_2d<T>, Point>(),
                 "Input points must be convertible to cuspatial::vec_2d");
 
   return thrust::count_if(
@@ -80,10 +80,10 @@ OutputIt copy_points_in_range(vec_2d<T> vertex_1,
 {
   using Point = typename std::iterator_traits<InputIt>::value_type;
 
-  static_assert(detail::is_convertible_to<cuspatial::vec_2d<T>, Point>(),
+  static_assert(cuspatial::is_convertible_to<cuspatial::vec_2d<T>, Point>(),
                 "Input points must be convertible to cuspatial::vec_2d");
 
-  static_assert(detail::is_same_floating_point<T, typename Point::value_type>(),
+  static_assert(is_same_floating_point<T, typename Point::value_type>(),
                 "Inputs and Range coordinates must have the same value type.");
 
   return thrust::copy_if(rmm::exec_policy(stream),

--- a/cpp/include/cuspatial/experimental/haversine.cuh
+++ b/cpp/include/cuspatial/experimental/haversine.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuspatial/constants.hpp>
-#include <cuspatial/detail/utility/traits.hpp>
+#include <cuspatial/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -66,7 +66,7 @@ namespace cuspatial {
 template <class LonLatItA,
           class LonLatItB,
           class OutputIt,
-          class T = typename detail::iterator_vec_base_type<LonLatItA>>
+          class T = typename cuspatial::iterator_vec_base_type<LonLatItA>>
 OutputIt haversine_distance(LonLatItA a_lonlat_first,
                             LonLatItA a_lonlat_last,
                             LonLatItB b_lonlat_first,

--- a/cpp/include/cuspatial/experimental/type_utils.hpp
+++ b/cpp/include/cuspatial/experimental/type_utils.hpp
@@ -15,7 +15,7 @@
  */
 
 #include <cuspatial/detail/iterator.hpp>
-#include <cuspatial/detail/utility/traits.hpp>
+#include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <thrust/iterator/transform_iterator.h>
@@ -84,8 +84,7 @@ template <typename FirstIter, typename SecondIter>
 auto make_vec_2d_iterator(FirstIter first, SecondIter second)
 {
   using T = typename std::iterator_traits<FirstIter>::value_type;
-  static_assert(detail::is_same<T, detail::iterator_value_type<SecondIter>>(),
-                "Iterator value_type mismatch");
+  static_assert(is_same<T, iterator_value_type<SecondIter>>(), "Iterator value_type mismatch");
 
   auto zipped = thrust::make_zip_iterator(thrust::make_tuple(first, second));
   return thrust::make_transform_iterator(zipped, detail::tuple_to_vec_2d<T>());

--- a/cpp/include/cuspatial/traits.hpp
+++ b/cpp/include/cuspatial/traits.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cuspatial/vec_2d.hpp>
+
 #include <iterator>
 #include <type_traits>
 
@@ -59,6 +61,16 @@ template <typename... Ts>
 constexpr bool is_integral()
 {
   return std::conjunction_v<std::is_integral<Ts>...>;
+}
+
+/**
+ * @internal
+ * @brief returns true if `T` is `vec_2d<float>` or `vec_2d<double>`
+ */
+template <typename T>
+constexpr bool is_vec_2d()
+{
+  return std::is_same_v<T, vec_2d<float>> or std::is_same_v<T, vec_2d<double>>;
 }
 
 /**

--- a/cpp/include/cuspatial/traits.hpp
+++ b/cpp/include/cuspatial/traits.hpp
@@ -20,7 +20,6 @@
 #include <type_traits>
 
 namespace cuspatial {
-namespace detail {
 
 /**
  * @internal
@@ -89,7 +88,6 @@ using iterator_value_type = typename std::iterator_traits<Iterator>::value_type;
  * @tparam Iterator The value type to get from, must point to a cuspatial::vec_2d
  */
 template <typename Iterator>
-using iterator_vec_base_type = typename iterator_value_type<Iterator>::value_type;
+using iterator_vec_base_type = typename cuspatial::iterator_value_type<Iterator>::value_type;
 
-}  // namespace detail
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/vec_2d.hpp
+++ b/cpp/include/cuspatial/vec_2d.hpp
@@ -43,6 +43,9 @@ struct alignas(2 * sizeof(T)) vec_2d {
   value_type y;
 };
 
+/**
+ * @brief Output stream operator for `vec_2d<T>` for human-readable formatting
+ */
 template <typename T>
 std::ostream& operator<<(std::ostream& os, cuspatial::vec_2d<T> const& vec)
 {

--- a/cpp/include/cuspatial/vec_2d.hpp
+++ b/cpp/include/cuspatial/vec_2d.hpp
@@ -18,6 +18,8 @@
 
 #include <cuspatial/cuda_utils.hpp>
 
+#include <ostream>
+
 namespace cuspatial {
 
 /**
@@ -40,6 +42,12 @@ struct alignas(2 * sizeof(T)) vec_2d {
   value_type x;
   value_type y;
 };
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, cuspatial::vec_2d<T> const& vec)
+{
+  return os << "(" << vec.x << "," << vec.y << ")";
+}
 
 /**
  * @brief Compare two 2D vectors for equality.

--- a/cpp/tests/experimental/spatial/hausdorff_test.cu
+++ b/cpp/tests/experimental/spatial/hausdorff_test.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "tests/utility/vector_equality.hpp"
+
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/hausdorff.cuh>
 #include <cuspatial/vec_2d.hpp>
@@ -49,7 +51,7 @@ struct HausdorffTest : public ::testing::Test {
 
     thrust::host_vector<T> h_distances(distances);
 
-    EXPECT_THAT(distances, ::testing::Pointwise(::testing::DoubleEq(), expected));
+    cuspatial::test::expect_vector_equivalent(distances, expected);
     EXPECT_EQ(num_distances, std::distance(distances.begin(), distances_end));
   }
 };
@@ -153,7 +155,7 @@ void generic_hausdorff_test()
                                                               space_offset_iter + num_spaces,
                                                               distances.begin());
 
-  EXPECT_EQ(distances, expected);
+  cuspatial::test::expect_vector_equivalent(distances, expected);
   EXPECT_EQ(num_distances, std::distance(distances.begin(), distances_end));
 }
 

--- a/cpp/tests/experimental/spatial/haversine_test.cu
+++ b/cpp/tests/experimental/spatial/haversine_test.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <tests/utility/vector_equality.hpp>
+
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/haversine.cuh>
 
@@ -45,7 +47,7 @@ TYPED_TEST(HaversineTest, Empty)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  cuspatial::test::expect_vector_equivalent(expected, distance);
   EXPECT_EQ(0, std::distance(distance.begin(), distance_end));
 }
 
@@ -64,7 +66,7 @@ TYPED_TEST(HaversineTest, Zero)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  EXPECT_EQ(expected, distance);
+  cuspatial::test::expect_vector_equivalent(expected, distance);
   EXPECT_EQ(1, std::distance(distance.begin(), distance_end));
 }
 
@@ -104,7 +106,7 @@ TYPED_TEST(HaversineTest, EquivalentPoints)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  EXPECT_EQ(expected, distance);
+  cuspatial::test::expect_vector_equivalent(expected, distance);
   EXPECT_EQ(2, std::distance(distance.begin(), distance_end));
 }
 
@@ -137,6 +139,6 @@ TYPED_TEST(HaversineTest, TransformIterator)
   auto distance_end =
     cuspatial::haversine_distance(xform_begin, xform_end, b_lonlat.begin(), distance.begin());
 
-  EXPECT_EQ(expected, distance);
+  cuspatial::test::expect_vector_equivalent(expected, distance);
   EXPECT_EQ(2, std::distance(distance.begin(), distance_end));
 }

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "tests/utility/vector_equality.hpp"
+
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/linestring_distance.cuh>
 #include <cuspatial/experimental/type_utils.hpp>
@@ -22,11 +24,6 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
 
-#include <cudf_test/base_fixture.hpp>
-#include <cudf_test/column_utilities.hpp>
-#include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/type_lists.hpp>
-
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
@@ -34,10 +31,9 @@ namespace cuspatial {
 namespace test {
 
 using namespace cudf;
-using namespace cudf::test;
 
 template <typename T>
-struct PairwiseLinestringDistanceTest : public BaseFixture {
+struct PairwiseLinestringDistanceTest : public ::testing::Test {
 };
 
 // float and double are logically the same but would require seperate tests due to precision.
@@ -67,7 +63,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSeparateArrayInputs)
                                b_cart2d.end(),
                                distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  test::expect_vector_equivalent(expected, distance);
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
@@ -90,7 +86,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
   pairwise_linestring_distance(
     offset.begin(), offset.end(), a_begin, a_end, offset.begin(), b_begin, b_end, distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  test::expect_vector_equivalent(expected, distance);
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
@@ -118,7 +114,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
   pairwise_linestring_distance(
     offset.begin(), offset.end(), a_begin, a_end, offset.begin(), b_begin, b_end, distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  test::expect_vector_equivalent(expected, distance);
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
@@ -149,7 +145,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
                                b_end,
                                distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  test::expect_vector_equivalent(expected, distance);
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromLongInputs)
@@ -183,7 +179,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromLongInputs)
                                b_cart2d_end,
                                distance.begin());
 
-  EXPECT_EQ(distance, expected);
+  test::expect_vector_equivalent(expected, distance);
 }
 
 }  // namespace test

--- a/cpp/tests/experimental/spatial/point_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_distance_test.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "tests/utility/vector_equality.hpp"
+
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/point_distance.cuh>
 #include <cuspatial/experimental/type_utils.hpp>
@@ -140,11 +142,7 @@ TYPED_TEST(PairwisePointDistanceTest, ManyRandom)
     pairwise_point_distance(points1.begin(), points1.end(), points2.begin(), got.begin());
   thrust::host_vector<T> hgot(got);
 
-  if constexpr (std::is_same_v<T, float>) {
-    EXPECT_THAT(expected, ::testing::Pointwise(::testing::FloatEq(), hgot));
-  } else {
-    EXPECT_THAT(expected, ::testing::Pointwise(::testing::DoubleEq(), hgot));
-  }
+  test::expect_vector_equivalent(expected, hgot);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -298,11 +296,7 @@ TYPED_TEST(PairwisePointDistanceTest, CompareWithShapely)
 
   thrust::host_vector<T> hgot(got);
 
-  if constexpr (std::is_same_v<T, float>) {
-    EXPECT_THAT(expected, ::testing::Pointwise(::testing::FloatEq(), hgot));
-  } else {
-    EXPECT_THAT(expected, ::testing::Pointwise(::testing::DoubleEq(), hgot));
-  }
+  test::expect_vector_equivalent(expected, hgot);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 

--- a/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "../../utility/vector_equality.hpp"
+#include "tests/utility/vector_equality.hpp"
 
 #include <cuspatial/detail/iterator.hpp>
 #include <cuspatial/error.hpp>
@@ -73,8 +73,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, Empty)
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -109,8 +108,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromVectorSingleComponent
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -144,8 +142,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromCountingIteratorSingl
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -180,8 +177,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, TwoPairFromVectorSingleComponent
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -222,8 +218,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ManyPairsFromIteratorsSingleComp
                                                 linestring_points + num_linestring_points,
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -382,8 +377,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePartFiftyPairsCompareWithShap
                                                 linestring_points + d_linestring_points_x.size(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -419,8 +413,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairMultiPointMultiLinestring
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -456,8 +449,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ThreePairMultiPointMultiLinestri
                                                 d_linestring_points.end(),
                                                 got.begin());
 
-  thrust::host_vector<T> hgot(got);
-  expect_vector_equivalent(expect, hgot);
+  expect_vector_equivalent(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 

--- a/cpp/tests/experimental/spatial/points_in_range_test.cu
+++ b/cpp/tests/experimental/spatial/points_in_range_test.cu
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "tests/utility/vector_equality.hpp"
+
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/points_in_range.cuh>
 #include <cuspatial/vec_2d.hpp>
@@ -50,7 +52,7 @@ struct SpatialRangeTest : public testing::Test {
     auto result_points = DeviceVecVec<T>(result_size);
     cuspatial::copy_points_in_range(v1, v2, points.begin(), points.end(), result_points.begin());
 
-    EXPECT_EQ(expected_points, result_points);
+    cuspatial::test::expect_vector_equivalent(expected_points, result_points);
   }
 };
 

--- a/cpp/tests/utility/vector_equality.hpp
+++ b/cpp/tests/utility/vector_equality.hpp
@@ -16,24 +16,77 @@
 
 #pragma once
 
+#include <cuspatial/vec_2d.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
+
+#include <thrust/host_vector.h>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <type_traits>
 
+template <typename T>
+std::ostream& operator<<(std::ostream& os, cuspatial::vec_2d<T> const& vec)
+{
+  return os << "(" << vec.x << "," << vec.y << ")";
+}
+
 namespace cuspatial {
 namespace test {
+
+template <typename T>
+auto float_matcher(T val)
+{
+  if constexpr (std::is_same_v<T, float>) {
+    return ::testing::FloatEq(val);
+  } else {
+    return ::testing::DoubleEq(val);
+  }
+}
+
+MATCHER(vec_2d_matcher,
+        std::string(negation ? "are not" : "are") + " approximately equal vec_2d structs")
+{
+  auto lhs = std::get<0>(arg);
+  auto rhs = std::get<1>(arg);
+
+  if (::testing::Matches(float_matcher(rhs.x))(lhs.x) &&
+      ::testing::Matches(float_matcher(rhs.y))(lhs.y))
+    return true;
+
+  //*result_listener << lhs << " != " << rhs;
+
+  return false;
+}
+
+template <typename T>
+constexpr bool is_vec_2d()
+{
+  return std::is_same_v<T, vec_2d<float>> or std::is_same_v<T, vec_2d<double>>;
+}
+
+template <typename T, typename Vector>
+thrust::host_vector<T> to_host(Vector vec)
+{
+  return thrust::host_vector<T>(vec);
+}
 
 template <typename Vector1, typename Vector2>
 inline void expect_vector_equivalent(Vector1 lhs, Vector2 rhs)
 {
   using T = typename Vector1::value_type;
-  static_assert(std::is_same_v<T, typename Vector2::value_type>, "Mismatch value type.");
+  static_assert(std::is_same_v<T, typename Vector2::value_type>, "Value type mismatch.");
+  static_assert(std::is_floating_point_v<T> or is_vec_2d<T>(), "Unsupported vector value type.");
 
-  if constexpr (std::is_same_v<T, float>) {
-    EXPECT_THAT(lhs, ::testing::Pointwise(::testing::FloatEq(), rhs));
-  } else {
-    EXPECT_THAT(lhs, ::testing::Pointwise(::testing::DoubleEq(), rhs));
+  if constexpr (is_vec_2d<T>()) {
+    EXPECT_THAT(to_host<T>(lhs), ::testing::Pointwise(vec_2d_matcher(), to_host<T>(rhs)));
+  } else if constexpr (std::is_same_v<T, float>) {
+    EXPECT_THAT(to_host<T>(lhs), ::testing::Pointwise(::testing::FloatEq(), to_host<T>(rhs)));
+  } else if constexpr (std::is_same_v<T, double>) {
+    EXPECT_THAT(to_host<T>(lhs), ::testing::Pointwise(::testing::DoubleEq(), to_host<T>(rhs)));
   }
 }
 


### PR DESCRIPTION
## Description
* Expands the test utility `expect_vector_equivalent` to support comparing vectors of `vec_2d<T>` with approximate comparison of floating point equality (using GTEST functionality). This function now also explicitly copies all vectors to the host for comparison.
* Updates various tests to use the utility instead of directly calling `EXPECT_EQ`.
* Moves traits.hpp to top-level include directory and moves all traits helpers out of `detail` namespace so they are more easily used in tests and user code.

TODO: 

 ~- [ ] `coordinate_transform_test` fails with this change, so I have not committed it. Something is different with `EXPECT_EQ` and this function for that test. Investigating.~  This will be fixed in a followup PR -- we discovered the test is flawed.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
