### PR TITLE
Update link to c++ developer guide

### DIFF
--- a/docs/source/developer_guide/index.md
+++ b/docs/source/developer_guide/index.md
@@ -3,7 +3,7 @@
 cuSpatial has two main components: the cuSpatial Python package and the `libcuspatial` C++ library,
 referred to as `cuspatial` and `libcuspatial` respectively in this documentation. This page
 discusses the design of `cuspatial`. For information on `libcuspatial`, see the [libcuspatial
-developer guide](https://docs.rapids.ai/api/libcuspatial/nightly/DEVELOPER_GUIDE.html)
+developer guide](https://docs.rapids.ai/api/libcuspatial/stable/DEVELOPER_GUIDE.html)
 and [C++ API reference](https://docs.rapids.ai/api/libcuspatial/stable/).
 
 ```{toctree}

--- a/docs/source/developer_guide/index.md
+++ b/docs/source/developer_guide/index.md
@@ -1,5 +1,11 @@
 # Developer Guide
 
+cuSpatial has two main components: the cuSpatial Python package and the `libcuspatial` C++ library,
+referred to as `cuspatial` and `libcuspatial` respectively in this documentation. This page
+discusses the design of `cuspatial`. For information on `libcuspatial`, see the [libcuspatial
+developer guide](https://docs.rapids.ai/api/libcuspatial/nightly/DEVELOPER_GUIDE.html)
+and [C++ API reference](https://docs.rapids.ai/api/libcuspatial/stable/).
+
 ```{toctree}
 :maxdepth: 2
 

--- a/docs/source/developer_guide/library_design.md
+++ b/docs/source/developer_guide/library_design.md
@@ -1,11 +1,5 @@
 # cuSpatial Library Design
 
-cuSpatial has two main components: the cuSpatial Python package and the `libcuspatial` C++ library,
-referred to as `cuspatial` and `libcuspatial` respectively in this documentation. This page
-discusses the design of `cuspatial`. For information on `libcuspatial`, see the [libcuspatial
-developer guide](https://docs.rapids.ai/api/libcuspatial/nightly/DEVELOPER_GUIDE.html)
-and [C++ API reference](https://docs.rapids.ai/api/libcuspatial/stable/).
-
 ## Overview
 
 At a high level, `cuspatial` has three parts:

--- a/docs/source/developer_guide/library_design.md
+++ b/docs/source/developer_guide/library_design.md
@@ -3,7 +3,7 @@
 cuSpatial has two main components: the cuSpatial Python package and the `libcuspatial` C++ library,
 referred to as `cuspatial` and `libcuspatial` respectively in this documentation. This page
 discusses the design of `cuspatial`. For information on `libcuspatial`, see the [libcuspatial
-developer guide](https://github.com/rapidsai/cuspatial/blob/branch-22.10/cpp/doc/DEVELOPER_GUIDE.md)
+developer guide](https://docs.rapids.ai/api/libcuspatial/nightly/DEVELOPER_GUIDE.html)
 and [C++ API reference](https://docs.rapids.ai/api/libcuspatial/stable/).
 
 ## Overview


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR moves the library wide overview section to top level `developer guide`. And updates link to c++ developer guide. As of creation, the link to c++ developer guide is not published yet. Should verify before merge.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
