### PR TITLE
Test boundary exclusion in python and add boundary exclusion to original point_in_polygon

### DIFF
--- a/cpp/src/utility/point_in_polygon.cuh
+++ b/cpp/src/utility/point_in_polygon.cuh
@@ -56,7 +56,15 @@ inline __device__ bool is_point_in_polygon(T const x,
       T rise               = y1 - y0;
       T rise_to_point      = y - y0;
 
-      if (y_in_bounds && x < (run / rise) * rise_to_point + x0) { in_polygon = not in_polygon; }
+      // colinearity test
+      T d           = (x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0);
+      T d1          = (x - x0) * (x - x1) + (y - y0) * (y - y1);
+      T d2          = (x1 - x) * (x1 - x) + (y1 - y) * (y1 - y);
+      bool colinear = d1 + d2 == d;
+
+      if (!colinear && y_in_bounds && x < (run / rise) * rise_to_point + x0) {
+        in_polygon = not in_polygon;
+      }
     }
   }
 

--- a/python/cuspatial/cuspatial/tests/test_contains.py
+++ b/python/cuspatial/cuspatial/tests/test_contains.py
@@ -1,0 +1,49 @@
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point, Polygon
+
+import cudf
+
+import cuspatial
+
+
+def test_point_shared_with_polygon():
+    point = Point([0, 0])
+    polygon = Polygon([[0, 0], [0, 1], [1, 1], [0, 0]])
+    point_series = cuspatial.from_geopandas(gpd.GeoSeries(point))
+    polygon_series = cuspatial.from_geopandas(gpd.GeoSeries(polygon))
+    result = cuspatial.point_in_polygon(
+        point_series.points.x,
+        point_series.points.y,
+        polygon_series.polygons.ring_offset[:-1],
+        polygon_series.polygons.part_offset[:-1],
+        polygon_series.polygons.x,
+        polygon_series.polygons.y,
+    )
+    cudf.testing.assert_frame_equal(result, cudf.DataFrame({0: False}))
+    gpdpoint = point_series.to_pandas()
+    gpdpolygon = polygon_series.to_pandas()
+    pd.testing.assert_series_equal(
+        gpdpolygon.contains(gpdpoint), pd.Series([False])
+    )
+
+
+def test_point_collinear_with_polygon():
+    point = Point([0.5, 0.0])
+    polygon = Polygon([[0, 0], [0, 1], [1, 1], [0, 0]])
+    point_series = cuspatial.from_geopandas(gpd.GeoSeries(point))
+    polygon_series = cuspatial.from_geopandas(gpd.GeoSeries(polygon))
+    result = cuspatial.point_in_polygon(
+        point_series.points.x,
+        point_series.points.y,
+        polygon_series.polygons.ring_offset[:-1],
+        polygon_series.polygons.part_offset[:-1],
+        polygon_series.polygons.x,
+        polygon_series.polygons.y,
+    )
+    cudf.testing.assert_frame_equal(result, cudf.DataFrame({0: False}))
+    gpdpoint = point_series.to_pandas()
+    gpdpolygon = polygon_series.to_pandas()
+    pd.testing.assert_series_equal(
+        gpdpolygon.contains(gpdpoint), pd.Series([False])
+    )


### PR DESCRIPTION
We don't properly boundary exclude edges during point-in-polygon tests. Previously, we excluded rejected points in `point_in_polygon` that matched points that composed the comparison polygon, but if a point was colinear with a pair of points on the edge of the polygon, that point would be included. This PR adds those tests, and also a fix for `point_in_polygon.cuh` that adds boundary exclusion for colinear points.