### PR TITLE
Support more than 31 polygons in point_in_polygon.

### DIFF
--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cuspatial/error.hpp>
-#include <cuspatial/experimental/detail/is_point_in_polygon_kernel.cuh>
 #include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
@@ -30,6 +29,69 @@
 
 namespace cuspatial {
 namespace detail {
+
+/**
+ * @brief Kernel to test if a point is inside a polygon.
+ *
+ * Implemented based on Eric Haines's crossings-multiply algorithm:
+ * See "Crossings test" section of http://erich.realtimerendering.com/ptinpoly/
+ * The improvement in addenda is also addopted to remove divisions in this kernel.
+ *
+ * TODO: the ultimate goal of refactoring this as independent function is to remove
+ * src/utility/point_in_polygon.cuh and its usage in quadtree_point_in_polygon.cu. It isn't
+ * possible today without further work to refactor quadtree_point_in_polygon into header only
+ * API.
+ */
+template <class Cart2d,
+          class OffsetType,
+          class OffsetIterator,
+          class Cart2dIt,
+          class OffsetItDiffType = typename std::iterator_traits<OffsetIterator>::difference_type,
+          class Cart2dItDiffType = typename std::iterator_traits<Cart2dIt>::difference_type>
+__device__ inline bool is_point_in_polygon(Cart2d const& test_point,
+                                           OffsetType poly_begin,
+                                           OffsetType poly_end,
+                                           OffsetIterator ring_offsets_first,
+                                           OffsetItDiffType const& num_rings,
+                                           Cart2dIt poly_points_first,
+                                           Cart2dItDiffType const& num_poly_points)
+{
+  using T = iterator_vec_base_type<Cart2dIt>;
+
+  bool point_is_within = false;
+  // for each ring
+  for (auto ring_idx = poly_begin; ring_idx < poly_end; ring_idx++) {
+    int32_t ring_idx_next = ring_idx + 1;
+    int32_t ring_begin    = ring_offsets_first[ring_idx];
+    int32_t ring_end =
+      (ring_idx_next < num_rings) ? ring_offsets_first[ring_idx_next] : num_poly_points;
+
+    Cart2d b     = poly_points_first[ring_end - 1];
+    bool y0_flag = b.y > test_point.y;
+    bool y1_flag;
+    // for each line segment, including the segment between the last and first vertex
+    for (auto point_idx = ring_begin; point_idx < ring_end; point_idx++) {
+      Cart2d const a = poly_points_first[point_idx];
+      y1_flag        = a.y > test_point.y;
+      if (y1_flag != y0_flag) {
+        T run           = b.x - a.x;
+        T rise          = b.y - a.y;
+        T rise_to_point = test_point.y - a.y;
+
+        // Transform the following inequality to avoid division
+        //  test_point.x < (run / rise) * rise_to_point + a.x
+        auto lhs = (test_point.x - a.x) * rise;
+        auto rhs = run * rise_to_point;
+        if ((rise > 0 && lhs < rhs) || (rise < 0 && lhs > rhs))
+          point_is_within = not point_is_within;
+      }
+      b       = a;
+      y0_flag = y1_flag;
+    }
+  }
+
+  return point_is_within;
+}
 
 template <class Cart2dItA,
           class Cart2dItB,

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -203,7 +203,7 @@ OutputIt point_in_polygon(Cart2dItA test_points_first,
     output);
   CUSPATIAL_CUDA_TRY(cudaGetLastError());
 
-  return output + num_test_points;
+  return output + num_test_points * num_polys;
 }
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -136,7 +136,7 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
                                                      poly_points_first,
                                                      num_poly_points);
 
-    result->begin()[poly_idx][idx] = static_cast<int32_t>(point_is_within);
+    result[num_test_points * poly_idx + idx] = point_is_within;
   }
 }
 

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuspatial/error.hpp>
+#include <cuspatial/experimental/detail/is_point_in_polygon_kernel.cuh>
 #include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
@@ -29,69 +30,6 @@
 
 namespace cuspatial {
 namespace detail {
-
-/**
- * @brief Kernel to test if a point is inside a polygon.
- *
- * Implemented based on Eric Haines's crossings-multiply algorithm:
- * See "Crossings test" section of http://erich.realtimerendering.com/ptinpoly/
- * The improvement in addenda is also addopted to remove divisions in this kernel.
- *
- * TODO: the ultimate goal of refactoring this as independent function is to remove
- * src/utility/point_in_polygon.cuh and its usage in quadtree_point_in_polygon.cu. It isn't
- * possible today without further work to refactor quadtree_point_in_polygon into header only
- * API.
- */
-template <class Cart2d,
-          class OffsetType,
-          class OffsetIterator,
-          class Cart2dIt,
-          class OffsetItDiffType = typename std::iterator_traits<OffsetIterator>::difference_type,
-          class Cart2dItDiffType = typename std::iterator_traits<Cart2dIt>::difference_type>
-__device__ inline bool is_point_in_polygon(Cart2d const& test_point,
-                                           OffsetType poly_begin,
-                                           OffsetType poly_end,
-                                           OffsetIterator ring_offsets_first,
-                                           OffsetItDiffType const& num_rings,
-                                           Cart2dIt poly_points_first,
-                                           Cart2dItDiffType const& num_poly_points)
-{
-  using T = iterator_vec_base_type<Cart2dIt>;
-
-  bool point_is_within = false;
-  // for each ring
-  for (auto ring_idx = poly_begin; ring_idx < poly_end; ring_idx++) {
-    int32_t ring_idx_next = ring_idx + 1;
-    int32_t ring_begin    = ring_offsets_first[ring_idx];
-    int32_t ring_end =
-      (ring_idx_next < num_rings) ? ring_offsets_first[ring_idx_next] : num_poly_points;
-
-    Cart2d b     = poly_points_first[ring_end - 1];
-    bool y0_flag = b.y > test_point.y;
-    bool y1_flag;
-    // for each line segment, including the segment between the last and first vertex
-    for (auto point_idx = ring_begin; point_idx < ring_end; point_idx++) {
-      Cart2d const a = poly_points_first[point_idx];
-      y1_flag        = a.y > test_point.y;
-      if (y1_flag != y0_flag) {
-        T run           = b.x - a.x;
-        T rise          = b.y - a.y;
-        T rise_to_point = test_point.y - a.y;
-
-        // Transform the following inequality to avoid division
-        //  test_point.x < (run / rise) * rise_to_point + a.x
-        auto lhs = (test_point.x - a.x) * rise;
-        auto rhs = run * rise_to_point;
-        if ((rise > 0 && lhs < rhs) || (rise < 0 && lhs > rhs))
-          point_is_within = not point_is_within;
-      }
-      b       = a;
-      y0_flag = y1_flag;
-    }
-  }
-
-  return point_is_within;
-}
 
 template <class Cart2dItA,
           class Cart2dItB,
@@ -119,8 +57,6 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
 
   if (idx >= num_test_points) { return; }
 
-  int32_t hit_mask = 0;
-
   Cart2d const test_point = test_points_first[idx];
 
   // for each polygon
@@ -138,9 +74,8 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
                                                      poly_points_first,
                                                      num_poly_points);
 
-    hit_mask |= point_is_within << poly_idx;
+    result->begin()[poly_idx][idx] = static_cast<int32_t>(point_is_within);
   }
-  result[idx] = hit_mask;
 }
 
 }  // namespace detail
@@ -178,8 +113,9 @@ OutputIt point_in_polygon(Cart2dItA test_points_first,
                                        iterator_value_type<OffsetIteratorB>>(),
                 "OffsetIterators must point to integral type.");
 
-  static_assert(std::is_same_v<iterator_value_type<OutputIt>, int32_t>,
-                "OutputIt must point to 32 bit integer type.");
+  // TODO Assert it points to a column, is that an OffsetIterator?
+  // static_assert(cuspatial::is_integral<iterator_value_type<OutputIt>>(),
+  //             "OutputIt must point to integral type.");
 
   CUSPATIAL_EXPECTS(num_polys <= std::numeric_limits<int32_t>::digits,
                     "Number of polygons cannot exceed 31");

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -179,9 +179,6 @@ OutputIt point_in_polygon(Cart2dItA test_points_first,
   // static_assert(cuspatial::is_integral<iterator_value_type<OutputIt>>(),
   //             "OutputIt must point to integral type.");
 
-  CUSPATIAL_EXPECTS(num_polys <= std::numeric_limits<int32_t>::digits,
-                    "Number of polygons cannot exceed 31");
-
   CUSPATIAL_EXPECTS(num_rings >= num_polys, "Each polygon must have at least one ring");
   CUSPATIAL_EXPECTS(num_poly_points >= num_polys * 4, "Each ring must have at least four vertices");
 

--- a/cpp/include/cuspatial/point_in_polygon.hpp
+++ b/cpp/include/cuspatial/point_in_polygon.hpp
@@ -71,7 +71,7 @@ namespace cuspatial {
  *        +-----------+   +------------------------+
  * ```
  */
-std::unique_ptr<cudf::column> point_in_polygon(
+std::pair<std::unique_ptr<cudf::column>, cudf::table_view> point_in_polygon(
   cudf::column_view const& test_points_x,
   cudf::column_view const& test_points_y,
   cudf::column_view const& poly_offsets,

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -92,7 +92,7 @@ struct point_in_polygon_functor {
     auto splits = std::vector<cudf::size_type>(splits_iter, splits_iter + test_points_x.size() - 1);
     auto result_column_views = cudf::split(results->view(), splits);
 
-    return std::pair(std::move(results), std::move(cudf::table_view(result_column_views)));
+    return std::pair(std::move(results), cudf::table_view(result_column_views));
   }
 };
 }  // anonymous namespace

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -91,9 +91,6 @@ struct point_in_polygon_functor {
       one_iter, [width = test_points_x.size()](cudf::size_type idx) { return idx * width; });
     auto splits = std::vector<cudf::size_type>(splits_iter, splits_iter + poly_offsets.size() - 1);
     auto result_column_views = cudf::split(results->view(), splits);
-    for (size_t i = 0; i < result_column_views.size(); ++i) {
-      std::cout << "Column length: " << result_column_views[i].size() << std::endl;
-    }
 
     return std::pair(std::move(results), cudf::table_view(result_column_views));
   }

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -42,7 +42,7 @@ struct point_in_polygon_functor {
   }
 
   template <typename T, std::enable_if_t<!is_supported<T>()>* = nullptr, typename... Args>
-  std::unique_ptr<cudf::table> operator()(Args&&...)
+  std::pair<std::unique_ptr<cudf::column>, cudf::table_view>  operator()(Args&&...)
   {
     CUSPATIAL_FAIL("Non-floating point operation is not supported");
   }
@@ -92,7 +92,7 @@ struct point_in_polygon_functor {
     auto splits = std::vector<cudf::size_type>(splits_iter, splits_iter + test_points_x.size() - 1);
     auto result_column_views = cudf::split(results->view(), splits);
 
-    return std::pair(std::move(results), cudf::table_view(result_column_views));
+    return std::pair(std::move(results), std::move(cudf::table_view(result_column_views)));
   }
 };
 }  // anonymous namespace

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -68,12 +68,6 @@ struct point_in_polygon_functor {
         cudf::make_fixed_width_column(type, size, cudf::mask_state::UNALLOCATED, stream, mr));
     }
 
-    auto make_table = [](auto&& col) {
-      auto columns = std::vector<std::unique_ptr<cudf::column>>();
-      columns.push_back(std::move(col));
-      return cudf::table{std::move(columns)};
-    };
-
     if (results.size() == 0) {
       return std::make_unique<cudf::table>(cudf::table(std::move(results)));
     }

--- a/cpp/src/spatial/point_in_polygon.cu
+++ b/cpp/src/spatial/point_in_polygon.cu
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
@@ -157,9 +156,6 @@ std::pair<std::unique_ptr<cudf::column>, cudf::table_view> point_in_polygon(
 
   CUSPATIAL_EXPECTS(not poly_points_x.has_nulls() && not poly_points_y.has_nulls(),
                     "Polygon points must not contain nulls");
-
-  CUSPATIAL_EXPECTS(poly_offsets.size() <= std::numeric_limits<int32_t>::digits,
-                    "Number of polygons cannot exceed 31");
 
   CUSPATIAL_EXPECTS(poly_ring_offsets.size() >= poly_offsets.size(),
                     "Each polygon must have at least one ring");

--- a/cpp/tests/experimental/spatial/point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/point_in_polygon_test.cu
@@ -293,7 +293,7 @@ TYPED_TEST(PointInPolygonTest, 31PolygonSupport)
     false, true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
     true,  false, true,  false, true,  false, true,  false, true,  false, true,  false, true,
     false, true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
-    true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
+    true,  false, true,  false, true,  false, true,  false, true,  false,
   };
   auto got = rmm::device_vector<bool>(test_point.size() * num_polys);
 

--- a/cpp/tests/experimental/spatial/point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/point_in_polygon_test.cu
@@ -62,8 +62,8 @@ TYPED_TEST(PointInPolygonTest, OnePolygonOneRing)
   auto poly_point =
     this->make_device_points({{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {-1.0, -1.0}});
 
-  auto got      = rmm::device_vector<int32_t>(test_point.size());
-  auto expected = std::vector<int32_t>{false, false, false, false, true, true, true, true};
+  auto got      = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
+  auto expected = std::vector<bool>{false, false, false, false, true, true, true, true};
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -103,8 +103,23 @@ TYPED_TEST(PointInPolygonTest, TwoPolygonsOneRingEach)
                                               {-1.0, 0.0},
                                               {0.0, 1.0}});
 
-  auto got      = rmm::device_vector<int32_t>(test_point.size());
-  auto expected = std::vector<int32_t>({0b00, 0b00, 0b00, 0b00, 0b11, 0b11, 0b11, 0b11});
+  auto got      = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
+  auto expected = std::vector<bool>({false,
+                                     false,
+                                     false,
+                                     false,
+                                     true,
+                                     true,
+                                     true,
+                                     true,
+                                     false,
+                                     false,
+                                     false,
+                                     false,
+                                     true,
+                                     true,
+                                     true,
+                                     true});
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -137,8 +152,8 @@ TYPED_TEST(PointInPolygonTest, OnePolygonTwoRings)
                                               {0.5, -0.5},
                                               {-0.5, -0.5}});
 
-  auto got      = rmm::device_vector<int32_t>(test_point.size());
-  auto expected = std::vector<int32_t>{0b0, 0b0, 0b1, 0b0, 0b1};
+  auto got      = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
+  auto expected = std::vector<bool>{false, false, true, false, true};
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -171,8 +186,8 @@ TYPED_TEST(PointInPolygonTest, EdgesOfSquare)
 
   // point is included in rects on min x and y sides, but not on max x or y sides.
   // this behavior is inconsistent, and not necessarily intentional.
-  auto expected = std::vector<int32_t>{0b1010};
-  auto got      = rmm::device_vector<int32_t>(test_point.size());
+  auto expected = std::vector<bool>{false, true, false, true};
+  auto got      = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -205,8 +220,8 @@ TYPED_TEST(PointInPolygonTest, CornersOfSquare)
 
   // point is only included on the max x max y corner.
   // this behavior is inconsistent, and not necessarily intentional.
-  auto expected = std::vector<int32_t>{0b1000};
-  auto got      = rmm::device_vector<int32_t>(test_point.size());
+  auto expected = std::vector<bool>{false, false, false, true};
+  auto got      = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -273,9 +288,14 @@ TYPED_TEST(PointInPolygonTest, 31PolygonSupport)
     thrust::make_transform_iterator(offsets_iter, PolyPointIteratorFunctorB<T>{});
   auto poly_point_iter = make_vec_2d_iterator(poly_point_xs_iter, poly_point_ys_iter);
 
-  auto expected =
-    std::vector<int32_t>({0b1111111111111111111111111111111, 0b0000000000000000000000000000000});
-  auto got = rmm::device_vector<int32_t>(test_point.size());
+  auto expected = std::vector<bool>{
+    true,  false, true,  false, true,  false, true,  false, true,  false, true,  false, true,
+    false, true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
+    true,  false, true,  false, true,  false, true,  false, true,  false, true,  false, true,
+    false, true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
+    true,  false, true,  false, true,  false, true,  false, true,  false, true,  false,
+  };
+  auto got = rmm::device_vector<bool>(test_point.size() * num_polys);
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -302,7 +322,7 @@ TEST_F(PointInPolygonErrorTest, MismatchPolyPointXYLength)
   auto poly_offsets      = this->make_device_offsets({0});
   auto poly_ring_offsets = this->make_device_offsets({0});
   auto poly_point        = this->make_device_points({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}});
-  auto got               = rmm::device_vector<int32_t>(test_point.size());
+  auto got               = rmm::device_vector<bool>(test_point.size());
 
   EXPECT_THROW(point_in_polygon(test_point.begin(),
                                 test_point.end(),
@@ -324,8 +344,8 @@ TYPED_TEST(PointInPolygonTest, SelfClosingLoopLeftEdgeMissing)
   auto poly_ring_offsets = this->make_device_offsets({0});
   // "left" edge missing
   auto poly_point = this->make_device_points({{-1, 1}, {1, 1}, {1, -1}, {-1, -1}});
-  auto expected   = std::vector<int32_t>{0b0, 0b1, 0b0};
-  auto got        = rmm::device_vector<int32_t>(test_point.size());
+  auto expected   = std::vector<bool>{false, true, false};
+  auto got        = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),
@@ -349,8 +369,8 @@ TYPED_TEST(PointInPolygonTest, SelfClosingLoopRightEdgeMissing)
   auto poly_ring_offsets = this->make_device_offsets({0});
   // "right" edge missing
   auto poly_point = this->make_device_points({{1, -1}, {-1, -1}, {-1, 1}, {1, 1}});
-  auto expected   = std::vector<int32_t>{0b0, 0b1, 0b0};
-  auto got        = rmm::device_vector<int32_t>(test_point.size());
+  auto expected   = std::vector<bool>{false, true, false};
+  auto got        = rmm::device_vector<bool>(test_point.size() * poly_offsets.size());
 
   auto ret = point_in_polygon(test_point.begin(),
                               test_point.end(),

--- a/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
+++ b/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
@@ -129,5 +129,5 @@ TEST_F(PolygonShapefileReaderTest, OnePointInPolygon)
 
   auto ret = cuspatial::point_in_polygon(test_xs, test_ys, polygons, rings, xs, ys);
 
-  expect_columns_equivalent(ret->view(), expected);
+  expect_columns_equivalent(ret.first()->view(), expected);
 }

--- a/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
+++ b/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
@@ -129,5 +129,5 @@ TEST_F(PolygonShapefileReaderTest, OnePointInPolygon)
 
   auto ret = cuspatial::point_in_polygon(test_xs, test_ys, polygons, rings, xs, ys);
 
-  expect_columns_equivalent(ret.first()->view(), expected);
+  expect_columns_equivalent(ret.first->view(), expected);
 }

--- a/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
+++ b/cpp/tests/io/shp/polygon_shapefile_reader_test.cpp
@@ -125,7 +125,7 @@ TEST_F(PolygonShapefileReaderTest, OnePointInPolygon)
   auto ys       = polygon_columns.at(3)->view();
   fixed_width_column_wrapper<double> test_xs({0.0});
   fixed_width_column_wrapper<double> test_ys({0.0});
-  fixed_width_column_wrapper<int32_t> expected({true});
+  fixed_width_column_wrapper<bool> expected({true});
 
   auto ret = cuspatial::point_in_polygon(test_xs, test_ys, polygons, rings, xs, ys);
 

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -51,7 +51,7 @@ TYPED_TEST(PointInPolygonTest, Empty)
   auto poly_point_xs     = wrapper<T>({});
   auto poly_point_ys     = wrapper<T>({});
 
-  auto expected = wrapper<int32_t>({0b0});
+  auto expected = wrapper<bool>({});
 
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -51,7 +51,7 @@ TYPED_TEST(PointInPolygonTest, Empty)
   auto poly_point_xs     = wrapper<T>({});
   auto poly_point_ys     = wrapper<T>({});
 
-  auto expected = wrapper<T>({});
+  auto expected = wrapper<bool>({});
 
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -51,7 +51,7 @@ TYPED_TEST(PointInPolygonTest, Empty)
   auto poly_point_xs     = wrapper<T>({});
   auto poly_point_ys     = wrapper<T>({});
 
-  auto expected = wrapper<bool>({});
+  auto expected = wrapper<T>({});
 
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);

--- a/cpp/tests/spatial/point_in_polygon_test.cpp
+++ b/cpp/tests/spatial/point_in_polygon_test.cpp
@@ -56,7 +56,7 @@ TYPED_TEST(PointInPolygonTest, Empty)
   auto actual = cuspatial::point_in_polygon(
     test_point_xs, test_point_ys, poly_offsets, poly_ring_offsets, poly_point_xs, poly_point_ys);
 
-  expect_columns_equal(expected, actual->view(), verbosity);
+  expect_columns_equal(expected, actual.first->view(), verbosity);
 }
 
 template <typename T>

--- a/python/cuspatial/cuspatial/_lib/cpp/point_in_polygon.pxd
+++ b/python/cuspatial/cuspatial/_lib/cpp/point_in_polygon.pxd
@@ -1,12 +1,14 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
+from libcpp.pair cimport pair
 
 from cudf._lib.column cimport column, column_view
+from cudf._lib.table cimport table_view
 
 
 cdef extern from "cuspatial/point_in_polygon.hpp" namespace "cuspatial" nogil:
-    cdef unique_ptr[column] point_in_polygon(
+    cdef pair[unique_ptr[column], table_view] point_in_polygon(
         const column_view & test_points_x,
         const column_view & test_points_y,
         const column_view & poly_offsets,

--- a/python/cuspatial/cuspatial/_lib/cpp/point_in_polygon.pxd
+++ b/python/cuspatial/cuspatial/_lib/cpp/point_in_polygon.pxd
@@ -4,7 +4,7 @@ from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
 
 from cudf._lib.column cimport column, column_view
-from cudf._lib.table cimport table_view
+from cudf._lib.cpp.table.table_view cimport table_view
 
 
 cdef extern from "cuspatial/point_in_polygon.hpp" namespace "cuspatial" nogil:

--- a/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
+++ b/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
@@ -1,16 +1,17 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
-from libcpp.utility cimport move
 from libcpp.pair cimport pair
+from libcpp.utility cimport move
 
 from cudf._lib.column cimport Column, column, column_view
-from cudf._lib.table cimport table_view
+from cudf._lib.cpp.table.table_view cimport table_view
+from cudf._lib.utils cimport columns_from_table_view
 
 from cuspatial._lib.cpp.point_in_polygon cimport (
     point_in_polygon as cpp_point_in_polygon,
 )
-from cudf._lib.utils cimport columns_from_table_view
+
 
 def point_in_polygon(
     Column test_points_x,
@@ -43,4 +44,4 @@ def point_in_polygon(
 
     result_owner = Column.from_unique_ptr(move(result.first))
     return columns_from_table_view(
-        result.second, owners=[result_owner] * result.second.num_columns()) 
+        result.second, owners=[result_owner] * result.second.num_columns())

--- a/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
+++ b/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
@@ -2,13 +2,15 @@
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
+from libcpp.pair cimport pair
 
 from cudf._lib.column cimport Column, column, column_view
+from cudf._lib.table cimport table_view
 
 from cuspatial._lib.cpp.point_in_polygon cimport (
     point_in_polygon as cpp_point_in_polygon,
 )
-
+from cudf._lib.utils cimport columns_from_table_view
 
 def point_in_polygon(
     Column test_points_x,
@@ -25,7 +27,7 @@ def point_in_polygon(
     cdef column_view c_poly_points_x = poly_points_x.view()
     cdef column_view c_poly_points_y = poly_points_y.view()
 
-    cdef unique_ptr[column] result
+    cdef pair[unique_ptr[column], table_view] result
 
     with nogil:
         result = move(
@@ -39,4 +41,6 @@ def point_in_polygon(
             )
         )
 
-    return Column.from_unique_ptr(move(result))
+    result_owner = Column.from_unique_ptr(move(result.first))
+    return columns_from_table_view(
+        result.second, owners=[result_owner] * result.second.num_columns()) 

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -106,16 +106,6 @@ def point_in_polygon(
         poly_points_x,
         poly_points_y,
     )
-
-    result = gis_utils.pip_bitmap_column_to_binary_array(
-        polygon_bitmap_column=result, width=len(poly_offsets)
-    )
-    result = DataFrame(result)
-    result = DataFrame._from_data(
-        {name: col.astype("bool") for name, col in result._data.items()}
-    )
-    result.columns = [x for x in list(reversed(poly_offsets.index))]
-    result = result[list(reversed(result.columns))]
     return result
 
 

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+import numpy as np
+
 from cudf import DataFrame
 from cudf.core.column import as_column
 
@@ -9,7 +11,6 @@ from cuspatial._lib import spatial_join
 from cuspatial._lib.point_in_polygon import (
     point_in_polygon as cpp_point_in_polygon,
 )
-from cuspatial.utils import gis_utils
 from cuspatial.utils.column_utils import normalize_point_columns
 
 
@@ -106,7 +107,7 @@ def point_in_polygon(
         poly_points_x,
         poly_points_y,
     )
-    return result
+    return DataFrame._from_columns(result, np.arange(len(poly_offsets)))
 
 
 def join_quadtree_and_bounding_boxes(


### PR DESCRIPTION
This PR drops the bitmask approach to performing 31 polygon point-in-polygon, instead preallocating a column of bools and storing the pip result there. This allows an unlimited number of polygons to be indexed at a time and increases performance with a minor memory usage increase.

This implementation uses 4x more bytes on 31 polygons (31 bytes instead of 1 int32_t) and is 37% faster than the bool mask approach. It supports more than 31 polygons, however, allocating a single `num_points x num_polygons` column for output.