### PR TITLE
Update to the latest version 3 of GDAL.

### DIFF
--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -11,4 +11,4 @@ sysroot_version:
   - "2.17"
 
 gdal_version:
-  - ">=3.4.3,<3.4.4a0"
+  - ">3.0.0"

--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -11,4 +11,4 @@ sysroot_version:
   - "2.17"
 
 gdal_version:
-  - ">3.0.0"
+  - ">3.5.0"

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.20.1"
 
 gdal_version:
-  - ">3.0.0"
+  - ">3.5.0"
 
 gtest_version:
   - "1.10.0"

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.20.1"
 
 gdal_version:
-  - ">=3.4.3,<3.4.4a0"
+  - ">3.0.0"
 
 gtest_version:
   - "1.10.0"


### PR DESCRIPTION
@beckernick report's a GDAL version conflict with cuda. We're pinned at GDAL 3.4 and TensorFlow and other libs have already updated to GDAL 3.5. Let's update that here.

Fixes https://github.com/rapidsai/cuspatial/issues/674 and depends on https://github.com/rapidsai/integration/pull/533