### PR TITLE
Refactor of `pairwise_linestring_distance` to use `multilinestring_range`, adds support to multilinestring distance

### DIFF
--- a/cpp/include/cuspatial/detail/iterator.hpp
+++ b/cpp/include/cuspatial/detail/iterator.hpp
@@ -15,8 +15,7 @@
  */
 
 #pragma once
-
-#include <cudf/types.hpp>
+#include <cuspatial/cuda_utils.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -24,8 +23,8 @@
 namespace cuspatial {
 namespace detail {
 
-template <typename UnaryFunction>
-inline auto make_counting_transform_iterator(cudf::size_type start, UnaryFunction f)
+template <typename IndexType, typename UnaryFunction>
+inline CUSPATIAL_HOST_DEVICE auto make_counting_transform_iterator(IndexType start, UnaryFunction f)
 {
   return thrust::make_transform_iterator(thrust::make_counting_iterator(start), f);
 }

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -92,10 +92,9 @@ __forceinline__ T __device__ segment_distance_no_intersect_or_colinear(vec_2d<T>
                                                                        vec_2d<T> const& c,
                                                                        vec_2d<T> const& d)
 {
-  auto dist_sqr = std::min(std::min(point_to_segment_distance_squared(a, c, d),
-                                    point_to_segment_distance_squared(b, c, d)),
-                           std::min(point_to_segment_distance_squared(c, a, b),
-                                    point_to_segment_distance_squared(d, a, b)));
+  auto dist_sqr = min(
+    min(point_to_segment_distance_squared(a, c, d), point_to_segment_distance_squared(b, c, d)),
+    min(point_to_segment_distance_squared(c, a, b), point_to_segment_distance_squared(d, a, b)));
   return dist_sqr;
 }
 

--- a/cpp/include/cuspatial/experimental/detail/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/detail/geometry/linestring_ref.cuh
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <cuspatial/cuda_utils.hpp>
+#include <cuspatial/detail/iterator.hpp>
+#include <cuspatial/traits.hpp>
+
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
+
+namespace cuspatial {
+
+template <typename VecIterator>
+struct to_segment_functor {
+  using element_t       = iterator_vec_base_type<VecIterator>;
+  using difference_type = typename thrust::iterator_difference<VecIterator>::type;
+  VecIterator _point_begin;
+
+  CUSPATIAL_HOST_DEVICE
+  to_segment_functor(VecIterator point_begin) : _point_begin(point_begin) {}
+
+  CUSPATIAL_HOST_DEVICE
+  thrust::pair<vec_2d<element_t>, vec_2d<element_t>> operator()(difference_type i)
+  {
+    return {_point_begin[i], _point_begin[i + 1]};
+  }
+};
+
+template <typename VecIterator>
+CUSPATIAL_HOST_DEVICE linestring_ref<VecIterator>::linestring_ref(VecIterator begin,
+                                                                  VecIterator end)
+  : _point_begin(begin), _point_end(end)
+{
+  using T = iterator_vec_base_type<VecIterator>;
+  static_assert(is_same<vec_2d<T>, iterator_value_type<VecIterator>>(), "must be vec2d type");
+}
+
+template <typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto linestring_ref<VecIterator>::num_segments() const
+{
+  return thrust::distance(_point_begin, _point_end) - 2;
+}
+
+template <typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto linestring_ref<VecIterator>::segment_begin() const
+{
+  return detail::make_counting_transform_iterator(0, to_segment_functor{_point_begin});
+}
+
+template <typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto linestring_ref<VecIterator>::segment_end() const
+{
+  return segment_begin() + num_segments();
+}
+
+}  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/detail/geometry/linestring_ref.cuh
@@ -51,7 +51,9 @@ CUSPATIAL_HOST_DEVICE linestring_ref<VecIterator>::linestring_ref(VecIterator be
 template <typename VecIterator>
 CUSPATIAL_HOST_DEVICE auto linestring_ref<VecIterator>::num_segments() const
 {
-  return thrust::distance(_point_begin, _point_end) - 2;
+  // The number of segment equals the number of points minus 1. And the number of points
+  // is thrust::distance(_point_begin, _point_end) - 1.
+  return thrust::distance(_point_begin, _point_end) - 1;
 }
 
 template <typename VecIterator>

--- a/cpp/include/cuspatial/experimental/detail/geometry_collection/multilinestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/detail/geometry_collection/multilinestring_ref.cuh
@@ -22,8 +22,7 @@ struct to_linestring_functor {
 
   CUSPATIAL_HOST_DEVICE auto operator()(difference_type i)
   {
-    return linestring_ref{point_begin + part_begin[i],
-                          thrust::next(point_begin + part_begin[i + 1])};
+    return linestring_ref{point_begin + part_begin[i], point_begin + part_begin[i + 1]};
   }
 };
 

--- a/cpp/include/cuspatial/experimental/detail/geometry_collection/multilinestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/detail/geometry_collection/multilinestring_ref.cuh
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "cuspatial/cuda_utils.hpp"
+#include <cuspatial/detail/iterator.hpp>
+#include <cuspatial/experimental/geometry/linestring_ref.cuh>
+
+#include <thrust/iterator/transform_iterator.h>
+
+namespace cuspatial {
+
+template <typename PartIterator, typename VecIterator>
+struct to_linestring_functor {
+  using difference_type = typename thrust::iterator_difference<PartIterator>::type;
+  PartIterator part_begin;
+  VecIterator point_begin;
+
+  CUSPATIAL_HOST_DEVICE
+  to_linestring_functor(PartIterator part_begin, VecIterator point_begin)
+    : part_begin(part_begin), point_begin(point_begin)
+  {
+  }
+
+  CUSPATIAL_HOST_DEVICE auto operator()(difference_type i)
+  {
+    return linestring_ref{point_begin + part_begin[i],
+                          thrust::next(point_begin + part_begin[i + 1])};
+  }
+};
+
+template <typename PartIterator, typename VecIterator>
+class multilinestring_ref;
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE multilinestring_ref<PartIterator, VecIterator>::multilinestring_ref(
+  PartIterator part_begin, PartIterator part_end, VecIterator point_begin, VecIterator point_end)
+  : _part_begin(part_begin), _part_end(part_end), _point_begin(point_begin), _point_end(point_end)
+{
+}
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto multilinestring_ref<PartIterator, VecIterator>::num_linestrings() const
+{
+  return thrust::distance(_part_begin, _part_end) - 1;
+}
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto multilinestring_ref<PartIterator, VecIterator>::part_begin() const
+{
+  return detail::make_counting_transform_iterator(0,
+                                                  to_linestring_functor{_part_begin, _point_begin});
+}
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto multilinestring_ref<PartIterator, VecIterator>::part_end() const
+{
+  return part_begin() + num_linestrings();
+}
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto multilinestring_ref<PartIterator, VecIterator>::point_begin() const
+{
+  return _point_begin;
+}
+
+template <typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto multilinestring_ref<PartIterator, VecIterator>::point_end() const
+{
+  return _point_end;
+}
+
+}  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -64,8 +64,7 @@ __global__ void pairwise_linestring_distance_kernel(MultiLinestringRange1 multil
         min_distance_squared = min(min_distance_squared, squared_segment_distance(a, b, c, d));
       }
     }
-    atomicMin(&thrust::raw_reference_cast(*(distances_first + geometry_idx)),
-              static_cast<T>(sqrt(min_distance_squared)));
+    atomicMin(&distances_first[geometry_idx], static_cast<T>(sqrt(min_distance_squared)));
   }
 }
 

--- a/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_distance.cuh
@@ -25,17 +25,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/binary_search.h>
-#include <thrust/distance.h>
-#include <thrust/execution_policy.h>
 #include <thrust/fill.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/memory.h>
 
-#include <iterator>
 #include <limits>
-#include <memory>
 #include <type_traits>
 
 namespace cuspatial {
@@ -43,7 +35,7 @@ namespace detail {
 
 /**
  * @internal
- * @brief The kernel to compute point to linestring distance
+ * @brief The kernel to compute linestring to linestring distance
  *
  * Each thread of the kernel computes the distance between a segment in a linestring in pair 1 to a
  * linestring in pair 2. For a segment in pair 1, the linestring index is looked up from the offset
@@ -51,142 +43,67 @@ namespace detail {
  * in the corresponding linestring in pair 2. This forms a local minima of the shortest distance,
  * which is then combined with other segment results via an atomic operation to form the globally
  * minimum distance between the linestrings.
- *
- * @tparam Cart2dItA Iterator to 2d cartesian coordinates. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam Cart2dItB Iterator to 2d cartesian coordinates. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OffsetIterator Iterator to linestring offsets. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OutputIterator Iterator to output distances. Must meet requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible and mutable.
- *
- * @param[in] linestring1_offsets_begin Iterator to the begin of the range of linestring offsets in
- * pair 1.
- * @param[in] linestring1_offsets_end Iterator to the end of the range of linestring offsets in
- * pair 1.
- * @param[in] linestring1_points_xs_begin Iterator to the begin of the range of x coordinates of
- * points in pair 1.
- * @param[in] linestring1_points_xs_end Iterator to the end of the range of x coordinates of points
- * in pair 1.
- * @param[in] linestring2_offsets_begin Iterator to the begin of the range of linestring offsets
- * in pair 2.
- * @param[in] linestring2_points_xs_begin Iterator to the begin of the range of x coordinates of
- * points in pair 2.
- * @param[in] linestring2_points_xs_end Iterator to the end of the range of x coordinates of points
- * in pair 2.
- * @param[out] distances Iterator to the output range of shortest distances between pairs.
- *
- * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
- * "LegacyRandomAccessIterator"
  */
-template <typename Cart2dItA, typename Cart2dItB, typename OffsetIterator, typename OutputIterator>
-void __global__ pairwise_linestring_distance_kernel(OffsetIterator linestring1_offsets_begin,
-                                                    OffsetIterator linestring1_offsets_end,
-                                                    Cart2dItA linestring1_points_begin,
-                                                    Cart2dItA linestring1_points_end,
-                                                    OffsetIterator linestring2_offsets_begin,
-                                                    Cart2dItB linestring2_points_begin,
-                                                    Cart2dItB linestring2_points_end,
-                                                    OutputIterator distances)
+template <class MultiLinestringRange1, class MultiLinestringRange2, class OutputIt>
+__global__ void pairwise_linestring_distance_kernel(MultiLinestringRange1 multilinestrings1,
+                                                    MultiLinestringRange2 multilinestrings2,
+                                                    OutputIt distances_first)
 {
-  using T = typename std::iterator_traits<Cart2dItA>::value_type::value_type;
+  using T = typename MultiLinestringRange1::element_t;
 
-  auto const p1_idx = threadIdx.x + blockIdx.x * blockDim.x;
-  std::size_t const num_linestrings =
-    thrust::distance(linestring1_offsets_begin, linestring1_offsets_end);
+  for (auto idx = threadIdx.x + blockIdx.x * blockDim.x; idx < multilinestrings1.num_points();
+       idx += gridDim.x * blockDim.x) {
+    auto const part_idx = multilinestrings1.part_idx_from_point_idx(idx);
+    if (!multilinestrings1.is_valid_segment_id(idx, part_idx)) continue;
+    auto const geometry_idx = multilinestrings1.geometry_idx_from_part_idx(part_idx);
+    auto [a, b]             = multilinestrings1.segment(idx);
+    T min_distance_squared  = std::numeric_limits<T>::max();
 
-  std::size_t const linestring1_num_points =
-    thrust::distance(linestring1_points_begin, linestring1_points_end);
-  std::size_t const linestring2_num_points =
-    thrust::distance(linestring2_points_begin, linestring2_points_end);
-
-  if (p1_idx >= linestring1_num_points) { return; }
-
-  auto linestring_it =
-    thrust::upper_bound(thrust::seq, linestring1_offsets_begin, linestring1_offsets_end, p1_idx);
-  std::size_t const linestring_idx =
-    thrust::distance(linestring1_offsets_begin, thrust::prev(linestring_it));
-
-  auto const ls1_end = endpoint_index_of_linestring(
-    linestring_idx, linestring1_offsets_begin, num_linestrings, linestring1_num_points);
-
-  if (p1_idx == ls1_end) {
-    // Current point is the end point of the line string.
-    return;
+    for (auto const& linestring2 : multilinestrings2[geometry_idx]) {
+      for (auto [c, d] : linestring2) {
+        min_distance_squared = min(min_distance_squared, squared_segment_distance(a, b, c, d));
+      }
+    }
+    atomicMin(&thrust::raw_reference_cast(*(distances_first + geometry_idx)),
+              static_cast<T>(sqrt(min_distance_squared)));
   }
-
-  auto const ls2_start = *(linestring2_offsets_begin + linestring_idx);
-  auto const ls2_end   = endpoint_index_of_linestring(
-    linestring_idx, linestring2_offsets_begin, num_linestrings, linestring2_num_points);
-
-  auto const& A = thrust::raw_reference_cast(linestring1_points_begin[p1_idx]);
-  auto const& B = thrust::raw_reference_cast(linestring1_points_begin[p1_idx + 1]);
-
-  auto min_squared_distance = std::numeric_limits<T>::max();
-  for (auto p2_idx = ls2_start; p2_idx < ls2_end; p2_idx++) {
-    auto const& C        = thrust::raw_reference_cast(linestring2_points_begin[p2_idx]);
-    auto const& D        = thrust::raw_reference_cast(linestring2_points_begin[p2_idx + 1]);
-    min_squared_distance = std::min(min_squared_distance, squared_segment_distance(A, B, C, D));
-  }
-
-  atomicMin(&thrust::raw_reference_cast(*(distances + linestring_idx)),
-            static_cast<T>(std::sqrt(min_squared_distance)));
 }
 
 }  // namespace detail
 
-template <class Cart2dItA, class Cart2dItB, class OffsetIterator, class OutputIt>
-OutputIt pairwise_linestring_distance(OffsetIterator linestring1_offsets_first,
-                                      OffsetIterator linestring1_offsets_last,
-                                      Cart2dItA linestring1_points_first,
-                                      Cart2dItA linestring1_points_last,
-                                      OffsetIterator linestring2_offsets_first,
-                                      Cart2dItB linestring2_points_first,
-                                      Cart2dItB linestring2_points_last,
+template <class MultiLinestringRange1, class MultiLinestringRange2, class OutputIt>
+OutputIt pairwise_linestring_distance(MultiLinestringRange1 multilinestrings1,
+                                      MultiLinestringRange2 multilinestrings2,
                                       OutputIt distances_first,
                                       rmm::cuda_stream_view stream)
 {
-  using T = typename cuspatial::iterator_vec_base_type<Cart2dItA>;
+  using T = typename MultiLinestringRange1::element_t;
 
-  static_assert(is_same_floating_point<T,
-                                       typename cuspatial::iterator_vec_base_type<Cart2dItB>,
-                                       typename cuspatial::iterator_value_type<OutputIt>>(),
+  static_assert(is_same_floating_point<T, typename MultiLinestringRange2::element_t>(),
                 "Inputs and output must have the same floating point value type.");
 
   static_assert(is_same<vec_2d<T>,
-                        typename cuspatial::iterator_value_type<Cart2dItA>,
-                        typename cuspatial::iterator_value_type<Cart2dItB>>(),
+                        typename MultiLinestringRange1::point_t,
+                        typename MultiLinestringRange2::point_t>(),
                 "All input types must be cuspatial::vec_2d with the same value type");
 
-  auto const num_linestring_pairs =
-    thrust::distance(linestring1_offsets_first, linestring1_offsets_last) - 1;
-  auto const num_linestring1_points =
-    thrust::distance(linestring1_points_first, linestring1_points_last);
-  auto const num_linestring2_points =
-    thrust::distance(linestring2_points_first, linestring2_points_last);
+  CUSPATIAL_EXPECTS(multilinestrings1.size() == multilinestrings2.size(),
+                    "Inputs must have the same number of rows.");
 
   thrust::fill(rmm::exec_policy(stream),
                distances_first,
-               distances_first + num_linestring_pairs,
+               distances_first + multilinestrings1.size(),
                std::numeric_limits<T>::max());
 
-  std::size_t constexpr threads_per_block = 64;
+  std::size_t constexpr threads_per_block = 256;
   std::size_t const num_blocks =
-    (num_linestring1_points + threads_per_block - 1) / threads_per_block;
+    (multilinestrings1.num_points() + threads_per_block - 1) / threads_per_block;
 
   detail::pairwise_linestring_distance_kernel<<<num_blocks, threads_per_block, 0, stream.value()>>>(
-    linestring1_offsets_first,
-    linestring1_offsets_last,
-    linestring1_points_first,
-    linestring1_points_last,
-    linestring2_offsets_first,
-    linestring2_points_first,
-    linestring2_points_last,
-    distances_first);
+    multilinestrings1, multilinestrings2, distances_first);
 
   CUSPATIAL_CUDA_TRY(cudaGetLastError());
-  return distances_first + num_linestring_pairs;
+  return distances_first + multilinestrings1.size();
 }
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/detail/ranges/multilinestring_range.cuh
+++ b/cpp/include/cuspatial/experimental/detail/ranges/multilinestring_range.cuh
@@ -23,7 +23,7 @@
 
 #include <cuspatial/cuda_utils.hpp>
 #include <cuspatial/detail/iterator.hpp>
-#include <cuspatial/experimental/geometry_collection/multipoint_ref.cuh>
+#include <cuspatial/experimental/geometry_collection/multilinestring_ref.cuh>
 #include <cuspatial/traits.hpp>
 #include <cuspatial/vec_2d.hpp>
 
@@ -31,7 +31,36 @@
 
 namespace cuspatial {
 
-using namespace cuspatial::detail;
+using namespace detail;
+
+template <typename GeometryIterator, typename PartIterator, typename VecIterator>
+struct to_multilinestring_functor {
+  using difference_type = typename thrust::iterator_difference<GeometryIterator>::type;
+  GeometryIterator _geometry_begin;
+  PartIterator _part_begin;
+  VecIterator _point_begin;
+  VecIterator _point_end;
+
+  CUSPATIAL_HOST_DEVICE
+  to_multilinestring_functor(GeometryIterator geometry_begin,
+                             PartIterator part_begin,
+                             VecIterator point_begin,
+                             VecIterator point_end)
+    : _geometry_begin(geometry_begin),
+      _part_begin(part_begin),
+      _point_begin(point_begin),
+      _point_end(point_end)
+  {
+  }
+
+  CUSPATIAL_HOST_DEVICE auto operator()(difference_type i)
+  {
+    return multilinestring_ref{_part_begin + _geometry_begin[i],
+                               thrust::next(_part_begin + _geometry_begin[i + 1]),
+                               _point_begin,
+                               _point_end};
+  }
+};
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
 class multilinestring_range;
@@ -42,14 +71,14 @@ multilinestring_range<GeometryIterator, PartIterator, VecIterator>::multilinestr
   GeometryIterator geometry_end,
   PartIterator part_begin,
   PartIterator part_end,
-  VecIterator points_begin,
-  VecIterator points_end)
-  : geometry_begin(geometry_begin),
-    geometry_end(geometry_end),
-    part_begin(part_begin),
-    part_end(part_end),
-    points_begin(points_begin),
-    points_end(points_end)
+  VecIterator point_begin,
+  VecIterator point_end)
+  : _geometry_begin(geometry_begin),
+    _geometry_end(geometry_end),
+    _part_begin(part_begin),
+    _part_end(part_end),
+    _point_begin(point_begin),
+    _point_end(point_end)
 {
 }
 
@@ -57,21 +86,36 @@ template <typename GeometryIterator, typename PartIterator, typename VecIterator
 CUSPATIAL_HOST_DEVICE auto
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::num_multilinestrings()
 {
-  return thrust::distance(geometry_begin, geometry_end) - 1;
+  return thrust::distance(_geometry_begin, _geometry_end) - 1;
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
 CUSPATIAL_HOST_DEVICE auto
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::num_linestrings()
 {
-  return thrust::distance(part_begin, part_end) - 1;
+  return thrust::distance(_part_begin, _part_end) - 1;
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
 CUSPATIAL_HOST_DEVICE auto
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::num_points()
 {
-  return thrust::distance(points_begin, points_end);
+  return thrust::distance(_point_begin, _point_end);
+}
+
+template <typename GeometryIterator, typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto
+multilinestring_range<GeometryIterator, PartIterator, VecIterator>::multilinestring_begin()
+{
+  return detail::make_counting_transform_iterator(
+    0, to_multilinestring_functor{_geometry_begin, _part_begin, _point_begin, _point_end});
+}
+
+template <typename GeometryIterator, typename PartIterator, typename VecIterator>
+CUSPATIAL_HOST_DEVICE auto
+multilinestring_range<GeometryIterator, PartIterator, VecIterator>::multilinestring_end()
+{
+  return multilinestring_begin() + num_multilinestrings();
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
@@ -80,8 +124,8 @@ CUSPATIAL_HOST_DEVICE auto
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::part_idx_from_point_idx(
   IndexType point_idx)
 {
-  auto part_it = thrust::upper_bound(thrust::seq, part_begin, part_end, point_idx);
-  return thrust::distance(part_begin, thrust::prev(part_it));
+  auto part_it = thrust::upper_bound(thrust::seq, _part_begin, _part_end, point_idx);
+  return thrust::distance(_part_begin, thrust::prev(part_it));
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
@@ -90,8 +134,8 @@ CUSPATIAL_HOST_DEVICE auto
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::geometry_idx_from_part_idx(
   IndexType part_idx)
 {
-  auto geom_it = thrust::upper_bound(thrust::seq, geometry_begin, geometry_end, part_idx);
-  return thrust::distance(geometry_begin, thrust::prev(geom_it));
+  auto geom_it = thrust::upper_bound(thrust::seq, _geometry_begin, _geometry_end, part_idx);
+  return thrust::distance(_geometry_begin, thrust::prev(geom_it));
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
@@ -110,9 +154,9 @@ multilinestring_range<GeometryIterator, PartIterator, VecIterator>::is_valid_seg
   IndexType1 segment_idx, IndexType2 part_idx)
 {
   if constexpr (std::is_signed_v<IndexType1>)
-    return segment_idx >= 0 && segment_idx < (part_begin[part_idx + 1] - 1);
+    return segment_idx >= 0 && segment_idx < (_part_begin[part_idx + 1] - 1);
   else
-    return segment_idx < (part_begin[part_idx + 1] - 1);
+    return segment_idx < (_part_begin[part_idx + 1] - 1);
 }
 
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
@@ -122,7 +166,16 @@ CUSPATIAL_HOST_DEVICE thrust::pair<
   vec_2d<typename multilinestring_range<GeometryIterator, PartIterator, VecIterator>::element_t>>
 multilinestring_range<GeometryIterator, PartIterator, VecIterator>::segment(IndexType segment_idx)
 {
-  return thrust::make_pair(points_begin[segment_idx], points_begin[segment_idx + 1]);
+  return thrust::make_pair(_point_begin[segment_idx], _point_begin[segment_idx + 1]);
+}
+
+template <typename GeometryIterator, typename PartIterator, typename VecIterator>
+template <typename IndexType>
+CUSPATIAL_HOST_DEVICE auto
+multilinestring_range<GeometryIterator, PartIterator, VecIterator>::operator[](
+  IndexType multilinestring_idx)
+{
+  return multilinestring_begin()[multilinestring_idx];
 }
 
 }  // namespace cuspatial

--- a/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
@@ -19,7 +19,7 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a multipoint stored in structure of array on memory.
+ * @brief Represent a linestring stored in structure of array on memory.
  *
  * @tparam VecIterator type of iterator to the underlying point array.
  */

--- a/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
@@ -19,7 +19,7 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a linestring stored in structure of array on memory.
+ * @brief Represent a reference to a linestring stored in a structure of arrays.
  *
  * @tparam VecIterator type of iterator to the underlying point array.
  */
@@ -30,16 +30,17 @@ class linestring_ref {
 
   CUSPATIAL_HOST_DEVICE auto num_segments() const;
 
-  /// Return iterator to the starting point of the multilinestring.
+  /// Return iterator to the first segment of the linestring
   CUSPATIAL_HOST_DEVICE auto segment_begin() const;
-  /// Return iterator to one-past the last point of the multilinestring.
+  /// Return iterator to one past the last segment
   CUSPATIAL_HOST_DEVICE auto segment_end() const;
 
-  /// Return iterator to the starting point of the multipoint.
+  /// Return iterator to the first segment of the linestring
   CUSPATIAL_HOST_DEVICE auto begin() const { return segment_begin(); }
-  /// Return iterator the the one-past the last point of the multipoint.
+  /// Return iterator to one past the last segment
   CUSPATIAL_HOST_DEVICE auto end() const { return segment_end(); }
 
+ protected:
   VecIterator _point_begin;
   VecIterator _point_end;
 };

--- a/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry/linestring_ref.cuh
@@ -19,30 +19,30 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a reference to multipoint stored in structure of array on memory.
+ * @brief Represent a multipoint stored in structure of array on memory.
  *
  * @tparam VecIterator type of iterator to the underlying point array.
  */
 template <typename VecIterator>
-class multipoint_ref {
+class linestring_ref {
  public:
-  CUSPATIAL_HOST_DEVICE multipoint_ref(VecIterator begin, VecIterator end);
+  CUSPATIAL_HOST_DEVICE linestring_ref(VecIterator begin, VecIterator end);
+
+  CUSPATIAL_HOST_DEVICE auto num_segments() const;
+
+  /// Return iterator to the starting point of the multilinestring.
+  CUSPATIAL_HOST_DEVICE auto segment_begin() const;
+  /// Return iterator to one-past the last point of the multilinestring.
+  CUSPATIAL_HOST_DEVICE auto segment_end() const;
 
   /// Return iterator to the starting point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto point_begin() const;
-  /// Return iterator to one-past the last point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto point_end() const;
-
-  /// Return iterator to the starting point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto begin() const { return point_begin(); }
+  CUSPATIAL_HOST_DEVICE auto begin() const { return segment_begin(); }
   /// Return iterator the the one-past the last point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto end() const { return point_end(); }
+  CUSPATIAL_HOST_DEVICE auto end() const { return segment_end(); }
 
- protected:
-  VecIterator _points_begin;
-  VecIterator _points_end;
+  VecIterator _point_begin;
+  VecIterator _point_end;
 };
 
 }  // namespace cuspatial
-
-#include <cuspatial/experimental/detail/geometry_collection/multipoint_ref.cuh>
+#include <cuspatial/experimental/detail/geometry/linestring_ref.cuh>

--- a/cpp/include/cuspatial/experimental/geometry_collection/multilinestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry_collection/multilinestring_ref.cuh
@@ -19,8 +19,9 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a multilinestring stored in structure of array on memory.
+ * @brief Represent a reference to a multilinestring stored in a structure of arrays.
  *
+ * @tparam PartIterator type of iterator to the part offset array.
  * @tparam VecIterator type of iterator to the underlying point array.
  */
 template <typename PartIterator, typename VecIterator>
@@ -30,23 +31,24 @@ class multilinestring_ref {
                                             PartIterator part_end,
                                             VecIterator point_begin,
                                             VecIterator point_end);
-
+  /// Return the number of linestrings in the multilinestring.
   CUSPATIAL_HOST_DEVICE auto num_linestrings() const;
+  /// Return the number of linestrings in the multilinestring.
   CUSPATIAL_HOST_DEVICE auto size() const { return num_linestrings(); }
 
-  /// Return iterator to the starting linestring.
+  /// Return iterator to the first linestring.
   CUSPATIAL_HOST_DEVICE auto part_begin() const;
-  /// Return iterator to one-past the last linestring.
+  /// Return iterator to one past the last linestring.
   CUSPATIAL_HOST_DEVICE auto part_end() const;
 
-  /// Return iterator to the starting point of the multipoint.
+  /// Return iterator to the first point of the multilinestring.
   CUSPATIAL_HOST_DEVICE auto point_begin() const;
-  /// Return iterator to one-past the last point of the multipoint.
+  /// Return iterator to one past the last point of the multilinestring.
   CUSPATIAL_HOST_DEVICE auto point_end() const;
 
-  /// Return iterator to the starting point of the multipoint.
+  /// Return iterator to the first linestring of the multilinestring.
   CUSPATIAL_HOST_DEVICE auto begin() const { return part_begin(); }
-  /// Return iterator the the one-past the last point of the multipoint.
+  /// Return iterator to one past the last linestring of the multilinestring.
   CUSPATIAL_HOST_DEVICE auto end() const { return part_end(); }
 
  protected:

--- a/cpp/include/cuspatial/experimental/geometry_collection/multilinestring_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry_collection/multilinestring_ref.cuh
@@ -19,14 +19,25 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a reference to multipoint stored in structure of array on memory.
+ * @brief Represent a multilinestring stored in structure of array on memory.
  *
  * @tparam VecIterator type of iterator to the underlying point array.
  */
-template <typename VecIterator>
-class multipoint_ref {
+template <typename PartIterator, typename VecIterator>
+class multilinestring_ref {
  public:
-  CUSPATIAL_HOST_DEVICE multipoint_ref(VecIterator begin, VecIterator end);
+  CUSPATIAL_HOST_DEVICE multilinestring_ref(PartIterator part_begin,
+                                            PartIterator part_end,
+                                            VecIterator point_begin,
+                                            VecIterator point_end);
+
+  CUSPATIAL_HOST_DEVICE auto num_linestrings() const;
+  CUSPATIAL_HOST_DEVICE auto size() const { return num_linestrings(); }
+
+  /// Return iterator to the starting linestring.
+  CUSPATIAL_HOST_DEVICE auto part_begin() const;
+  /// Return iterator to one-past the last linestring.
+  CUSPATIAL_HOST_DEVICE auto part_end() const;
 
   /// Return iterator to the starting point of the multipoint.
   CUSPATIAL_HOST_DEVICE auto point_begin() const;
@@ -34,15 +45,17 @@ class multipoint_ref {
   CUSPATIAL_HOST_DEVICE auto point_end() const;
 
   /// Return iterator to the starting point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto begin() const { return point_begin(); }
+  CUSPATIAL_HOST_DEVICE auto begin() const { return part_begin(); }
   /// Return iterator the the one-past the last point of the multipoint.
-  CUSPATIAL_HOST_DEVICE auto end() const { return point_end(); }
+  CUSPATIAL_HOST_DEVICE auto end() const { return part_end(); }
 
  protected:
-  VecIterator _points_begin;
-  VecIterator _points_end;
+  PartIterator _part_begin;
+  PartIterator _part_end;
+  VecIterator _point_begin;
+  VecIterator _point_end;
 };
 
 }  // namespace cuspatial
 
-#include <cuspatial/experimental/detail/geometry_collection/multipoint_ref.cuh>
+#include <cuspatial/experimental/detail/geometry_collection/multilinestring_ref.cuh>

--- a/cpp/include/cuspatial/experimental/geometry_collection/multipoint_ref.cuh
+++ b/cpp/include/cuspatial/experimental/geometry_collection/multipoint_ref.cuh
@@ -19,7 +19,7 @@
 namespace cuspatial {
 
 /**
- * @brief Represent a reference to multipoint stored in structure of array on memory.
+ * @brief Represent a reference to multipoint stored in a structure of arrays.
  *
  * @tparam VecIterator type of iterator to the underlying point array.
  */

--- a/cpp/include/cuspatial/experimental/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/linestring_distance.cuh
@@ -28,48 +28,22 @@ namespace cuspatial {
  * between all pairs of segments of the two linestrings. If any of the segments intersect,
  * the distance is 0.
  *
- * @tparam Cart2dItA iterator type for point array of the first linestring of each pair. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam Cart2dItB iterator type for point array of the second linestring of each pair. Must meet
- * the requirements of [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OffsetIterator iterator type for offset array. Must meet the requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
- * @tparam OutputIt iterator type for output array. Must meet the requirements of
- * [LegacyRandomAccessIterator][LinkLRAI] and be device-accessible.
+ * @tparam MultiLinestringRange an instance of template type `multilinestring_range`
+ * @tparam OutputIt iterator type for output array. Must meet the requirements of [LRAI](LinkLRAI).
  *
- * @param linestring1_offsets_first beginning of range of the offsets to the first linestring of
- * each pair
- * @param linestring1_offsets_last end of range of the offsets to the first linestring of each pair
- * @param linestring1_points_first beginning of range of the point of the first linestring of each
- * pair
- * @param linestring1_points_last end of range of the point of the first linestring of each pair
- * @param linestring2_offsets_first beginning of range of the offsets to the second linestring of
- * each pair
- * @param linestring2_points_first beginning of range of the point of the second linestring of each
- * pair
- * @param linestring2_points_last end of range of the point of the second linestring of each pair
- * @param distances_first beginning iterator to output
+ * @param multilinestrings1 Range object of the lhs multilinestring array
+ * @param multilinestrings2 Range object of the rhs multilinestring array
  * @param stream The CUDA stream to use for device memory operations and kernel launches.
- * @return Output iterator to one past the last element in the output range
- *
- * @pre all input iterators for coordinates must have `cuspatial::vec_2d` type.
- * @pre all scalar types must be floating point types, and must be the same type for all input
- * iterators and output iterators.
+ * @return Output iterator to the element past the last distance computed.
  *
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
  * "LegacyRandomAccessIterator"
  */
-template <class Cart2dItA, class Cart2dItB, class OffsetIterator, class OutputIt>
-OutputIt pairwise_linestring_distance(OffsetIterator linestring1_offsets_first,
-                                      OffsetIterator linestring1_offsets_last,
-                                      Cart2dItA linestring1_points_first,
-                                      Cart2dItA linestring1_points_last,
-                                      OffsetIterator linestring2_offsets_first,
-                                      Cart2dItB linestring2_points_first,
-                                      Cart2dItB linestring2_points_last,
+template <class MultiLinestringRange1, class MultiLinstringRange2, class OutputIt>
+OutputIt pairwise_linestring_distance(MultiLinestringRange1 multilinestrings1,
+                                      MultiLinstringRange2 multilinestrings2,
                                       OutputIt distances_first,
                                       rmm::cuda_stream_view stream = rmm::cuda_stream_default);
-
 }  // namespace cuspatial
 
 #include <cuspatial/experimental/detail/linestring_distance.cuh>

--- a/cpp/include/cuspatial/experimental/linestring_distance.cuh
+++ b/cpp/include/cuspatial/experimental/linestring_distance.cuh
@@ -29,7 +29,8 @@ namespace cuspatial {
  * the distance is 0.
  *
  * @tparam MultiLinestringRange an instance of template type `multilinestring_range`
- * @tparam OutputIt iterator type for output array. Must meet the requirements of [LRAI](LinkLRAI).
+ * @tparam OutputIt iterator type for output array. Must meet the requirements of [LRAI](LinkLRAI)
+ * and be device writable.
  *
  * @param multilinestrings1 Range object of the lhs multilinestring array
  * @param multilinestrings2 Range object of the rhs multilinestring array

--- a/cpp/include/cuspatial/experimental/ranges/multilinestring_range.cuh
+++ b/cpp/include/cuspatial/experimental/ranges/multilinestring_range.cuh
@@ -63,69 +63,56 @@ class multilinestring_range {
                         VecIterator points_begin,
                         VecIterator points_end);
 
-  /**
-   * @brief Return the number of multilinestrings in the array.
-   */
+  /// Return the number of multilinestrings in the array.
   CUSPATIAL_HOST_DEVICE auto size() { return num_multilinestrings(); }
 
-  /**
-   * @brief Return the number of multilinestrings in the array.
-   */
+  /// Return the number of multilinestrings in the array.
   CUSPATIAL_HOST_DEVICE auto num_multilinestrings();
 
-  /**
-   * @brief Return the total number of linestrings in the array.
-   */
+  /// Return the total number of linestrings in the array.
   CUSPATIAL_HOST_DEVICE auto num_linestrings();
 
-  /**
-   * @brief Return the total number of points in the array.
-   */
+  /// Return the total number of points in the array.
   CUSPATIAL_HOST_DEVICE auto num_points();
 
+  /// Return the iterator to the first multilinestring in the range.
   CUSPATIAL_HOST_DEVICE auto multilinestring_begin();
 
+  /// Return the iterator to the one past the last multilinestring in the range.
   CUSPATIAL_HOST_DEVICE auto multilinestring_end();
 
+  /// Return the iterator to the first multilinestring in the range.
   CUSPATIAL_HOST_DEVICE auto begin() { return multilinestring_begin(); }
 
+  /// Return the iterator to the one past the last multilinestring in the range.
   CUSPATIAL_HOST_DEVICE auto end() { return multilinestring_end(); }
 
-  /**
-   * @brief Given the index of a point, return the part (linestring) index where the point locates.
-   */
+  /// Given the index of a point, return the part (linestring) index where the point locates.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE auto part_idx_from_point_idx(IndexType point_idx);
 
-  /**
-   * @brief Given the index of a part (linestring), return the geometry (multilinestring) index
-   * where the linestring locates.
-   */
+  /// Given the index of a part (linestring), return the geometry (multilinestring) index
+  /// where the linestring locates.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE auto geometry_idx_from_part_idx(IndexType part_idx);
 
-  /**
-   * @brief Given the index of a point, return the geometry (multilinestring) index where the
-   * point locates.
-   */
+  /// Given the index of a point, return the geometry (multilinestring) index where the
+  /// point locates.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE auto geometry_idx_from_point_idx(IndexType point_idx);
 
-  /**
-   * @brief Given an index of a segment, returns true if the index is valid.
-   * The index of a segment is the same as the index to the starting point of the segment.
-   * Thus, the index to the last point of a linestring is an invalid segment index.
-   */
+  /// Given an index of a segment, returns true if the index is valid.
+  /// The index of a segment is the same as the index to the starting point of the segment.
+  /// Thus, the index to the last point of a linestring is an invalid segment index.
   template <typename IndexType1, typename IndexType2>
   CUSPATIAL_HOST_DEVICE bool is_valid_segment_id(IndexType1 segment_idx, IndexType2 part_idx);
 
-  /**
-   * @brief Returns the segment given a segment index.
-   */
+  /// Returns the segment given a segment index.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE thrust::pair<vec_2d<element_t>, vec_2d<element_t>> segment(
     IndexType segment_idx);
 
+  /// Returns the `multilinestring_idx`th multilinestring in the range.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE auto operator[](IndexType multilinestring_idx);
 

--- a/cpp/include/cuspatial/experimental/ranges/multilinestring_range.cuh
+++ b/cpp/include/cuspatial/experimental/ranges/multilinestring_range.cuh
@@ -83,6 +83,14 @@ class multilinestring_range {
    */
   CUSPATIAL_HOST_DEVICE auto num_points();
 
+  CUSPATIAL_HOST_DEVICE auto multilinestring_begin();
+
+  CUSPATIAL_HOST_DEVICE auto multilinestring_end();
+
+  CUSPATIAL_HOST_DEVICE auto begin() { return multilinestring_begin(); }
+
+  CUSPATIAL_HOST_DEVICE auto end() { return multilinestring_end(); }
+
   /**
    * @brief Given the index of a point, return the part (linestring) index where the point locates.
    */
@@ -118,13 +126,16 @@ class multilinestring_range {
   CUSPATIAL_HOST_DEVICE thrust::pair<vec_2d<element_t>, vec_2d<element_t>> segment(
     IndexType segment_idx);
 
+  template <typename IndexType>
+  CUSPATIAL_HOST_DEVICE auto operator[](IndexType multilinestring_idx);
+
  protected:
-  GeometryIterator geometry_begin;
-  GeometryIterator geometry_end;
-  PartIterator part_begin;
-  PartIterator part_end;
-  VecIterator points_begin;
-  VecIterator points_end;
+  GeometryIterator _geometry_begin;
+  GeometryIterator _geometry_end;
+  PartIterator _part_begin;
+  PartIterator _part_end;
+  VecIterator _point_begin;
+  VecIterator _point_end;
 };
 
 /**

--- a/cpp/include/cuspatial_test/vector_factories.cuh
+++ b/cpp/include/cuspatial_test/vector_factories.cuh
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/device_vector.hpp>
+
+#include <initializer_list>
+
+template <typename T>
+auto make_device_vector(std::initializer_list<T> inl)
+{
+  return rmm::device_vector<T>(inl.begin(), inl.end());
+}

--- a/cpp/src/spatial/linestring_distance.cu
+++ b/cpp/src/spatial/linestring_distance.cu
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
+#include "thrust/iterator/counting_iterator.h"
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/iterator_factory.cuh>
 #include <cuspatial/experimental/linestring_distance.cuh>
+#include <cuspatial/experimental/ranges/multilinestring_range.cuh>
 #include <cuspatial/vec_2d.hpp>
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
-#include <cudf/detail/utilities/device_atomics.cuh>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/exec_policy.hpp>
-
-#include <thrust/binary_search.h>
-#include <thrust/distance.h>
-#include <thrust/execution_policy.h>
-#include <thrust/fill.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
 
 #include <limits>
 #include <memory>
@@ -67,15 +59,22 @@ struct pairwise_linestring_distance_functor {
     auto linestring2_coords_it =
       make_vec_2d_iterator(linestring2_points_x.begin<T>(), linestring2_points_y.begin<T>());
 
-    pairwise_linestring_distance(linestring1_offsets.begin(),
-                                 linestring1_offsets.end(),
-                                 linestring1_coords_it,
-                                 linestring1_coords_it + linestring1_points_x.size(),
-                                 linestring2_offsets.begin(),
-                                 linestring2_coords_it,
-                                 linestring2_coords_it + linestring2_points_x.size(),
-                                 distances->mutable_view().begin<T>(),
-                                 stream);
+    auto multilinestrings1 = make_multilinestring_range(num_string_pairs,
+                                                        thrust::make_counting_iterator(0),
+                                                        num_string_pairs,
+                                                        linestring1_offsets.begin(),
+                                                        linestring1_points_x.size(),
+                                                        linestring1_coords_it);
+
+    auto multilinestrings2 = make_multilinestring_range(num_string_pairs,
+                                                        thrust::make_counting_iterator(0),
+                                                        num_string_pairs,
+                                                        linestring2_offsets.begin(),
+                                                        linestring2_points_x.size(),
+                                                        linestring2_coords_it);
+
+    pairwise_linestring_distance(
+      multilinestrings1, multilinestrings2, distances->mutable_view().begin<T>());
 
     return distances;
   }

--- a/cpp/src/spatial/linestring_distance.cu
+++ b/cpp/src/spatial/linestring_distance.cu
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "thrust/iterator/counting_iterator.h"
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/iterator_factory.cuh>
 #include <cuspatial/experimental/linestring_distance.cuh>
@@ -27,6 +26,8 @@
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
 
 #include <limits>
 #include <memory>

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -19,22 +19,29 @@
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/iterator_factory.cuh>
 #include <cuspatial/experimental/linestring_distance.cuh>
+#include <cuspatial/experimental/ranges/multilinestring_range.cuh>
 #include <cuspatial/vec_2d.hpp>
 
-#include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
+#include <initializer_list>
+
 namespace cuspatial {
 namespace test {
 
-using namespace cudf;
+template <typename T>
+auto make_device_vector(std::initializer_list<T> inl)
+{
+  return rmm::device_vector<T>(inl.begin(), inl.end());
+}
 
 template <typename T>
-struct PairwiseLinestringDistanceTest : public ::testing::Test {
-};
+struct PairwiseLinestringDistanceTest : public ::testing::Test {};
+
+struct PairwiseLinestringDistanceTestUntyped : public ::testing::Test {};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
@@ -45,26 +52,34 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSeparateArrayInputs)
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
 
+  auto constexpr num_pairs = 1;
+
   auto a_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
   auto b_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 1.0f}, {1.0f, 1.0f}, {2.0f, 1.0f}, {3.0f, 1.0f}, {4.0f, 1.0f}})};
-  auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 5}};
+  auto offset = make_device_vector<int32_t>({0, 5});
 
-  auto distance = rmm::device_vector<T>{1};
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  a_cart2d.size(),
+                                                  a_cart2d.begin());
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  b_cart2d.size(),
+                                                  b_cart2d.begin());
+
+  auto got      = rmm::device_vector<T>(num_pairs);
   auto expected = rmm::device_vector<T>{std::vector<T>{1.0}};
 
-  auto ret = pairwise_linestring_distance(offset.begin(),
-                                          offset.end(),
-                                          a_cart2d.begin(),
-                                          a_cart2d.end(),
-                                          offset.begin(),
-                                          b_cart2d.begin(),
-                                          b_cart2d.end(),
-                                          distance.begin());
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
 
-  test::expect_vector_equivalent(expected, distance);
-  EXPECT_EQ(offset.size() - 1, std::distance(distance.begin(), ret));
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
@@ -72,30 +87,34 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromSamePointArrayInput)
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
 
-  auto cart2ds = rmm::device_vector<vec_2d<T>>{
-    CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
-  auto offset_a = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 3}};
-  auto offset_b = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 4}};
+  auto constexpr num_pairs = 1;
 
-  auto a_begin = cart2ds.begin();
-  auto a_end   = cart2ds.begin() + 3;
-  auto b_begin = cart2ds.begin() + 1;
-  auto b_end   = cart2ds.end();
+  auto cart2ds = make_device_vector<vec_2d<T>>(
+    {{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}});
+  auto offset_a = make_device_vector<int32_t>({0, 3});
+  auto offset_b = make_device_vector<int32_t>({0, 4});
 
-  auto distance = rmm::device_vector<T>{1};
-  auto expected = rmm::device_vector<T>{std::vector<T>{0.0}};
+  auto got      = rmm::device_vector<T>(1);
+  auto expected = make_device_vector<T>({0.0});
 
-  auto ret = pairwise_linestring_distance(offset_a.begin(),
-                                          offset_a.end(),
-                                          a_begin,
-                                          a_end,
-                                          offset_a.begin(),
-                                          b_begin,
-                                          b_end,
-                                          distance.begin());
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset_a.size() - 1,
+                                                  offset_a.begin(),
+                                                  3,
+                                                  cart2ds.begin());
 
-  test::expect_vector_equivalent(expected, distance);
-  EXPECT_EQ(offset_a.size() - 1, std::distance(distance.begin(), ret));
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset_b.size() - 1,
+                                                  offset_b.begin(),
+                                                  4,
+                                                  thrust::next(cart2ds.begin()));
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
@@ -103,34 +122,49 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromTransformIterator)
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
 
+  auto constexpr num_pairs = 1;
+
   auto a_cart2d_x = rmm::device_vector<T>{std::vector<T>{0.0, 1.0, 2.0, 3.0, 4.0}};
   auto a_cart2d_y = rmm::device_vector<T>(5, 0.0);
 
   auto a_begin = make_vec_2d_iterator(a_cart2d_x.begin(), a_cart2d_y.begin());
-  auto a_end   = a_begin + a_cart2d_x.size();
 
   auto b_cart2d_x = rmm::device_vector<T>{std::vector<T>{0.0, 1.0, 2.0, 3.0, 4.0}};
   auto b_cart2d_y = rmm::device_vector<T>(5, 1.0);
 
   auto b_begin = make_vec_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
-  auto b_end   = b_begin + b_cart2d_x.size();
 
   auto offset = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 5}};
 
-  auto distance = rmm::device_vector<T>{1};
+  auto got      = rmm::device_vector<T>{1};
   auto expected = rmm::device_vector<T>{std::vector<T>{1.0}};
 
-  auto ret = pairwise_linestring_distance(
-    offset.begin(), offset.end(), a_begin, a_end, offset.begin(), b_begin, b_end, distance.begin());
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  a_cart2d_x.size(),
+                                                  a_begin);
 
-  test::expect_vector_equivalent(expected, distance);
-  EXPECT_EQ(offset.size() - 1, std::distance(distance.begin(), ret));
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  b_cart2d_x.size(),
+                                                  b_begin);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
 {
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
+
+  auto constexpr num_pairs = 1;
 
   auto a_cart2d = rmm::device_vector<vec_2d<T>>{
     CartVec({{0.0f, 0.0f}, {1.0f, 0.0f}, {2.0f, 0.0f}, {3.0f, 0.0f}, {4.0f, 0.0f}})};
@@ -139,25 +173,31 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromMixedIterator)
   auto b_cart2d_y = rmm::device_vector<T>(5, 1.0);
 
   auto b_begin = make_vec_2d_iterator(b_cart2d_x.begin(), b_cart2d_y.begin());
-  auto b_end   = b_begin + b_cart2d_x.size();
 
   auto offset_a = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 5}};
   auto offset_b = rmm::device_vector<int32_t>{std::vector<int32_t>{0, 5}};
 
-  auto distance = rmm::device_vector<T>{1};
+  auto got      = rmm::device_vector<T>{1};
   auto expected = rmm::device_vector<T>{std::vector<T>{1.0}};
 
-  auto ret = pairwise_linestring_distance(offset_a.begin(),
-                                          offset_a.end(),
-                                          a_cart2d.begin(),
-                                          a_cart2d.end(),
-                                          offset_b.begin(),
-                                          b_begin,
-                                          b_end,
-                                          distance.begin());
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset_a.size() - 1,
+                                                  offset_a.begin(),
+                                                  a_cart2d.size(),
+                                                  a_cart2d.begin());
 
-  test::expect_vector_equivalent(expected, distance);
-  EXPECT_EQ(offset_a.size() - 1, std::distance(distance.begin(), ret));
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset_b.size() - 1,
+                                                  offset_b.begin(),
+                                                  b_cart2d_x.size(),
+                                                  b_begin);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
 }
 
 TYPED_TEST(PairwiseLinestringDistanceTest, FromLongInputs)
@@ -165,35 +205,756 @@ TYPED_TEST(PairwiseLinestringDistanceTest, FromLongInputs)
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
 
-  auto num_points = 1000;
+  auto constexpr num_pairs  = 5;
+  auto constexpr num_points = 1000;
 
   auto a_cart2d_x_begin = thrust::make_constant_iterator(T{0.0});
   auto a_cart2d_y_begin = thrust::make_counting_iterator(T{0.0});
   auto a_cart2d_begin   = make_vec_2d_iterator(a_cart2d_x_begin, a_cart2d_y_begin);
-  auto a_cart2d_end     = a_cart2d_begin + num_points;
 
   auto b_cart2d_x_begin = thrust::make_constant_iterator(T{42.0});
   auto b_cart2d_y_begin = thrust::make_counting_iterator(T{0.0});
   auto b_cart2d_begin   = make_vec_2d_iterator(b_cart2d_x_begin, b_cart2d_y_begin);
-  auto b_cart2d_end     = b_cart2d_begin + num_points;
 
   auto offset =
     rmm::device_vector<int32_t>{std::vector<int32_t>{0, 100, 200, 300, 400, num_points}};
 
-  auto distance = rmm::device_vector<T>{5};
+  auto got      = rmm::device_vector<T>{num_pairs};
   auto expected = rmm::device_vector<T>{std::vector<T>{42.0, 42.0, 42.0, 42.0, 42.0}};
 
-  auto ret = pairwise_linestring_distance(offset.begin(),
-                                          offset.end(),
-                                          a_cart2d_begin,
-                                          a_cart2d_end,
-                                          offset.begin(),
-                                          b_cart2d_begin,
-                                          b_cart2d_end,
-                                          distance.begin());
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  num_points,
+                                                  a_cart2d_begin);
 
-  test::expect_vector_equivalent(expected, distance);
-  EXPECT_EQ(offset.size() - 1, std::distance(distance.begin(), ret));
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  offset.size() - 1,
+                                                  offset.begin(),
+                                                  num_points,
+                                                  b_cart2d_begin);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringParallel)
+{
+  using T = TypeParam;
+  // Linestring 1: (0.0, 0.0), (1.0, 1.0)
+  // Linestring 2: (1.0, 0.0), (2.0, 1.0)
+
+  int32_t constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({1.0, 0.0, 2.0, 1.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.7071067811865476});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringEndpointsDistance)
+{
+  using T = TypeParam;
+  // Linestring 1: (0.0, 0.0), (1.0, 1.0), (2.0, 2.0)
+  // Linestring 2: (2.0, 0.0), (1.0, -1.0), (0.0, -1.0)
+
+  auto constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 3});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 1.0, 2.0, 2.0});
+  auto linestring2_offsets   = make_device_vector<T>({0, 3});
+  auto linestring2_points_xy = make_device_vector<T>({2.0, 0.0, 1.0, -1.0, 0.0, -1.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({1.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringProjectionNotOnLine)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring 1: (0.0, 0.0), (1.0, 1.0)
+  // Linestring 2: (3.0, 1.5), (3.0, 2.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({3.0, 1.5, 3.0, 2.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({2.0615528128088303});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringPerpendicular)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring 1: (0.0, 0.0), (2.0, 0.0)
+  // Linestring 2: (1.0, 1.0), (1.0, 2.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 2.0, 0.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({1.0, 1.0, 1.0, 2.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({1.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringIntersects)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring 1: (0.0, 0.0), (1.0, 1.0)
+  // Linestring 2: (0.0, 1.0), (1.0, 0.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({0.0, 1.0, 1.0, 0.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringSharedVertex)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring 1: (0.0, 0.0), (0.0, 2.0), (2.0, 2.0)
+  // Linestring 2: (2.0, 2.0), (2.0, 1.0), (1.0, 1.0), (2.5, 0.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 3});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 0.0, 2.0, 2.0, 2.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 4});
+  auto linestring2_points_xy = make_device_vector<T>({2.0, 2.0, 2.0, 1.0, 1.0, 1.0, 2.5, 0.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairLinestringCoincide)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+  // Linestring 1: (0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)
+  // Linestring 2: (2.0, 1.0), (1.0, 1.0), (1.0, 0.0), (2.0, 0.0), (2.0, 0.5)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 4});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 5});
+  auto linestring2_points_xy =
+    make_device_vector<T>({2.0, 1.0, 1.0, 1.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.5});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairDegenerateCollinearNoIntersect)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring1: (0.0, 0.0) -> (0.0, 1.0)
+  // Linestring2: (0.0, 2.0) -> (0.0, 3.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 0.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({0.0, 2.0, 0.0, 3.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({1.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairCollinearNoIntersect)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  // Linestring1: (0.0, 0.0) -> (1.0, 1.0)
+  // Linestring2: (2.0, 2.0) -> (3.0, 3.0)
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 1.0, 1.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({2.0, 2.0, 3.0, 3.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({1.4142135623730951});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairDegenerateCollinearIntersect)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<T>({0.0, 0.0, 2.0, 2.0});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>({1.0, 1.0, 3.0, 3.0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TEST_F(PairwiseLinestringDistanceTestUntyped, OnePairDeterminantDoublePrecisionDenormalized)
+{
+  // Vector ab: (1e-155, 2e-155)
+  // Vector cd: (2e-155, 1e-155)
+  // determinant of matrix [a, b] = -3e-310, a denormalized number
+
+  auto constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<double>({0.0, 0.0, 1e-155, 2e-155});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<double>({4e-155, 5e-155, 6e-155, 6e-155});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<double>({4.24264068711929e-155});
+  auto got      = rmm::device_vector<double>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TEST_F(PairwiseLinestringDistanceTestUntyped, OnePairDeterminantSinglePrecisionDenormalized)
+{
+  // Vector ab: (1e-20, 2e-20)
+  // Vector cd: (2e-20, 1e-20)
+  // determinant of matrix [ab, cd] = -3e-40, a denormalized number
+
+  auto constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy = make_device_vector<float>({0.0, 0.0, 1e-20, 2e-20});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<float>({4e-20, 5e-20, 6e-20, 6e-20});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<float>({4.2426405524813e-20});
+  auto got      = rmm::device_vector<float>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  // Expect a slightly greater floating point error compared to 4 ULP
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got, 1e-25f);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairRandom1)
+{
+  using T = TypeParam;
+
+  auto constexpr num_pairs   = 1;
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 3});
+  auto linestring1_points_xy = make_device_vector<T>({-22556.235212018168,
+                                                      41094.0501840996,
+                                                      -16375.655690574613,
+                                                      42992.319790050366,
+                                                      -20082.724633593425,
+                                                      33759.13529113619});
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy = make_device_vector<T>(
+    {4365.496374409238, -59857.47177852941, 1671.0269165650761, -54931.9723439855});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({91319.97744223749});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairIntersectFromRealData1)
+{
+  // Example extracted from a pair of trajectry in geolife dataset
+  using T                  = TypeParam;
+  auto constexpr num_pairs = 1;
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 5});
+  auto linestring1_points_xy = make_device_vector<T>({39.97551667,
+                                                      116.33028333,
+                                                      39.97585,
+                                                      116.3304,
+                                                      39.97598333,
+                                                      116.33046667,
+                                                      39.9761,
+                                                      116.3305,
+                                                      39.97623333,
+                                                      116.33056667});
+
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 55});
+  auto linestring2_points_xy = make_device_vector<T>(
+    {39.97381667, 116.34211667, 39.97341667, 116.34215,    39.9731,     116.34218333,
+     39.97293333, 116.34221667, 39.97233333, 116.34225,    39.97218333, 116.34243333,
+     39.97218333, 116.34296667, 39.97215,    116.34478333, 39.97168333, 116.34486667,
+     39.97093333, 116.34485,    39.97073333, 116.34468333, 39.9705,     116.34461667,
+     39.96991667, 116.34465,    39.96961667, 116.34465,    39.96918333, 116.34466667,
+     39.96891667, 116.34465,    39.97531667, 116.33036667, 39.97533333, 116.32961667,
+     39.97535,    116.3292,     39.97515,    116.32903333, 39.97506667, 116.32985,
+     39.97508333, 116.33128333, 39.9751,     116.33195,    39.97513333, 116.33618333,
+     39.97511667, 116.33668333, 39.97503333, 116.33818333, 39.97513333, 116.34,
+     39.97523333, 116.34045,    39.97521667, 116.34183333, 39.97503333, 116.342,
+     39.97463333, 116.34203333, 39.97443333, 116.3422,     39.96838333, 116.3445,
+     39.96808333, 116.34451667, 39.96771667, 116.3445,     39.96745,    116.34453333,
+     39.96735,    116.34493333, 39.9673,     116.34506667, 39.96718333, 116.3451,
+     39.96751667, 116.34483333, 39.9678,     116.3448,     39.9676,     116.3449,
+     39.96741667, 116.345,      39.9672,     116.34506667, 39.97646667, 116.33006667,
+     39.9764,     116.33015,    39.97625,    116.33026667, 39.9762,     116.33038333,
+     39.97603333, 116.33036667, 39.97581667, 116.3303,     39.9757,     116.33033333,
+     39.97551667, 116.33035,    39.97535,    116.3304,     39.97543333, 116.33078333,
+     39.97538333, 116.33066667});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, OnePairFromRealData)
+{
+  // Example extracted from a pair of trajectry in geolife dataset
+  using T = TypeParam;
+
+  auto constexpr num_pairs = 1;
+  auto linestring1_offsets = make_device_vector<int32_t>({0, 2});
+  auto linestring1_points_xy =
+    make_device_vector<T>({39.9752666666667, 116.334316666667, 39.9752666666667, 116.334533333333});
+  auto linestring2_offsets = make_device_vector<int32_t>({0, 2});
+  auto linestring2_points_xy =
+    make_device_vector<T>({39.9752666666667, 116.323966666667, 39.9752666666667, 116.3236});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  // Steps to reproduce:
+  // Create a float32/float64 numpy array with the literal inputs as above.
+  // Construct a shapely.geometry.LineString object and compute the result.
+  // Cast the result to np.float32/np.float64 and print the result.
+  auto expected =
+    make_device_vector<T>({std::is_same_v<T, float> ? 0.010353088f : 0.010349999999988313});
+  auto got = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, TwoPairsSingleLineString)
+{
+  using T                  = TypeParam;
+  auto constexpr num_pairs = 2;
+
+  // First pair lhs:
+  // (41658.902315589876, 14694.11814724456)->(46600.70359801489, 8771.431887804214)->
+  // (47079.510547637154, 10199.68027155776)->(51498.48049880379, 17049.62665643919)
+  // First pair rhs:
+  // (24046.170375947084, 27878.56737867571)->(20614.007047185743, 26489.74880629428)
+
+  // Second pair lhs:
+  // (-27429.917796286478, -33240.8339287343)->(-21764.269974046114, -37974.45515744517)->
+  // (-14460.71813363161, -31333.481529957502)->(-18226.13032712476, -30181.03842467982)
+  // Second pair rhs:
+  // (48381.39607717942, -8366.313156569413)->(53346.77764665915, -2066.3869793077383)
+
+  auto linestring1_offsets   = make_device_vector<int32_t>({0, 4, 8});
+  auto linestring1_points_xy = make_device_vector<T>({41658.902315589876,
+                                                      14694.11814724456,
+                                                      46600.70359801489,
+                                                      8771.431887804214,
+                                                      47079.510547637154,
+                                                      10199.68027155776,
+                                                      51498.48049880379,
+                                                      17049.62665643919,
+                                                      -27429.917796286478,
+                                                      -33240.8339287343,
+                                                      -21764.269974046114,
+                                                      -37974.45515744517,
+                                                      -14460.71813363161,
+                                                      -31333.481529957502,
+                                                      -18226.13032712476,
+                                                      -30181.03842467982});
+
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 2, 4});
+  auto linestring2_points_xy = make_device_vector<T>({
+    24046.170375947084,
+    27878.56737867571,
+    20614.007047185743,
+    26489.74880629428,
+    48381.39607717942,
+    -8366.313156569413,
+    53346.77764665915,
+    -2066.3869793077383,
+  });
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({22000.86425379464, 66907.56415814416});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
+}
+
+TYPED_TEST(PairwiseLinestringDistanceTest, FourPairsSingleLineString)
+{
+  using T                  = TypeParam;
+  auto constexpr num_pairs = 4;
+
+  auto linestring1_offsets = make_device_vector<int32_t>({0, 3, 5, 8, 10});
+
+  auto linestring1_points_xy =
+    make_device_vector<T>({0, 1, 1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 2, 2, -2, 0, 2, 2, -2, -2});
+
+  auto linestring2_offsets   = make_device_vector<int32_t>({0, 4, 7, 9, 12});
+  auto linestring2_points_xy = make_device_vector<T>(
+    {1, 1, 2, 1, 2, 0, 3, 0, 1, 0, 1, 1, 1, 2, 2, 0, 0, 2, 1, 1, 5, 5, 10, 0});
+
+  auto linestring1_points_it = make_vec_2d_iterator(linestring1_points_xy.begin());
+  auto linestring2_points_it = make_vec_2d_iterator(linestring2_points_xy.begin());
+
+  auto expected = make_device_vector<T>({static_cast<T>(std::sqrt(2.0) * 0.5), 1.0, 0.0, 0.0});
+  auto got      = rmm::device_vector<T>(expected.size());
+
+  auto mlinestrings1 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring1_offsets.size() - 1,
+                                                  linestring1_offsets.begin(),
+                                                  linestring1_points_xy.size() / 2,
+                                                  linestring1_points_it);
+  auto mlinestrings2 = make_multilinestring_range(num_pairs,
+                                                  thrust::make_counting_iterator(0),
+                                                  linestring2_offsets.size() - 1,
+                                                  linestring2_offsets.begin(),
+                                                  linestring2_points_xy.size() / 2,
+                                                  linestring2_points_it);
+
+  auto ret = pairwise_linestring_distance(mlinestrings1, mlinestrings2, got.begin());
+
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
+  EXPECT_EQ(num_pairs, std::distance(got.begin(), ret));
 }
 
 }  // namespace test

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -39,9 +39,11 @@ auto make_device_vector(std::initializer_list<T> inl)
 }
 
 template <typename T>
-struct PairwiseLinestringDistanceTest : public ::testing::Test {};
+struct PairwiseLinestringDistanceTest : public ::testing::Test {
+};
 
-struct PairwiseLinestringDistanceTestUntyped : public ::testing::Test {};
+struct PairwiseLinestringDistanceTestUntyped : public ::testing::Test {
+};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -14,29 +14,20 @@
  * limitations under the License.
  */
 
-#include "tests/utility/vector_equality.hpp"
+#include <tests/utility/vector_equality.hpp>
+
+#include <cuspatial_test/vector_factories.cuh>
 
 #include <cuspatial/error.hpp>
 #include <cuspatial/experimental/iterator_factory.cuh>
 #include <cuspatial/experimental/linestring_distance.cuh>
 #include <cuspatial/experimental/ranges/multilinestring_range.cuh>
 #include <cuspatial/vec_2d.hpp>
-
-#include <rmm/device_vector.hpp>
-
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
-#include <initializer_list>
-
 namespace cuspatial {
 namespace test {
-
-template <typename T>
-auto make_device_vector(std::initializer_list<T> inl)
-{
-  return rmm::device_vector<T>(inl.begin(), inl.end());
-}
 
 template <typename T>
 struct PairwiseLinestringDistanceTest : public ::testing::Test {

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -822,7 +822,7 @@ TYPED_TEST(PairwiseLinestringDistanceTest, OnePairFromRealData)
   // Steps to reproduce:
   // Create a float32/float64 numpy array with the literal inputs as above.
   // Construct a shapely.geometry.LineString object and compute the result.
-  // Cast the result to np.float32/np.float64 and print the result.
+  // Cast the result to np.float32/np.float64.
   auto expected =
     make_device_vector<T>({std::is_same_v<T, float> ? 0.010353088f : 0.010349999999988313});
   auto got = rmm::device_vector<T>(expected.size());

--- a/cpp/tests/utility/vector_equality.hpp
+++ b/cpp/tests/utility/vector_equality.hpp
@@ -32,13 +32,32 @@
 namespace cuspatial {
 namespace test {
 
+/**
+ * @brief Compare two floats are close within N ULPs
+ *
+ * N is predefined by GoogleTest
+ * https://google.github.io/googletest/reference/assertions.html#EXPECT_FLOAT_EQ
+ */
 template <typename T>
-auto floating_eq(T val)
+auto floating_eq_by_ulp(T val)
 {
   if constexpr (std::is_same_v<T, float>) {
     return ::testing::FloatEq(val);
   } else {
     return ::testing::DoubleEq(val);
+  }
+}
+
+/**
+ * @brief Compare two floats are close within `abs_error`
+ */
+template <typename T>
+auto floating_eq_by_abs_error(T val, T abs_error)
+{
+  if constexpr (std::is_same_v<T, float>) {
+    return ::testing::FloatNear(val, abs_error);
+  } else {
+    return ::testing::FloatNear(val, abs_error);
   }
 }
 
@@ -48,8 +67,24 @@ MATCHER(vec_2d_matcher,
   auto lhs = std::get<0>(arg);
   auto rhs = std::get<1>(arg);
 
-  if (::testing::Matches(floating_eq(rhs.x))(lhs.x) &&
-      ::testing::Matches(floating_eq(rhs.y))(lhs.y))
+  if (::testing::Matches(floating_eq_by_ulp(rhs.x))(lhs.x) &&
+      ::testing::Matches(floating_eq_by_ulp(rhs.y))(lhs.y))
+    return true;
+
+  *result_listener << lhs << " != " << rhs;
+
+  return false;
+}
+
+MATCHER_P(vec_2d_near_matcher,
+          abs_error,
+          std::string(negation ? "are not" : "are") + " approximately equal vec_2d structs")
+{
+  auto lhs = std::get<0>(arg);
+  auto rhs = std::get<1>(arg);
+
+  if (::testing::Matches(floating_eq_by_abs_error(rhs.x, abs_error))(lhs.x) &&
+      ::testing::Matches(floating_eq_by_abs_error(rhs.y, abs_error))(lhs.y))
     return true;
 
   *result_listener << lhs << " != " << rhs;
@@ -62,7 +97,21 @@ MATCHER(float_matcher, std::string(negation ? "are not" : "are") + " approximate
   auto lhs = std::get<0>(arg);
   auto rhs = std::get<1>(arg);
 
-  if (::testing::Matches(floating_eq(rhs))(lhs)) return true;
+  if (::testing::Matches(floating_eq_by_ulp(rhs))(lhs)) return true;
+
+  *result_listener << std::setprecision(18) << lhs << " != " << rhs;
+
+  return false;
+}
+
+MATCHER_P(float_near_matcher,
+          abs_error,
+          std::string(negation ? "are not" : "are") + " approximately equal floats")
+{
+  auto lhs = std::get<0>(arg);
+  auto rhs = std::get<1>(arg);
+
+  if (::testing::Matches(floating_eq_by_abs_error(rhs, abs_error))(lhs)) return true;
 
   *result_listener << std::setprecision(18) << lhs << " != " << rhs;
 
@@ -102,6 +151,29 @@ inline void expect_vector_equivalent(Vector1 const& lhs, Vector2 const& rhs)
     EXPECT_EQ(lhs, rhs);
   }
 }
+
+template <typename Vector1, typename Vector2, typename T = typename Vector1::value_type>
+inline void expect_vector_equivalent(Vector1 const& lhs, Vector2 const& rhs, T abs_error)
+{
+  static_assert(std::is_same_v<T, typename Vector2::value_type>, "Value type mismatch.");
+  static_assert(!std::is_integral_v<T>, "Integral types cannot be compared with an error.");
+
+  if constexpr (cuspatial::is_vec_2d<T>()) {
+    EXPECT_THAT(to_host<T>(lhs),
+                ::testing::Pointwise(vec_2d_near_matcher(abs_error), to_host<T>(rhs)));
+  } else if constexpr (std::is_floating_point_v<T>) {
+    EXPECT_THAT(to_host<T>(lhs),
+                ::testing::Pointwise(float_near_matcher(abs_error), to_host<T>(rhs)));
+  } else {
+    EXPECT_EQ(lhs, rhs);
+  }
+}
+
+#define CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(lhs, rhs, ...) \
+  do {                                                     \
+    SCOPED_TRACE(" <--  line of failure\n");               \
+    expect_vector_equivalent(lhs, rhs, ##__VA_ARGS__);     \
+  } while (0)
 
 }  // namespace test
 }  // namespace cuspatial


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Note, this is the first part of `pairwise_linestring_distance` refactoring, part 1 of PR: https://github.com/rapidsai/cuspatial/pull/753

Depends on #752 

Contributes to https://github.com/rapidsai/cuspatial/issues/706, https://github.com/rapidsai/cuspatial/issues/703

Closes #745 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
