### PR TITLE
Document that minimum required CMake version is now 3.23.1

### DIFF
--- a/conda/environments/cuspatial_dev_cuda11.0.yml
+++ b/conda/environments/cuspatial_dev_cuda11.0.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.0
   - gdal>=3.0.2
   - geopandas>=0.11.0
-  - cmake>=3.20.1,!=3.23.0
+  - cmake>=3.23.1
   - cython>=0.29,<0.30
   - scikit-build>=0.13.1
   - gtest=1.10.0

--- a/conda/environments/cuspatial_dev_cuda11.1.yml
+++ b/conda/environments/cuspatial_dev_cuda11.1.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.1
   - gdal>=3.0.2
   - geopandas>=0.11.0
-  - cmake>=3.20.1,!=3.23.0
+  - cmake>=3.23.1
   - cython>=0.29,<0.30
   - scikit-build>=0.13.1
   - gtest=1.10.0

--- a/conda/environments/cuspatial_dev_cuda11.2.yml
+++ b/conda/environments/cuspatial_dev_cuda11.2.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.2
   - gdal>=3.0.2
   - geopandas>=0.11.0
-  - cmake>=3.20.1,!=3.23.0
+  - cmake>=3.23.1
   - cython>=0.29,<0.30
   - scikit-build>=0.13.1
   - gtest=1.10.0

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   host:
     - python
     - cython >=0.29,<0.30
-    - cmake>=3.20.1,!=3.23.0
+    - cmake>=3.23.1
     - scikit-build>=0.13.1
     - setuptools
     - cudf {{ minor_version }}.*

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.20.1"
+  - ">=3.23.1"
 
 gdal_version:
   - ">3.5.0"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 include(../fetch_rapids.cmake)
 include(rapids-cmake)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 include(../../../../fetch_rapids.cmake)
 

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 set(cuspatial_version 22.10.00)
 

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -19,6 +19,6 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.20.1,!=3.23.0",
+    "cmake>=3.23.1",
     "ninja",
 ]


### PR DESCRIPTION
## Description
With rapids-cmake now requiring CMake 3.23.1 update consumers to correctly express this requirement

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
