### PR TITLE
[skip-ci] [Do Not Merge] Experiment on `iterator_collections` structure

### DIFF
--- a/cpp/include/cuspatial/distance/point_distance.hpp
+++ b/cpp/include/cuspatial/distance/point_distance.hpp
@@ -24,18 +24,18 @@ namespace cuspatial {
  * @ingroup distance
  * @brief Compute pairwise point-to-point Cartesian distance
  *
- * @param points1_x Column of x-coordinates of the first point in each pair
- * @param points1_y Column of y-coordinates of the first point in each pair
- * @param points2_x Column of x-coordinates of the second point in each pair
- * @param points2_y Column of y-coordinates of the second point in each pair
- * @param stream The CUDA stream to use for device memory operations and kernel launches
+ * @param multipoints1_offset Index to the first point of each multipoint in points1_xy
+ * @param multipoints2_offset Index to the second point of each multipoint in points2_xy
+ * @param points1_xy Column of xy-coordinates of the first point in each pair
+ * @param points2_xy Column of xy-coordinates of the second point in each pair
  * @return Column of distances between each pair of input points
  */
+
 std::unique_ptr<cudf::column> pairwise_point_distance(
-  cudf::column_view const& points1_x,
-  cudf::column_view const& points1_y,
-  cudf::column_view const& points2_x,
-  cudf::column_view const& points2_y,
+  std::optional<cudf::device_span<cudf::size_type const>> multipoints1_offset,
+  cudf::column_view const& points1_xy,
+  std::optional<cudf::device_span<cudf::size_type const>> multipoints2_offset,
+  cudf::column_view const& points2_xy,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_distance.cuh
@@ -60,11 +60,12 @@ OutputIt pairwise_point_distance(
                            distances_first,
                            [] __device__(auto& mp1, auto& mp2) {
                              T min_distance_squared;
-                             for (vec_2d<T> const& p1 : mp1)
+                             for (vec_2d<T> const& p1 : mp1) {
                                for (vec_2d<T> const& p2 : mp2) {
                                  auto v               = p1 - p2;
                                  min_distance_squared = min(min_distance_squared, dot(v, v));
                                }
+                             }
                              return sqrt(min_distance_squared);
                            });
 }

--- a/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
@@ -70,7 +70,6 @@ void __global__ pairwise_point_linestring_distance(
     // Reduce the minimum distance between different parts of the multi-point.
     auto [a, b]            = multilinestrings.segment(idx);
     T min_distance_squared = std::numeric_limits<T>::max();
-    auto multipoint        = multipoints.element(geometry_idx);
 
     for (vec_2d<T> const& c : multipoints.element(geometry_idx)) {
       // TODO: reduce redundant computation only related to `a`, `b` in this helper.

--- a/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_linestring_distance.cuh
@@ -20,6 +20,7 @@
 #include <cuspatial/detail/utility/linestring.cuh>
 #include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/error.hpp>
+#include <cuspatial/experimental/iterator_collections.cuh>
 #include <cuspatial/vec_2d.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -40,116 +41,91 @@
 namespace cuspatial {
 namespace detail {
 
-/**
- * @internal
- * @brief The kernel to compute multi-point to multi-linestring distance
- *
- * Each thread computes the distance between a line segment in the linestring and the
- * corresponding multi-point part in the pair. The shortest distance is computed in the
- * output array via an atomic operation.
- *
- * @tparam Cart2dItA Iterator to 2d cartesian coordinates. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam Cart2dItB Iterator to 2d cartesian coordinates. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OffsetIteratorA Iterator to offsets. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OffsetIteratorB Iterator to offsets. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OffsetIteratorC Iterator to offsets. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OutputIterator Iterator to output distances. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible and mutable.
- *
- * @param[in] point_geometry_offset_first Iterator to the beginning of the range of the multipoint
- * parts
- * @param[in] point_geometry_offset_last Iterator to the end of the range of the multipoint parts
- * @param[in] points_first Iterator to the beginning of the range of the points
- * @param[in] points_last  Iterator to the end of the range of the points
- * @param[in] linestring_geometry_offset_first Iterator to the beginning of the range of the
- * linestring parts
- * @param[in] linestring_geometry_offset_last Iterator to the end of the range of the linestring
- * parts
- * @param[in] linestring_part_offsets_first Iterator to the beginning of the range of the linestring
- * offsets
- * @param[in] linestring_part_offsets_last Iterator to the beginning of the range of the linestring
- * offsets
- * @param[in] linestring_points_first Iterator to the beginning of the range of the linestring
- * points
- * @param[in] linestring_points_last Iterator to the end of the range of the linestring points
- * @param[out] distances Iterator to the output range of shortest distances between pairs.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
- */
 template <class Cart2dItA,
           class Cart2dItB,
           class OffsetIteratorA,
           class OffsetIteratorB,
           class OffsetIteratorC,
           class OutputIterator>
-void __global__ pairwise_point_linestring_distance(OffsetIteratorA point_geometry_offset_first,
-                                                   OffsetIteratorA point_geometry_offset_last,
-                                                   Cart2dItA points_first,
-                                                   Cart2dItA points_last,
-                                                   OffsetIteratorB linestring_geometry_offset_first,
-                                                   OffsetIteratorB linestring_geometry_offset_last,
-                                                   OffsetIteratorC linestring_part_offsets_first,
-                                                   OffsetIteratorC linestring_part_offsets_last,
-                                                   Cart2dItB linestring_points_first,
-                                                   Cart2dItB linestring_points_last,
-                                                   OutputIterator distances)
+void __global__ pairwise_point_linestring_distance(
+  iterator_collections::multipoint_array<OffsetIteratorA, Cart2dItA> multipoints,
+  iterator_collections::multilinestring_array<OffsetIteratorB, OffsetIteratorC, Cart2dItB>
+    multilinestrings,
+  OutputIterator distances)
 {
   using T = iterator_vec_base_type<Cart2dItA>;
 
-  for (auto idx = threadIdx.x + blockIdx.x * blockDim.x;
-       idx < std::distance(linestring_points_first, thrust::prev(linestring_points_last));
+  for (auto idx = threadIdx.x + blockIdx.x * blockDim.x; idx < multilinestrings.num_points();
        idx += gridDim.x * blockDim.x) {
     // Search from the part offsets array to determine the part idx of current linestring point
-    auto linestring_part_offsets_iter = thrust::upper_bound(
-      thrust::seq, linestring_part_offsets_first, linestring_part_offsets_last, idx);
-
+    auto part_idx = multilinestrings.part_idx_from_point_idx(idx);
     // Pointer to the last point in the linestring, skip iteration.
     // Note that the last point for the last linestring is guarded by the grid-stride loop.
-    if (linestring_part_offsets_iter != linestring_part_offsets_last &&
-        *linestring_part_offsets_iter - 1 == idx) {
-      continue;
-    }
+    if (!multilinestrings.is_valid_segment_id(idx, part_idx)) continue;
 
-    auto part_offsets_idx =
-      thrust::distance(linestring_part_offsets_first, thrust::prev(linestring_part_offsets_iter));
-
-    // Search from the linestring geometry offsets array to determine the geometry idx of current
-    // linestring point
-    auto geometry_offsets_iter = thrust::upper_bound(thrust::seq,
-                                                     linestring_geometry_offset_first,
-                                                     linestring_geometry_offset_last,
-                                                     part_offsets_idx);
-    // geometry_idx is also the index to corresponding multipoint in the pair
-    auto geometry_idx =
-      thrust::distance(linestring_geometry_offset_first, thrust::prev(geometry_offsets_iter));
+    // Search from the linestring geometry offsets array to determine the geometry idx of
+    // current linestring point
+    auto geometry_idx = multilinestrings.geometry_idx_from_part_idx(part_idx);
 
     // Reduce the minimum distance between different parts of the multi-point.
-    vec_2d<T> const a      = linestring_points_first[idx];
-    vec_2d<T> const b      = linestring_points_first[idx + 1];
+    auto [a, b]            = multilinestrings.segment(idx);
     T min_distance_squared = std::numeric_limits<T>::max();
+    auto multipoint        = multipoints.element(geometry_idx);
 
-    for (auto point_idx = point_geometry_offset_first[geometry_idx];
-         point_idx < point_geometry_offset_first[geometry_idx + 1];
-         point_idx++) {
-      vec_2d<T> const c = points_first[point_idx];
-
+    for (vec_2d<T> const& c : multipoints.element(geometry_idx)) {
       // TODO: reduce redundant computation only related to `a`, `b` in this helper.
       auto const distance_squared = point_to_segment_distance_squared(c, a, b);
       min_distance_squared        = std::min(distance_squared, min_distance_squared);
     }
-
     atomicMin(&thrust::raw_reference_cast(*(distances + geometry_idx)),
               static_cast<T>(std::sqrt(min_distance_squared)));
   }
 }
 
 }  // namespace detail
+template <class Cart2dItA,
+          class Cart2dItB,
+          class OffsetIteratorA,
+          class OffsetIteratorB,
+          class OffsetIteratorC,
+          class OutputIt>
+OutputIt pairwise_point_linestring_distance(
+  iterator_collections::multipoint_array<OffsetIteratorA, Cart2dItA> multipoints,
+  iterator_collections::multilinestring_array<OffsetIteratorB, OffsetIteratorC, Cart2dItB>
+    multilinestrings,
+  OutputIt distances_first,
+  rmm::cuda_stream_view stream = rmm::cuda_stream_default)
+{
+  using T = detail::iterator_vec_base_type<Cart2dItA>;
+
+  static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
+                "Inputs must have same floating point value type.");
+
+  static_assert(detail::is_same<vec_2d<T>,
+                                detail::iterator_value_type<Cart2dItA>,
+                                detail::iterator_value_type<Cart2dItB>>(),
+                "Inputs must be cuspatial::vec_2d");
+
+  CUSPATIAL_EXPECTS(multilinestrings.size() == multipoints.size(),
+                    "Input must have the same number of rows.");
+  if (multilinestrings.size() == 0) { return distances_first; }
+
+  thrust::fill_n(rmm::exec_policy(stream),
+                 distances_first,
+                 multilinestrings.size(),
+                 std::numeric_limits<T>::max());
+
+  std::size_t constexpr threads_per_block = 256;
+  std::size_t const num_blocks =
+    (multilinestrings.size() + threads_per_block - 1) / threads_per_block;
+
+  detail::pairwise_point_linestring_distance<<<num_blocks, threads_per_block, 0, stream.value()>>>(
+    multipoints, multilinestrings, distances_first);
+
+  CUSPATIAL_CUDA_TRY(cudaGetLastError());
+
+  return distances_first + multilinestrings.size();
+}
 
 template <class Cart2dItA,
           class Cart2dItB,
@@ -169,47 +145,20 @@ OutputIt pairwise_point_linestring_distance(OffsetIteratorA point_geometry_offse
                                             OutputIt distances_first,
                                             rmm::cuda_stream_view stream)
 {
-  using T = detail::iterator_vec_base_type<Cart2dItA>;
+  auto d = thrust::distance(point_geometry_offset_first, point_geometry_offset_first);
+  return pairwise_point_linestring_distance(
+    iterator_collections::multipoint_array(
+      point_geometry_offset_first, point_geometry_offset_last, points_first, points_last),
+    iterator_collections::multilinestring_array(linestring_geometry_offset_first,
+                                                linestring_geometry_offset_first + d,
+                                                linestring_part_offsets_first,
+                                                linestring_part_offsets_last,
+                                                linestring_points_first,
+                                                linestring_points_last),
+    distances_first,
+    stream
 
-  static_assert(detail::is_same_floating_point<T, detail::iterator_vec_base_type<Cart2dItB>>(),
-                "Inputs must have same floating point value type.");
-
-  static_assert(detail::is_same<vec_2d<T>,
-                                detail::iterator_value_type<Cart2dItA>,
-                                detail::iterator_value_type<Cart2dItB>>(),
-                "Inputs must be cuspatial::vec_2d");
-
-  auto const num_pairs =
-    thrust::distance(point_geometry_offset_first, point_geometry_offset_last) - 1;
-
-  if (num_pairs == 0) { return distances_first; }
-
-  auto const num_linestring_points =
-    thrust::distance(linestring_points_first, linestring_points_last);
-
-  thrust::fill_n(
-    rmm::exec_policy(stream), distances_first, num_pairs, std::numeric_limits<T>::max());
-
-  std::size_t constexpr threads_per_block = 256;
-  std::size_t const num_blocks =
-    (num_linestring_points + threads_per_block - 1) / threads_per_block;
-
-  detail::pairwise_point_linestring_distance<<<num_blocks, threads_per_block, 0, stream.value()>>>(
-    point_geometry_offset_first,
-    point_geometry_offset_last,
-    points_first,
-    points_last,
-    linestring_geometry_offset_first,
-    linestring_geometry_offset_first + num_pairs + 1,
-    linestring_part_offsets_first,
-    linestring_part_offsets_last,
-    linestring_points_first,
-    linestring_points_last,
-    distances_first);
-
-  CUSPATIAL_CUDA_TRY(cudaGetLastError());
-
-  return distances_first + num_pairs;
+  );
 }
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/iterator_collections.cuh
+++ b/cpp/include/cuspatial/experimental/iterator_collections.cuh
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/iterator/transform_iterator.h>
+
+#include <cuspatial/detail/iterator.hpp>
+#include <cuspatial/vec_2d.hpp>
+
+#include <iterator>
+
+namespace cuspatial {
+
+namespace iterator_collections {
+
+template <typename VecIterator>
+class multipoint {
+ public:
+  CUSPATIAL_HOST_DEVICE
+  multipoint(VecIterator begin, VecIterator end) : points_begin(begin), points_end(end) {}
+
+  CUSPATIAL_HOST_DEVICE
+  auto point_begin() const { return points_begin; }
+  CUSPATIAL_HOST_DEVICE
+  auto point_end() const { return points_end; }
+
+ protected:
+  VecIterator points_begin;
+  VecIterator points_end;
+};
+
+template <typename GeometryIterator,
+          typename VecIterator,
+          typename T = typename std::iterator_traits<VecIterator>::value_type>
+class multipoint_array {
+ public:
+  multipoint_array(GeometryIterator geom_begin,
+                   GeometryIterator geom_end,
+                   VecIterator point_begin,
+                   VecIterator point_end)
+    : geometry_begin(geom_begin),
+      geometry_end(geom_end),
+      points_begin(point_begin),
+      points_end(point_end)
+  {
+  }
+
+  struct to_multipoint_functor {
+    using difference_type = typename thrust::iterator_difference<GeometryIterator>::type;
+    GeometryIterator geometry_begin;
+    VecIterator points_begin;
+
+    to_multipoint_functor(GeometryIterator g, VecIterator p) : geometry_begin(g), points_begin(p) {}
+
+    CUSPATIAL_HOST_DEVICE
+    auto operator()(difference_type const& i)
+    {
+      return multipoint<VecIterator>{points_begin + geometry_begin[i],
+                                     points_begin + geometry_begin[i + 1]};
+    }
+  };
+
+  struct to_point_functor {
+    using difference_type = typename thrust::iterator_difference<VecIterator>::type;
+    VecIterator points_begin;
+
+    to_point_functor(VecIterator p) : points_begin(p) {}
+
+    CUSPATIAL_HOST_DEVICE
+    vec_2d<T> operator()(difference_type const& i) { return points_begin[i]; }
+  };
+
+  auto multipoint_begin()
+  {
+    return detail::make_counting_transform_iterator(
+      0, to_multipoint_functor(geometry_begin, points_begin));
+  }
+
+  auto multipoint_end()
+  {
+    return multipoint_begin() + thrust::distance(geometry_begin, geometry_end);
+  }
+
+  auto point_begin()
+  {
+    return detail::make_counting_transform_iterator(0, to_point_functor(points_begin));
+  }
+
+  auto point_end() { return point_begin() + thrust::distance(points_begin, points_end); }
+
+ protected:
+  GeometryIterator geometry_begin;
+  GeometryIterator geometry_end;
+  VecIterator points_begin;
+  VecIterator points_end;
+};
+}  // namespace iterator_collections
+}  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/iterator_collections.cuh
+++ b/cpp/include/cuspatial/experimental/iterator_collections.cuh
@@ -16,9 +16,14 @@
 
 #pragma once
 
+#include "cuspatial/cuda_utils.hpp"
+#include <thrust/binary_search.h>
+#include <thrust/distance.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/pair.h>
 
 #include <cuspatial/detail/iterator.hpp>
+#include <cuspatial/detail/utility/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
 #include <iterator>
@@ -37,6 +42,11 @@ class multipoint {
   auto point_begin() const { return points_begin; }
   CUSPATIAL_HOST_DEVICE
   auto point_end() const { return points_end; }
+
+  CUSPATIAL_HOST_DEVICE
+  auto begin() const { return point_begin(); }
+  CUSPATIAL_HOST_DEVICE
+  auto end() const { return point_end(); }
 
  protected:
   VecIterator points_begin;
@@ -84,6 +94,8 @@ class multipoint_array {
     vec_2d<T> operator()(difference_type const& i) { return points_begin[i]; }
   };
 
+  auto size() { return thrust::distance(geometry_begin, geometry_end) - 1; }
+
   auto multipoint_begin()
   {
     return detail::make_counting_transform_iterator(
@@ -102,11 +114,94 @@ class multipoint_array {
 
   auto point_end() { return point_begin() + thrust::distance(points_begin, points_end); }
 
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE auto element(IndexType idx)
+  {
+    return multipoint{points_begin + geometry_begin[idx], points_end + geometry_begin[idx + 1]};
+  }
+
  protected:
   GeometryIterator geometry_begin;
   GeometryIterator geometry_end;
   VecIterator points_begin;
   VecIterator points_end;
 };
+
+template <typename GeometryIterator, typename PartIterator, typename VecIterator>
+class multilinestring_array {
+  using T = cuspatial::detail::iterator_vec_base_type<VecIterator>;
+
+ public:
+  multilinestring_array(GeometryIterator geometry_begin,
+                        GeometryIterator geometry_end,
+                        PartIterator part_begin,
+                        PartIterator part_end,
+                        VecIterator points_begin,
+                        VecIterator points_end)
+    : geometry_begin(geometry_begin),
+      geometry_end(geometry_end),
+      part_begin(part_begin),
+      part_end(part_end),
+      points_begin(points_begin),
+      points_end(points_end)
+  {
+  }
+
+  CUSPATIAL_HOST_DEVICE auto size() { return num_multilinestrings(); }
+
+  CUSPATIAL_HOST_DEVICE
+  auto num_multilinestrings() { return thrust::distance(geometry_begin, geometry_end) - 1; }
+  CUSPATIAL_HOST_DEVICE auto num_linestrings()
+  {
+    return thrust::distance(part_begin, part_end) - 1;
+  }
+
+  CUSPATIAL_HOST_DEVICE auto num_points() { return thrust::distance(points_begin, points_end) - 1; }
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE auto part_idx_from_point_idx(IndexType point_idx)
+  {
+    auto part_it = thrust::upper_bound(thrust::seq, part_begin, part_end, point_idx);
+    return thrust::distance(part_begin, thrust::prev(part_it));
+  }
+
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE auto geometry_idx_from_part_idx(IndexType part_idx)
+  {
+    auto geom_it = thrust::upper_bound(thrust::seq, geometry_begin, geometry_end, part_idx);
+    return thrust::distance(geometry_begin, thrust::prev(geom_it));
+  }
+
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE auto geometry_idx_from_point_idx(IndexType point_idx)
+  {
+    return geometry_idx_from_part_idx(part_idx_from_point_idx(point_idx));
+  }
+
+  /**
+   * @internal
+   * A segment id is the same as the id to the starting point of the segment.
+   * A segment id is valid iff the id is not the last point in the linestring.
+   */
+  template <typename IndexType1, typename IndexType2>
+  CUSPATIAL_HOST_DEVICE bool is_valid_segment_id(IndexType1 segment_idx, IndexType2 part_idx)
+  {
+    return segment_idx != num_points() && segment_idx < part_begin[part_idx + 1];
+  }
+
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE thrust::pair<vec_2d<T>, vec_2d<T>> segment(IndexType segment_idx)
+  {
+    return thrust::make_pair(points_begin[segment_idx], points_begin[segment_idx + 1]);
+  }
+
+ protected:
+  GeometryIterator geometry_begin;
+  GeometryIterator geometry_end;
+  PartIterator part_begin;
+  PartIterator part_end;
+  VecIterator points_begin;
+  VecIterator points_end;
+};
+
 }  // namespace iterator_collections
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/point_distance.cuh
@@ -40,6 +40,28 @@ OutputIt pairwise_point_distance(
   OutputIt distances_first,
   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
+/**
+ * @ingroup distance
+ * @copybrief cuspatial::pairwise_point_distance
+ *
+ * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
+ * "LegacyRandomAccessIterator"
+ */
+template <class OffsetIteratorA,
+          class OffsetIteratorB,
+          class Cart2dItA,
+          class Cart2dItB,
+          class OutputIt>
+OutputIt pairwise_point_distance(OffsetIteratorA multipoint1_geometry_begin,
+                                 OffsetIteratorA multipoint2_geometry_end,
+                                 Cart2dItA points1_begin,
+                                 Cart2dItB points1_end,
+                                 OffsetIteratorB multipoint2_geometry_offset,
+                                 Cart2dItB points2_begin,
+                                 Cart2dItB points2_end,
+                                 OutputIt distances_first,
+                                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
 }  // namespace cuspatial
 
 #include <cuspatial/experimental/detail/point_distance.cuh>

--- a/cpp/include/cuspatial/experimental/point_distance.cuh
+++ b/cpp/include/cuspatial/experimental/point_distance.cuh
@@ -18,39 +18,27 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuspatial/experimental/iterator_collections.cuh>
+
 namespace cuspatial {
 
 /**
  * @ingroup distance
  * @copybrief cuspatial::pairwise_point_distance
  *
- * @tparam Cart2dItA iterator type for point array of the first point of each pair. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam Cart2dItB iterator type for point array of the second point of each pair. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OutputIt iterator type for output array. Must meet the requirements of
- * [LegacyRandomAccessIterator][LinkLRAI], be mutable and be device-accessible.
- *
- * @param points1_first beginning of range of the first point of each pair
- * @param points1_last end of range of the first point of each pair
- * @param points2_first beginning of range of the second point of each pair
- * @param distances_first beginning iterator to output
- * @param stream The CUDA stream to use for device memory operations and kernel launches
- * @return Output iterator to one past the last element in the output range
- *
- * @pre all input iterators for coordinates must have a `value_type` of `cuspatial::vec_2d`.
- * @pre all scalar types must be floating point types, and must be the same type for all input
- * iterators and output iterators.
- *
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
  * "LegacyRandomAccessIterator"
  */
-template <class Cart2dItA, class Cart2dItB, class OutputIt>
-OutputIt pairwise_point_distance(Cart2dItA points1_first,
-                                 Cart2dItA points1_last,
-                                 Cart2dItB points2_first,
-                                 OutputIt distances_first,
-                                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+template <class OffsetIteratorA,
+          class OffsetIteratorB,
+          class Cart2dItA,
+          class Cart2dItB,
+          class OutputIt>
+OutputIt pairwise_point_distance(
+  iterator_collections::multipoint_array<OffsetIteratorA, Cart2dItA> multipoints1,
+  iterator_collections::multipoint_array<OffsetIteratorB, Cart2dItB> multipoints2,
+  OutputIt distances_first,
+  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 }  // namespace cuspatial
 

--- a/cpp/include/cuspatial/experimental/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/point_linestring_distance.cuh
@@ -18,6 +18,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuspatial/experimental/iterator_collections.cuh>
+
 namespace cuspatial {
 
 /**
@@ -80,6 +82,18 @@ OutputIt pairwise_point_linestring_distance(
   Cart2dItB linestring_points_first,
   Cart2dItB linestring_points_last,
   OutputIt distances_first,
+  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+template <class Cart2dItA,
+          class Cart2dItB,
+          class OffsetIteratorA,
+          class OffsetIteratorB,
+          class OffsetIteratorC,
+          class OutputIt>
+OutputIt pairwise_point_linestring_distance(
+  iterator_collections::multipoint_array<OffsetIteratorA, Cart2dItA> multipoints,
+  iterator_collections::multilinestring_array<OffsetIteratorB, OffsetIteratorC, Cart2dItB>
+    multilinestrings,
   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 }  // namespace cuspatial

--- a/cpp/src/spatial/point_distance.cu
+++ b/cpp/src/spatial/point_distance.cu
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#include "../utility/double_boolean_dispatch.hpp"
+#include "../utility/iterator.hpp"
+
 #include <cuspatial/error.hpp>
+#include <cuspatial/experimental/iterator_collections.cuh>
 #include <cuspatial/experimental/point_distance.cuh>
 #include <cuspatial/experimental/type_utils.hpp>
 #include <cuspatial/vec_2d.hpp>
@@ -32,30 +36,42 @@
 
 namespace cuspatial {
 namespace detail {
-struct pairwise_point_distance_functor {
+template <bool is_multipoint1, bool is_multipoint2>
+struct pairwise_point_distance_impl {
   template <typename T>
   std::enable_if_t<std::is_floating_point<T>::value, std::unique_ptr<cudf::column>> operator()(
-    cudf::column_view const& points1_x,
-    cudf::column_view const& points1_y,
-    cudf::column_view const& points2_x,
-    cudf::column_view const& points2_y,
+    cudf::size_type num_pairs,
+    std::optional<cudf::device_span<cudf::size_type const>> multipoints1_offset,
+    cudf::column_view const& points1_xy,
+    std::optional<cudf::device_span<cudf::size_type const>> multipoints2_offset,
+    cudf::column_view const& points2_xy,
     rmm::cuda_stream_view stream,
     rmm::mr::device_memory_resource* mr)
   {
-    auto distances = cudf::make_numeric_column(cudf::data_type{cudf::type_to_id<T>()},
-                                               points1_x.size(),
-                                               cudf::mask_state::UNALLOCATED,
-                                               stream,
-                                               mr);
+    auto distances = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_to_id<T>()}, num_pairs, cudf::mask_state::UNALLOCATED, stream, mr);
 
-    auto points1_it = make_vec_2d_iterator(points1_x.begin<T>(), points1_y.begin<T>());
-    auto points2_it = make_vec_2d_iterator(points2_x.begin<T>(), points2_y.begin<T>());
+    auto multipoint1_offset_it =
+      get_geometry_iterator_functor<is_multipoint1>{}(multipoints1_offset);
+    auto multipoint2_offset_it =
+      get_geometry_iterator_functor<is_multipoint2>{}(multipoints2_offset);
 
-    pairwise_point_distance(points1_it,
-                            points1_it + points1_x.size(),
-                            points2_it,
-                            distances->mutable_view().begin<T>(),
-                            stream);
+    auto points1_it = interleaved_iterator_to_vec_2d_iterator(points1_xy.begin<T>());
+    auto points2_it = interleaved_iterator_to_vec_2d_iterator(points2_xy.begin<T>());
+
+    auto multipoint1_its =
+      iterator_collections::multipoint_array(multipoint1_offset_it,
+                                             multipoint1_offset_it + num_pairs,
+                                             points1_it,
+                                             points1_it + points1_xy.size() / 2);
+    auto multipoint2_its =
+      iterator_collections::multipoint_array(multipoint2_offset_it,
+                                             multipoint2_offset_it + num_pairs,
+                                             points2_it,
+                                             points2_it + points2_xy.size() / 2);
+
+    pairwise_point_distance(
+      multipoint1_its, multipoint2_its, distances->mutable_view().begin<T>(), stream);
 
     return distances;
   }
@@ -68,46 +84,60 @@ struct pairwise_point_distance_functor {
   }
 };
 
-std::unique_ptr<cudf::column> pairwise_point_distance(cudf::column_view const& points1_x,
-                                                      cudf::column_view const& points1_y,
-                                                      cudf::column_view const& points2_x,
-                                                      cudf::column_view const& points2_y,
-                                                      rmm::cuda_stream_view stream,
-                                                      rmm::mr::device_memory_resource* mr)
-{
-  CUSPATIAL_EXPECTS(points1_x.size() == points1_y.size() and
-                      points2_x.size() == points2_y.size() and points1_x.size() == points2_x.size(),
-                    "Mismatch number of coordinate or number of points.");
+template <bool is_multipoint1, bool is_multipoint2>
+struct pairwise_point_distance_functor {
+  std::unique_ptr<cudf::column> operator()(
+    std::optional<cudf::device_span<cudf::size_type const>> multipoints1_offset,
+    cudf::column_view const& points1_xy,
+    std::optional<cudf::device_span<cudf::size_type const>> multipoints2_offset,
+    cudf::column_view const& points2_xy,
+    rmm::cuda_stream_view stream,
+    rmm::mr::device_memory_resource* mr)
+  {
+    CUSPATIAL_EXPECTS(points1_xy.size() % 2 == 0 and points2_xy.size() % 2 == 0,
+                      "Coordinate array should contain even number of points.");
+    CUSPATIAL_EXPECTS(points1_xy.type() == points2_xy.type(),
+                      "The types of point coordinates arrays mismatch.");
+    CUSPATIAL_EXPECTS(not points1_xy.has_nulls() and not points2_xy.has_nulls(),
+                      "The coordinate columns cannot have nulls.");
 
-  CUSPATIAL_EXPECTS(points1_x.type() == points1_y.type() and
-                      points2_x.type() == points2_y.type() and points1_x.type() == points2_x.type(),
-                    "The types of point coordinates arrays mismatch.");
-  CUSPATIAL_EXPECTS(not points1_x.has_nulls() and not points1_y.has_nulls() and
-                      not points2_x.has_nulls() and not points2_y.has_nulls(),
-                    "The coordinate columns cannot have nulls.");
+    auto num_lhs = is_multipoint1 ? multipoints1_offset.value().size() - 1 : points1_xy.size() / 2;
+    auto num_rhs = is_multipoint2 ? multipoints2_offset.value().size() - 1 : points2_xy.size() / 2;
 
-  if (points1_x.size() == 0) { return cudf::empty_like(points1_x); }
+    CUSPATIAL_EXPECTS(num_lhs == num_rhs, "Mismatch number of (multi)point(s) in input.");
 
-  return cudf::type_dispatcher(points1_x.type(),
-                               pairwise_point_distance_functor{},
-                               points1_x,
-                               points1_y,
-                               points2_x,
-                               points2_y,
-                               stream,
-                               mr);
-}
+    if (num_lhs == 1) { return cudf::empty_like(points1_xy); }
+
+    return cudf::type_dispatcher(points1_xy.type(),
+                                 pairwise_point_distance_impl<is_multipoint1, is_multipoint2>{},
+                                 num_lhs - 1,
+                                 multipoints1_offset,
+                                 points1_xy,
+                                 multipoints2_offset,
+                                 points2_xy,
+                                 stream,
+                                 mr);
+  }
+};
 
 }  // namespace detail
 
-std::unique_ptr<cudf::column> pairwise_point_distance(cudf::column_view const& points1_x,
-                                                      cudf::column_view const& points1_y,
-                                                      cudf::column_view const& points2_x,
-                                                      cudf::column_view const& points2_y,
-                                                      rmm::mr::device_memory_resource* mr)
+std::unique_ptr<cudf::column> pairwise_point_distance(
+  std::optional<cudf::device_span<cudf::size_type const>> multipoints1_offset,
+  cudf::column_view const& points1_xy,
+  std::optional<cudf::device_span<cudf::size_type const>> multipoints2_offset,
+  cudf::column_view const& points2_xy,
+  rmm::mr::device_memory_resource* mr)
 {
-  return detail::pairwise_point_distance(
-    points1_x, points1_y, points2_x, points2_y, rmm::cuda_stream_default, mr);
+  return double_boolean_dispatch<detail::pairwise_point_distance_functor>(
+    multipoints1_offset.has_value(),
+    multipoints2_offset.has_value(),
+    multipoints1_offset,
+    points1_xy,
+    multipoints2_offset,
+    points2_xy,
+    rmm::cuda_stream_default,
+    mr);
 }
 
 }  // namespace cuspatial

--- a/cpp/tests/spatial/point_distance_test.cpp
+++ b/cpp/tests/spatial/point_distance_test.cpp
@@ -37,18 +37,70 @@ using TestTypes = ::testing::Types<float, double>;
 
 TYPED_TEST_CASE(PairwisePointDistanceTest, TestTypes);
 
-TYPED_TEST(PairwisePointDistanceTest, Empty)
+TYPED_TEST(PairwisePointDistanceTest, SingleToSingleEmpty)
 {
   using T = TypeParam;
 
-  auto x1 = fixed_width_column_wrapper<T>{};
-  auto y1 = fixed_width_column_wrapper<T>{};
-  auto x2 = fixed_width_column_wrapper<T>{};
-  auto y2 = fixed_width_column_wrapper<T>{};
+  auto offset1 = std::nullopt;
+  auto offset2 = std::nullopt;
+
+  auto xy1 = fixed_width_column_wrapper<T>{};
+  auto xy2 = fixed_width_column_wrapper<T>{};
 
   auto expect = fixed_width_column_wrapper<T>{};
 
-  auto got = pairwise_point_distance(x1, y1, x2, y2);
+  auto got = pairwise_point_distance(offset1, xy1, offset2, xy2);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect, *got);
+}
+
+TYPED_TEST(PairwisePointDistanceTest, SingleToMultiEmpty)
+{
+  using T = TypeParam;
+
+  auto offset1        = std::nullopt;
+  column_view offset2 = fixed_width_column_wrapper<cudf::size_type>{0};
+
+  auto xy1 = fixed_width_column_wrapper<T>{};
+  auto xy2 = fixed_width_column_wrapper<T>{};
+
+  auto expect = fixed_width_column_wrapper<T>{};
+
+  auto got = pairwise_point_distance(offset1, xy1, offset2, xy2);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect, *got);
+}
+
+TYPED_TEST(PairwisePointDistanceTest, MultiToSingleEmpty)
+{
+  using T = TypeParam;
+
+  column_view offset1 = fixed_width_column_wrapper<cudf::size_type>{0};
+  auto offset2        = std::nullopt;
+
+  auto xy1 = fixed_width_column_wrapper<T>{};
+  auto xy2 = fixed_width_column_wrapper<T>{};
+
+  auto expect = fixed_width_column_wrapper<T>{};
+
+  auto got = pairwise_point_distance(offset1, xy1, offset2, xy2);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect, *got);
+}
+
+TYPED_TEST(PairwisePointDistanceTest, MultiToMultiEmpty)
+{
+  using T = TypeParam;
+
+  column_view offset1 = fixed_width_column_wrapper<cudf::size_type>{0};
+  column_view offset2 = fixed_width_column_wrapper<cudf::size_type>{0};
+
+  auto xy1 = fixed_width_column_wrapper<T>{};
+  auto xy2 = fixed_width_column_wrapper<T>{};
+
+  auto expect = fixed_width_column_wrapper<T>{};
+
+  auto got = pairwise_point_distance(offset1, xy1, offset2, xy2);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect, *got);
 }
@@ -58,62 +110,33 @@ struct PairwisePointDistanceTestThrow : public ::testing::Test {
 
 TEST_F(PairwisePointDistanceTestThrow, SizeMismatch)
 {
-  auto x1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto x2 = fixed_width_column_wrapper<float>{};
-  auto y2 = fixed_width_column_wrapper<float>{};
+  column_view offset1 = fixed_width_column_wrapper<cudf::size_type>{0, 3};
+  column_view offset2 = fixed_width_column_wrapper<cudf::size_type>{0};
 
-  auto expect = fixed_width_column_wrapper<float>{};
+  auto xy1 = fixed_width_column_wrapper<float>{1, 1, 2, 2, 3, 3};
+  auto xy2 = fixed_width_column_wrapper<float>{};
 
-  EXPECT_THROW(pairwise_point_distance(x1, y1, x2, y2), cuspatial::logic_error);
+  EXPECT_THROW(pairwise_point_distance(offset1, xy1, offset2, xy2), cuspatial::logic_error);
 }
 
 TEST_F(PairwisePointDistanceTestThrow, SizeMismatch2)
 {
-  auto x1 = fixed_width_column_wrapper<float>{};
-  auto y1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto x2 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y2 = fixed_width_column_wrapper<float>{1, 2, 3};
+  column_view offset1 = fixed_width_column_wrapper<cudf::size_type>{0, 3};
+  auto offset2        = std::nullopt;
 
-  auto expect = fixed_width_column_wrapper<float>{};
+  auto xy1 = fixed_width_column_wrapper<float>{1, 1, 2, 2, 3, 3};
+  auto xy2 = fixed_width_column_wrapper<float>{};
 
-  EXPECT_THROW(pairwise_point_distance(x1, y1, x2, y2), cuspatial::logic_error);
+  EXPECT_THROW(pairwise_point_distance(offset1, xy1, offset2, xy2), cuspatial::logic_error);
 }
 
 TEST_F(PairwisePointDistanceTestThrow, TypeMismatch)
 {
-  auto x1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y1 = fixed_width_column_wrapper<double>{1, 2, 3};
-  auto x2 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y2 = fixed_width_column_wrapper<float>{1, 2, 3};
+  auto offset1 = std::nullopt;
+  auto offset2 = std::nullopt;
+  auto xy1     = fixed_width_column_wrapper<float>{1, 1, 2, 2, 3, 3};
+  auto xy2     = fixed_width_column_wrapper<double>{1, 1, 2, 2, 3, 3};
 
-  auto expect = fixed_width_column_wrapper<float>{};
-
-  EXPECT_THROW(pairwise_point_distance(x1, y1, x2, y2), cuspatial::logic_error);
+  EXPECT_THROW(pairwise_point_distance(offset1, xy1, offset2, xy2), cuspatial::logic_error);
 }
-
-TEST_F(PairwisePointDistanceTestThrow, TypeMismatch2)
-{
-  auto x1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto x2 = fixed_width_column_wrapper<double>{1, 2, 3};
-  auto y2 = fixed_width_column_wrapper<double>{1, 2, 3};
-
-  auto expect = fixed_width_column_wrapper<float>{};
-
-  EXPECT_THROW(pairwise_point_distance(x1, y1, x2, y2), cuspatial::logic_error);
-}
-
-TEST_F(PairwisePointDistanceTestThrow, ContainsNull)
-{
-  auto x1 = fixed_width_column_wrapper<float>{{1, 2, 3}, {1, 0, 1}};
-  auto y1 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto x2 = fixed_width_column_wrapper<float>{1, 2, 3};
-  auto y2 = fixed_width_column_wrapper<float>{1, 2, 3};
-
-  auto expect = fixed_width_column_wrapper<float>{};
-
-  EXPECT_THROW(pairwise_point_distance(x1, y1, x2, y2), cuspatial::logic_error);
-}
-
 }  // namespace cuspatial


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR demonstrates the idea of a `iterator_collections` structure, in an attempt to simplify the header only API interface.

In arrow `LIST` type structure, there might be nested iterables that utilizes a random accessible offset array to index into child arrays. Currently, cuspatial exposes the APIs by accepting a "flattened" view/iterator list of the nested columns.

This can easily make the input cumbersome. To show case the complexity, a multipolygon-multipolygon distance API may look like:
```c++
auto polygon_distance(
   OffsetIteratorA polygonA_geometry_offsets_begin,
   OffsetIteratorA polygonA_geometry_offsets_end,
   OffsetIteratorB polygonA_parts_offsets_begin,
   OffsetIteratorB polygonA_parts_offsets_end,
   OffsetIteratorC polygonA_ring_offsets_begin,
   OffsetIteratorC polygonA_ring_offsets_end,
   VecIterator polygonA_coordinates_begin,
   VecIterator polygonA_coordinates_end,
   OffsetIteratorD polygonB_geometry_offsets_begin,
   OffsetIteratorE polygonB_parts_offsets_begin,
   OffsetIteratorE polygonB_parts_offsets_end,
   OffsetIteratorF polygonB_ring_offsets_begin,
   OffsetIteratorF polygonB_ring_offsets_end,
   VecIterator polygonB_coordinates_begin,
   VecIterator polygonB_coordinates_end,
   OutputIterator distance_begin,
   rmm::cuda_stream_view stream
)
```

An `iterator_collection` packages up the inputs of different levels of input in a structure and provides different level of iteration to thrust algorithms. Ideally this may simplify the API to be like:

```c++
auto polygon_distance(
   iterator_collections::multipolygon_array<...> multipolygon1
   iterator_collections::multipolygon_array<...> multipolygon2
   OutputIterator distance_begin,
   rmm::cuda_stream_view stream
)
```

An `iterator_collection` can also provide different levels of iterators to allow developers to write kernel at their desired paralleled level. For example:

The below computes the multipoint distance with pair-wise parallel model.
```c++
thrust::transform(
  multipoint1.geometry_begin(), multipoint1.geometry_end(), multipoint2.geometry_begin(), distances_first, multipoint_wise_distance_op{});
```
and the below computes the distance with point-wise parallel model with a custom kernel.
```c++
point_wise_distance_kernel<<<...>>>(
   multipoint1.geometry_offset.begin(),
   multipoint1.geometry_offset.end(),
   multipoint1.point_offset.begin(),
   multipoint1.point_offset.end(),
   multipoint2.geometry_offset.begin(),
   multipoint2.geometry_offset.end(),
   multipoint2.point_offset.begin(),
   multipoint2.point_offset.end(),
)
```

## Update 09/23

After pairing with @thomcom, we introduced `multilinestring_array` iterator collections and adopted this towards `point_linestring_distance` kernel. This iterator collections supports traversing upwards in the nested hierarchy. Point-linestring distance kernel is launched upon each point in the multilinestring, thus the newly introduced structure should provide ways to retrieve the part/geometry index of the point that current thread operates on, this is essential to finding the corresponding multipoint in the pair. What this has demonstrated is that:

1. Several explicit dereference in the original kernel can be abstracted nicely in the `multilinestring_array` structure.
2. Some restriction in thrust makes dereferencing a bit cumbersome in kernel, but when wrapped with the new structure, the return type of the method can be made explicit and thus can make use of the implicit cast from `thrust::device_reference<T> -> T&`, further simplifying the kernel code path.
3. Range based for loop is more succinct than nested `for_each`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
