### PR TITLE
`unwrap_pyoptcol` is missing `except` keyword that causes exceptions ignored, fixes function bug

### DIFF
--- a/python/cuspatial/cuspatial/_lib/utils.pyx
+++ b/python/cuspatial/cuspatial/_lib/utils.pyx
@@ -5,13 +5,15 @@ from cudf._lib.cpp.column.column_view cimport column_view
 from cuspatial._lib.cpp.optional cimport nullopt, optional
 
 
-cdef optional[column_view] unwrap_pyoptcol(pyoptcol):
+cdef optional[column_view] unwrap_pyoptcol(pyoptcol) except *:
     # Unwrap python optional Column arg to c optional[column_view]
     cdef Column pycol
-    cdef optional[column_view] c_opt = nullopt
+    cdef optional[column_view] c_opt
     if isinstance(pyoptcol, Column):
         pycol = pyoptcol
         c_opt = pycol.view()
+    elif pyoptcol is None:
+        c_opt = nullopt
     else:
-        raise ValueError("pyoptcol must be a Column or None")
+        raise ValueError("pyoptcol must be either Column or None.")
     return c_opt


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Fixes a bug in the cdef function when `pyoptcol` is `None` and gets mishandled (raised as error). This error is captured in one of the pytests for `point_linestring_distance`. However, due to the cdef function is missing the `except` keyword, the exception gets ignored by the python interpreter and not reraised.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
