### PR TITLE
`GeoSeries.contains` that matches `GeoPandas` with the exception of cases that depend on intersection.

### DIFF
--- a/cpp/tests/experimental/spatial/point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/point_in_polygon_test.cu
@@ -169,9 +169,7 @@ TYPED_TEST(PointInPolygonTest, EdgesOfSquare)
      {1.0, 1.0},   {0.0, 1.0},  {0.0, -1.0}, {-1.0, -1.0}, {-1.0, 0.0},  {1.0, 0.0},  {1.0, -1.0},
      {-1.0, 1.0},  {-1.0, 0.0}, {-1.0, 1.0}, {1.0, 1.0},   {1.0, 0.0},   {-1.0, 0.0}});
 
-  // point is included in rects on min x and y sides, but not on max x or y sides.
-  // this behavior is inconsistent, and not necessarily intentional.
-  auto expected = std::vector<int32_t>{0b1010};
+  auto expected = std::vector<int32_t>{0b0000};
   auto got      = rmm::device_vector<int32_t>(test_point.size());
 
   auto ret = point_in_polygon(test_point.begin(),
@@ -203,9 +201,7 @@ TYPED_TEST(PointInPolygonTest, CornersOfSquare)
      {0.0, 1.0},   {-1.0, 0.0}, {-1.0, 0.0}, {0.0, -1.0}, {0.0, 0.0},   {1.0, 0.0},  {1.0, -1.0},
      {0.0, -1.0},  {0.0, 0.0},  {0.0, 1.0},  {1.0, 1.0},  {1.0, 0.0},   {0.0, 0.0}});
 
-  // point is only included on the max x max y corner.
-  // this behavior is inconsistent, and not necessarily intentional.
-  auto expected = std::vector<int32_t>{0b1000};
+  auto expected = std::vector<int32_t>{0b0000};
   auto got      = rmm::device_vector<int32_t>(test_point.size());
 
   auto ret = point_in_polygon(test_point.begin(),

--- a/python/cuspatial/benchmarks/api/bench_api.py
+++ b/python/cuspatial/benchmarks/api/bench_api.py
@@ -165,8 +165,8 @@ def bench_quadtree_on_points(benchmark, gpu_dataframe):
 
 def bench_quadtree_point_in_polygon(benchmark, polygons):
     polygons = polygons["geometry"].polygons
-    x_points = (cupy.random.random(10000000) - 0.5) * 360
-    y_points = (cupy.random.random(10000000) - 0.5) * 180
+    x_points = (cupy.random.random(50000000) - 0.5) * 360
+    y_points = (cupy.random.random(50000000) - 0.5) * 180
     scale = 5
     max_depth = 7
     min_size = 125
@@ -263,8 +263,8 @@ def bench_quadtree_point_to_nearest_polyline(benchmark):
 
 
 def bench_point_in_polygon(benchmark, gpu_dataframe):
-    x_points = (cupy.random.random(10000000) - 0.5) * 360
-    y_points = (cupy.random.random(10000000) - 0.5) * 180
+    x_points = (cupy.random.random(50000000) - 0.5) * 360
+    y_points = (cupy.random.random(50000000) - 0.5) * 180
     short_dataframe = gpu_dataframe.iloc[0:32]
     geometry = short_dataframe["geometry"]
     benchmark(

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -24,6 +24,12 @@ import cudf
 import cuspatial.io.pygeoarrow as pygeoarrow
 from cuspatial.core._column.geocolumn import GeoColumn
 from cuspatial.core._column.geometa import Feature_Enum, GeoMeta
+from cuspatial.core.spatial.binops import contains
+from cuspatial.utils.column_utils import (
+    contains_only_linestrings,
+    contains_only_multipoints,
+    contains_only_polygons,
+)
 
 T = TypeVar("T", bound="GeoSeries")
 
@@ -147,6 +153,12 @@ class GeoSeries(cudf.Series):
             result = self._col.take(indices._column).leaves().values
             return cudf.Series(result)
 
+        def point_indices(self):
+            # Points only case
+            offsets = cp.arange(0, len(self.x) * 2 + 1, 2)
+            sizes = offsets[1:] - offsets[:-1]
+            return cp.repeat(self._series.index, sizes)
+
     class MultiPointGeoColumnAccessor(GeoColumnAccessor):
         def __init__(self, list_series, meta):
             super().__init__(list_series, meta)
@@ -155,6 +167,11 @@ class GeoSeries(cudf.Series):
         @property
         def geometry_offset(self):
             return cudf.Series(self._col.offsets.values)
+
+        def point_indices(self):
+            offsets = cp.array(self.geometry_offset)
+            sizes = offsets[1:] - offsets[:-1]
+            return cp.repeat(self._series.index, sizes)
 
     class LineStringGeoColumnAccessor(GeoColumnAccessor):
         def __init__(self, list_series, meta):
@@ -168,6 +185,11 @@ class GeoSeries(cudf.Series):
         @property
         def part_offset(self):
             return cudf.Series(self._col.elements.offsets.values)
+
+        def point_indices(self):
+            offsets = cp.array(self.part_offset)
+            sizes = offsets[1:] - offsets[:-1]
+            return cp.repeat(self._series.index, sizes)
 
     class PolygonGeoColumnAccessor(GeoColumnAccessor):
         def __init__(self, list_series, meta):
@@ -185,6 +207,11 @@ class GeoSeries(cudf.Series):
         @property
         def ring_offset(self):
             return cudf.Series(self._col.elements.elements.offsets.values)
+
+        def point_indices(self):
+            offsets = cp.array(self.ring_offset)
+            sizes = offsets[1:] - offsets[:-1]
+            return cp.repeat(self._series.index, sizes)
 
     @property
     def points(self):
@@ -517,3 +544,67 @@ class GeoSeries(cudf.Series):
                 arrow_polygons,
             ],
         )
+
+    def contains(self, other, align=True):
+        if contains_only_polygons(self) is False:
+            raise TypeError("left series contains non-polygons.")
+
+        # RHS conditioning:
+        mode = "POINTS"
+        # point in polygon
+        if contains_only_linestrings(other) is True:
+            # condition for linestrings
+            mode = "LINESTRINGS"
+            xy = other.lines
+        elif contains_only_polygons(other) is True:
+            # polygon in polygon
+            mode = "POLYGONS"
+            xy = other.polygons
+        elif contains_only_multipoints(other) is True:
+            # mpoint in polygon
+            mode = "MULTIPOINTS"
+            xy = other.multipoints
+        else:
+            # no conditioning is required
+            xy = other.points
+            # mpoint in polygon
+            # linestring in polygon
+        xy_points = xy.xy
+        point_indices = xy.point_indices()
+        points = GeoSeries(GeoColumn._from_points_xy(xy_points._column)).points
+
+        # call pip on the three subtypes on the right:
+        point_result = contains(
+            points.x,
+            points.y,
+            self.polygons.part_offset[:-1],
+            self.polygons.ring_offset[:-1],
+            self.polygons.x,
+            self.polygons.y,
+        )
+        """
+            # Apply binpreds rules on results:
+            # point in polygon = true for row
+                # reverse index, points indices refer back to row
+                # indices
+            # mpoint in polygon for all points = true
+            # linestring in polygon for all points = true
+            # polygon in polygon for all points = true
+        """
+        if (
+            mode == "LINESTRINGS"
+            or mode == "POLYGONS"
+            or mode == "MULTIPOINTS"
+        ):
+            # process for completed linestrings
+            result = cudf.DataFrame(
+                {"idx": point_indices, "pip": point_result}
+            )
+            df_result = (
+                result.groupby("idx").sum() == result.groupby("idx").count()
+            ).sort_index()
+            point_result = cudf.Series(
+                df_result["pip"], index=cudf.RangeIndex(0, len(df_result))
+            )
+            point_result.name = None
+        return point_result

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -546,6 +546,11 @@ class GeoSeries(cudf.Series):
         )
 
     def contains(self, other, align=True):
+        """
+        Returns a `GeoSeries` of bools with value `True` for each
+        aligned geometry that contains _other_.
+        """
+
         if contains_only_polygons(self) is False:
             raise TypeError("left series contains non-polygons.")
 

--- a/python/cuspatial/cuspatial/core/spatial/binops.py
+++ b/python/cuspatial/cuspatial/core/spatial/binops.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+
+from cudf import Series
+from cudf.core.column import as_column
+
+from cuspatial._lib.point_in_polygon import (
+    point_in_polygon as cpp_point_in_polygon,
+)
+from cuspatial.utils.column_utils import normalize_point_columns
+
+
+def contains(
+    test_points_x,
+    test_points_y,
+    poly_offsets,
+    poly_ring_offsets,
+    poly_points_x,
+    poly_points_y,
+):
+    """Compute from a set of points and a set of polygons which points fall
+    within each polygon. Note that `polygons_(x,y)` must be specified as
+    closed polygons: the first and last coordinate of each polygon must be
+    the same.
+
+    Parameters
+    ----------
+    test_points_x
+        x-coordinate of test points
+    test_points_y
+        y-coordinate of test points
+    poly_offsets
+        beginning index of the first ring in each polygon
+    poly_ring_offsets
+        beginning index of the first point in each ring
+    poly_points_x
+        x closed-coordinate of polygon points
+    poly_points_y
+        y closed-coordinate of polygon points
+
+    Examples
+    --------
+
+    Test whether 3 points fall within either of two polygons
+
+    # TODO: Examples
+
+    note
+    input Series x and y will not be index aligned, but computed as
+    sequential arrays.
+
+    note
+    poly_ring_offsets must contain only the rings that make up the polygons
+    indexed by poly_offsets. If there are rings in poly_ring_offsets that
+    are not part of the polygons in poly_offsets, results are likely to be
+    incorrect and behavior is undefined.
+
+    Returns
+    -------
+    result : cudf.DataFrame
+        A DataFrame of boolean values indicating whether each point falls
+        within each polygon.
+    """
+
+    if len(poly_offsets) == 0:
+        return Series()
+    (
+        test_points_x,
+        test_points_y,
+        poly_points_x,
+        poly_points_y,
+    ) = normalize_point_columns(
+        as_column(test_points_x),
+        as_column(test_points_y),
+        as_column(poly_points_x),
+        as_column(poly_points_y),
+    )
+
+    pip_result = cpp_point_in_polygon(
+        test_points_x,
+        test_points_y,
+        as_column(poly_offsets, dtype="int32"),
+        as_column(poly_ring_offsets, dtype="int32"),
+        poly_points_x,
+        poly_points_y,
+    )
+
+    result = Series(pip_result, dtype="bool")
+    return result

--- a/python/cuspatial/cuspatial/tests/conftest.py
+++ b/python/cuspatial/cuspatial/tests/conftest.py
@@ -4,6 +4,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
+from shapely.affinity import rotate
 from shapely.geometry import (
     LineString,
     MultiLineString,
@@ -182,7 +183,7 @@ def multipoint_generator(point_generator):
 
 @pytest.fixture
 def linestring_generator(point_generator):
-    rstate = np.random.RandomState(0)
+    rstate = np.random.RandomState(1)
 
     def generator(n, max_num_segments):
         for _ in range(n):
@@ -202,5 +203,52 @@ def multilinestring_generator(linestring_generator):
             yield MultiLineString(
                 [*linestring_generator(num_geometries, max_num_segments)]
             )
+
+    return generator
+
+
+@pytest.fixture
+def simple_polygon_generator():
+    np.random.seed(0)
+    rstate = np.random.RandomState(0)
+
+    def generator(n, distance_from_origin, radius=1.0):
+        for _ in range(n):
+            outer = Point(distance_from_origin * 2, 0).buffer(radius)
+            circle = Polygon(outer)
+            yield rotate(circle, rstate.random() * 2 * np.pi, use_radians=True)
+
+    return generator
+
+
+@pytest.fixture
+def polygon_generator():
+    rstate = np.random.RandomState(0)
+
+    def generator(n, distance_from_origin, radius=1.0):
+        for _ in range(n):
+            outer = Point(distance_from_origin * 2, 0).buffer(radius)
+            inners = []
+            for i in range(rstate.randint(1, 4)):
+                inner = Point(distance_from_origin + i * 0.1, 0).buffer(
+                    0.01 * radius
+                )
+                inners.append(inner)
+            together = Polygon(outer, inners)
+            yield rotate(
+                together, rstate.random() * 2 * np.pi, use_radians=True
+            )
+
+    return generator
+
+
+@pytest.fixture
+def multipolygon_generator():
+    rstate = np.random.RandomState(0)
+
+    def generator(n, max_per_multi):
+        for _ in range(n):
+            num_polygons = rstate.randint(1, max_per_multi)
+            yield MultiPolygon([*polygon_generator(0, num_polygons)])
 
     return generator

--- a/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
+++ b/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
@@ -236,7 +236,7 @@ def test_three_points_two_features():
     )
     expected = cudf.DataFrame()
     expected[0] = [True, True, False]
-    expected[1] = [True, False, True]
+    expected[1] = [False, False, True]
     cudf.testing.assert_frame_equal(expected, result)
 
 

--- a/python/cuspatial/cuspatial/tests/test_contains.py
+++ b/python/cuspatial/cuspatial/tests/test_contains.py
@@ -1,4 +1,5 @@
 import geopandas as gpd
+import pandas as pd
 import pytest
 from shapely.geometry import LineString, Point, Polygon
 
@@ -41,9 +42,10 @@ def test_float_precision_limits(point, polygon, expects):
     gpdpolygon = gpd.GeoSeries(polygon)
     point = cuspatial.from_geopandas(gpdpoint)
     polygon = cuspatial.from_geopandas(gpdpolygon)
-    result = polygon.contains(point)
-    assert gpdpolygon.contains(gpdpoint).values == result.values_host
-    assert result.values_host[0] == expects
+    expected = gpdpolygon.contains(gpdpoint)
+    got = polygon.contains(point).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
+    assert got.values == expects
 
 
 clockwiseTriangle = Polygon([[0, 0], [0, 1], [1, 1], [0, 0]])
@@ -90,9 +92,10 @@ def test_point_in_polygon(point, polygon, expects):
     gpdpolygon = gpd.GeoSeries(polygon)
     point = cuspatial.from_geopandas(gpdpoint)
     polygon = cuspatial.from_geopandas(gpdpolygon)
-    result = polygon.contains(point)
-    assert gpdpolygon.contains(gpdpoint).values == result.values_host
-    assert result.values_host[0] == expects
+    expected = gpdpolygon.contains(gpdpoint)
+    got = polygon.contains(point).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
+    assert got.values == expects
 
 
 def test_two_points_one_polygon():
@@ -100,10 +103,9 @@ def test_two_points_one_polygon():
     gpdpolygon = gpd.GeoSeries(Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]))
     point = cuspatial.from_geopandas(gpdpoint)
     polygon = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdpoint).values
-        == polygon.contains(point).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdpoint)
+    got = polygon.contains(point).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_one_point_two_polygons():
@@ -116,10 +118,9 @@ def test_one_point_two_polygons():
     )
     point = cuspatial.from_geopandas(gpdpoint)
     polygon = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdpoint).values
-        == polygon.contains(point).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdpoint)
+    got = polygon.contains(point).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_ten_pair_points(point_generator, polygon_generator):
@@ -127,10 +128,9 @@ def test_ten_pair_points(point_generator, polygon_generator):
     gpdpolygons = gpd.GeoSeries([*polygon_generator(10, 0)])
     points = cuspatial.from_geopandas(gpdpoints)
     polygons = cuspatial.from_geopandas(gpdpolygons)
-    assert (
-        gpdpolygons.contains(gpdpoints).values
-        == polygons.contains(points).values_host
-    ).all()
+    expected = gpdpolygons.contains(gpdpoints)
+    got = polygons.contains(points).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 @pytest.mark.xfail(
@@ -162,10 +162,9 @@ def test_one_polygon_with_hole_one_linestring_crossing_it(
     )
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdlinestring).values
-        == polygons.contains(linestring).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_one_polygon_with_hole_one_linestring_inside_it(linestring_generator):
@@ -192,10 +191,9 @@ def test_one_polygon_with_hole_one_linestring_inside_it(linestring_generator):
     )
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdlinestring).values
-        == polygons.contains(linestring).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_one_polygon_one_linestring(linestring_generator):
@@ -205,10 +203,9 @@ def test_one_polygon_one_linestring(linestring_generator):
     )
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdlinestring).values
-        == polygons.contains(linestring).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 @pytest.mark.xfail(reason="The boundaries share points, so pip is impossible.")
@@ -219,10 +216,9 @@ def test_one_polygon_one_linestring_crosses_the_diagonal(linestring_generator):
     )
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdlinestring).values
-        == polygons.contains(linestring).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_four_polygons_four_linestrings(linestring_generator):
@@ -244,10 +240,9 @@ def test_four_polygons_four_linestrings(linestring_generator):
     )
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygon)
-    assert (
-        gpdpolygon.contains(gpdlinestring).values
-        == polygons.contains(linestring).values_host
-    ).all()
+    expected = gpdpolygon.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_max_polygons_max_linestrings(linestring_generator, polygon_generator):
@@ -255,9 +250,9 @@ def test_max_polygons_max_linestrings(linestring_generator, polygon_generator):
     gpdpolygons = gpd.GeoSeries([*polygon_generator(31, 0)])
     linestring = cuspatial.from_geopandas(gpdlinestring)
     polygons = cuspatial.from_geopandas(gpdpolygons)
-    gpdresult = gpdpolygons.contains(gpdlinestring)
-    result = polygons.contains(linestring)
-    assert (gpdresult.values == result.values_host).all()
+    expected = gpdpolygons.contains(gpdlinestring)
+    got = polygons.contains(linestring).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_one_polygon_one_polygon(polygon_generator):
@@ -265,16 +260,16 @@ def test_one_polygon_one_polygon(polygon_generator):
     gpdrhs = gpd.GeoSeries([*polygon_generator(1, 0)])
     rhs = cuspatial.from_geopandas(gpdrhs)
     lhs = cuspatial.from_geopandas(gpdlhs)
-    assert (
-        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
-    ).all()
-    assert (
-        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
-    ).all()
+    expected = gpdlhs.contains(gpdrhs)
+    got = lhs.contains(rhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
+    expected = gpdrhs.contains(gpdlhs)
+    got = rhs.contains(lhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 @pytest.mark.xfail(
-    reason="The polygons share numerous boundaries, so pip is impossible."
+    reason="The polygons share numerous boundaries, so pip needs intersection."
 )
 def test_manual_polygons():
     gpdlhs = gpd.GeoSeries([Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))) * 6])
@@ -290,12 +285,12 @@ def test_manual_polygons():
     )
     rhs = cuspatial.from_geopandas(gpdrhs)
     lhs = cuspatial.from_geopandas(gpdlhs)
-    assert (
-        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
-    ).all()
-    assert (
-        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
-    ).all()
+    expected = gpdlhs.contains(gpdrhs)
+    got = lhs.contains(rhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
+    expected = gpdrhs.contains(gpdlhs)
+    got = rhs.contains(lhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_max_polygons_max_polygons(simple_polygon_generator):
@@ -303,12 +298,12 @@ def test_max_polygons_max_polygons(simple_polygon_generator):
     gpdrhs = gpd.GeoSeries([*simple_polygon_generator(31, 1.49, 2)])
     rhs = cuspatial.from_geopandas(gpdrhs)
     lhs = cuspatial.from_geopandas(gpdlhs)
-    assert (
-        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
-    ).all()
-    assert (
-        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
-    ).all()
+    expected = gpdlhs.contains(gpdrhs)
+    got = lhs.contains(rhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
+    expected = gpdrhs.contains(gpdlhs)
+    got = rhs.contains(lhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_one_polygon_one_multipoint(multipoint_generator, polygon_generator):
@@ -316,7 +311,9 @@ def test_one_polygon_one_multipoint(multipoint_generator, polygon_generator):
     gpdrhs = gpd.GeoSeries([*multipoint_generator(1, 5)])
     rhs = cuspatial.from_geopandas(gpdrhs)
     lhs = cuspatial.from_geopandas(gpdlhs)
-    assert gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+    expected = gpdlhs.contains(gpdrhs)
+    got = lhs.contains(rhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)
 
 
 def test_max_polygons_max_multipoints(multipoint_generator, polygon_generator):
@@ -324,6 +321,6 @@ def test_max_polygons_max_multipoints(multipoint_generator, polygon_generator):
     gpdrhs = gpd.GeoSeries([*multipoint_generator(31, 10)])
     rhs = cuspatial.from_geopandas(gpdrhs)
     lhs = cuspatial.from_geopandas(gpdlhs)
-    assert (
-        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
-    ).all()
+    expected = gpdlhs.contains(gpdrhs)
+    got = lhs.contains(rhs).to_pandas()
+    pd.testing.assert_series_equal(expected, got)

--- a/python/cuspatial/cuspatial/tests/test_contains.py
+++ b/python/cuspatial/cuspatial/tests/test_contains.py
@@ -1,0 +1,329 @@
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, Point, Polygon
+
+import cuspatial
+
+"""
+[
+    Point([0.6, 0.06]),
+    Polygon([[0, 0], [10, 1], [1, 1], [0, 0]]),
+    False,
+],
+[
+    Point([3.333, 1.111]),
+    Polygon([[6, 2], [3, 1], [3, 4], [6, 2]]),
+    True,
+],
+"""
+
+
+@pytest.mark.parametrize(
+    "point, polygon, expects",
+    [
+        # unique failure cases identified by @mharris
+        [
+            Point([0.66, 0.006]),
+            Polygon([[0, 0], [10, 1], [1, 1], [0, 0]]),
+            False,
+        ],
+        [
+            Point([0.666, 0.0006]),
+            Polygon([[0, 0], [10, 1], [1, 1], [0, 0]]),
+            False,
+        ],
+        [Point([3.3, 1.1]), Polygon([[6, 2], [3, 1], [3, 4], [6, 2]]), True],
+        [Point([3.33, 1.11]), Polygon([[6, 2], [3, 1], [3, 4], [6, 2]]), True],
+    ],
+)
+def test_float_precision_limits(point, polygon, expects):
+    gpdpoint = gpd.GeoSeries(point)
+    gpdpolygon = gpd.GeoSeries(polygon)
+    point = cuspatial.from_geopandas(gpdpoint)
+    polygon = cuspatial.from_geopandas(gpdpolygon)
+    result = polygon.contains(point)
+    assert gpdpolygon.contains(gpdpoint).values == result.values_host
+    assert result.values_host[0] == expects
+
+
+clockwiseTriangle = Polygon([[0, 0], [0, 1], [1, 1], [0, 0]])
+clockwiseSquare = Polygon(
+    [[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5], [-0.5, -0.5]]
+)
+
+
+@pytest.mark.parametrize(
+    "point, polygon, expects",
+    [
+        [Point([-0.5, -0.5]), clockwiseSquare, False],
+        [Point([-0.5, 0.5]), clockwiseSquare, False],
+        [Point([0.5, 0.5]), clockwiseSquare, False],
+        [Point([0.5, -0.5]), clockwiseSquare, False],
+        # clockwise square, should be true
+        [Point([-0.5, 0.0]), clockwiseSquare, False],
+        [Point([0.0, 0.5]), clockwiseSquare, False],
+        [Point([0.5, 0.0]), clockwiseSquare, False],
+        [Point([0.0, -0.5]), clockwiseSquare, False],
+        # wound clockwise, should be false
+        [Point([0, 0]), clockwiseTriangle, False],
+        [Point([0.0, 1.0]), clockwiseTriangle, False],
+        [Point([1.0, 1.0]), clockwiseTriangle, False],
+        [Point([0.0, 0.5]), clockwiseTriangle, False],
+        [Point([0.5, 0.5]), clockwiseTriangle, False],
+        [Point([0.5, 1]), clockwiseTriangle, False],
+        # wound clockwise, should be true
+        [Point([0.25, 0.5]), clockwiseTriangle, True],
+        [Point([0.75, 0.9]), clockwiseTriangle, True],
+        # wound counter clockwise, should be false
+        [Point([0.0, 0.0]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), False],
+        [Point([1.0, 0.0]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), False],
+        [Point([1.0, 1.0]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), False],
+        [Point([0.5, 0.0]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), False],
+        [Point([0.5, 0.5]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), False],
+        # wound counter clockwise, should be true
+        [Point([0.5, 0.25]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), True],
+        [Point([0.9, 0.75]), Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]), True],
+    ],
+)
+def test_point_in_polygon(point, polygon, expects):
+    gpdpoint = gpd.GeoSeries(point)
+    gpdpolygon = gpd.GeoSeries(polygon)
+    point = cuspatial.from_geopandas(gpdpoint)
+    polygon = cuspatial.from_geopandas(gpdpolygon)
+    result = polygon.contains(point)
+    assert gpdpolygon.contains(gpdpoint).values == result.values_host
+    assert result.values_host[0] == expects
+
+
+def test_two_points_one_polygon():
+    gpdpoint = gpd.GeoSeries([Point(0, 0), Point(0, 0)])
+    gpdpolygon = gpd.GeoSeries(Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]))
+    point = cuspatial.from_geopandas(gpdpoint)
+    polygon = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdpoint).values
+        == polygon.contains(point).values_host
+    ).all()
+
+
+def test_one_point_two_polygons():
+    gpdpoint = gpd.GeoSeries([Point(0, 0)])
+    gpdpolygon = gpd.GeoSeries(
+        [
+            Polygon([[0, 0], [1, 0], [1, 1], [0, 0]]),
+            Polygon([[-2, -2], [-2, 2], [2, 2], [-2, -2]]),
+        ]
+    )
+    point = cuspatial.from_geopandas(gpdpoint)
+    polygon = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdpoint).values
+        == polygon.contains(point).values_host
+    ).all()
+
+
+def test_ten_pair_points(point_generator, polygon_generator):
+    gpdpoints = gpd.GeoSeries([*point_generator(10)])
+    gpdpolygons = gpd.GeoSeries([*polygon_generator(10, 0)])
+    points = cuspatial.from_geopandas(gpdpoints)
+    polygons = cuspatial.from_geopandas(gpdpolygons)
+    assert (
+        gpdpolygons.contains(gpdpoints).values
+        == polygons.contains(points).values_host
+    ).all()
+
+
+@pytest.mark.xfail(
+    reason="We don't support intersection yet to check for crossings."
+)
+def test_one_polygon_with_hole_one_linestring_crossing_it(
+    linestring_generator,
+):
+    gpdlinestring = gpd.GeoSeries(LineString([[0.5, 2.0], [3.5, 2.0]]))
+    gpdpolygon = gpd.GeoSeries(
+        Polygon(
+            (
+                [0, 0],
+                [0, 4],
+                [4, 4],
+                [4, 0],
+                [0, 0],
+            ),
+            [
+                (
+                    [1, 1],
+                    [1, 3],
+                    [3, 3],
+                    [3, 1],
+                    [1, 1],
+                )
+            ],
+        )
+    )
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdlinestring).values
+        == polygons.contains(linestring).values_host
+    ).all()
+
+
+def test_one_polygon_with_hole_one_linestring_inside_it(linestring_generator):
+    gpdlinestring = gpd.GeoSeries(LineString([[1.5, 2.0], [2.5, 2.0]]))
+    gpdpolygon = gpd.GeoSeries(
+        Polygon(
+            (
+                [0, 0],
+                [0, 4],
+                [4, 4],
+                [4, 0],
+                [0, 0],
+            ),
+            [
+                (
+                    [1, 1],
+                    [1, 3],
+                    [3, 3],
+                    [3, 1],
+                    [1, 1],
+                )
+            ],
+        )
+    )
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdlinestring).values
+        == polygons.contains(linestring).values_host
+    ).all()
+
+
+def test_one_polygon_one_linestring(linestring_generator):
+    gpdlinestring = gpd.GeoSeries([*linestring_generator(1, 4)])
+    gpdpolygon = gpd.GeoSeries(
+        Polygon([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
+    )
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdlinestring).values
+        == polygons.contains(linestring).values_host
+    ).all()
+
+
+@pytest.mark.xfail(reason="The boundaries share points, so pip is impossible.")
+def test_one_polygon_one_linestring_crosses_the_diagonal(linestring_generator):
+    gpdlinestring = gpd.GeoSeries(LineString([[0, 0], [1, 1]]))
+    gpdpolygon = gpd.GeoSeries(
+        Polygon([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
+    )
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdlinestring).values
+        == polygons.contains(linestring).values_host
+    ).all()
+
+
+def test_four_polygons_four_linestrings(linestring_generator):
+    gpdlinestring = gpd.GeoSeries(
+        [
+            LineString([[0.35, 0.35], [0.35, 0.65]]),
+            LineString([[0.25, 0.25], [0.25, 0.75]]),
+            LineString([[0.15, 0.15], [0.15, 0.85]]),
+            LineString([[0.05, 0.05], [0.05, 0.95]]),
+        ]
+    )
+    gpdpolygon = gpd.GeoSeries(
+        [
+            Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+            Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]),
+        ]
+    )
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygon)
+    assert (
+        gpdpolygon.contains(gpdlinestring).values
+        == polygons.contains(linestring).values_host
+    ).all()
+
+
+def test_max_polygons_max_linestrings(linestring_generator, polygon_generator):
+    gpdlinestring = gpd.GeoSeries([*linestring_generator(31, 3)])
+    gpdpolygons = gpd.GeoSeries([*polygon_generator(31, 0)])
+    linestring = cuspatial.from_geopandas(gpdlinestring)
+    polygons = cuspatial.from_geopandas(gpdpolygons)
+    gpdresult = gpdpolygons.contains(gpdlinestring)
+    result = polygons.contains(linestring)
+    assert (gpdresult.values == result.values_host).all()
+
+
+def test_one_polygon_one_polygon(polygon_generator):
+    gpdlhs = gpd.GeoSeries(Polygon([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]))
+    gpdrhs = gpd.GeoSeries([*polygon_generator(1, 0)])
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    assert (
+        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+    ).all()
+    assert (
+        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
+    ).all()
+
+
+@pytest.mark.xfail(
+    reason="The polygons share numerous boundaries, so pip is impossible."
+)
+def test_manual_polygons():
+    gpdlhs = gpd.GeoSeries([Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))) * 6])
+    gpdrhs = gpd.GeoSeries(
+        [
+            Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
+            Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
+            Polygon(((-10, -2), (-10, 2), (-6, 2), (-6, -2))),
+            Polygon(((-2, 8), (-2, 12), (2, 12), (2, 8))),
+            Polygon(((6, 0), (8, 2), (10, 0), (8, -2))),
+            Polygon(((-2, -8), (-2, -4), (2, -4), (2, -8))),
+        ]
+    )
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    assert (
+        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+    ).all()
+    assert (
+        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
+    ).all()
+
+
+def test_max_polygons_max_polygons(simple_polygon_generator):
+    gpdlhs = gpd.GeoSeries([*simple_polygon_generator(31, 1, 3)])
+    gpdrhs = gpd.GeoSeries([*simple_polygon_generator(31, 1.49, 2)])
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    assert (
+        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+    ).all()
+    assert (
+        gpdrhs.contains(gpdlhs).values == rhs.contains(lhs).values_host
+    ).all()
+
+
+def test_one_polygon_one_multipoint(multipoint_generator, polygon_generator):
+    gpdlhs = gpd.GeoSeries([*polygon_generator(1, 0)])
+    gpdrhs = gpd.GeoSeries([*multipoint_generator(1, 5)])
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    assert gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+
+
+def test_max_polygons_max_multipoints(multipoint_generator, polygon_generator):
+    gpdlhs = gpd.GeoSeries([*polygon_generator(31, 0, 1)])
+    gpdrhs = gpd.GeoSeries([*multipoint_generator(31, 10)])
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    assert (
+        gpdlhs.contains(gpdrhs).values == lhs.contains(rhs).values_host
+    ).all()

--- a/python/cuspatial/cuspatial/utils/column_utils.py
+++ b/python/cuspatial/cuspatial/utils/column_utils.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+from typing import TypeVar
+
 import numpy as np
 
 from cudf.api.types import is_datetime_dtype
 
-from cuspatial.core.geoseries import GeoSeries
+GeoSeries = TypeVar("GeoSeries", bound="GeoSeries")
 
 
 def normalize_point_columns(*cols):
@@ -71,6 +73,14 @@ def contains_only_points(gs: GeoSeries):
     return contain_single_type_geometry(gs) and (
         len(gs.points.xy) > 0 or len(gs.multipoints.xy) > 0
     )
+
+
+def contains_only_multipoints(gs: GeoSeries):
+    """
+    Returns true if `gs` contains only multipoints
+    """
+
+    return contain_single_type_geometry(gs) and (len(gs.multipoints.xy) > 0)
 
 
 def contains_only_linestrings(gs: GeoSeries):


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cuspatial/issues/738, https://github.com/rapidsai/cuspatial/issues/742, https://github.com/rapidsai/cuspatial/issues/743, and https://github.com/rapidsai/cuspatial/issues/744>

A feature $a$ is contained in a feature $b$ $\leftrightarrow$ all of the points in $a$ are in the inner region of $b$ and none of the exterior points of $a$ or $b$ intersect. This PR implements the first part of the `.contains` operation, that is, $\leftrightarrow$ all of the points in $a$ are in the inner region of $b$.

We do not have an intersection primitive available yet, so I will add the second portion of this operation when it is available. There are a small number of pytest `xfails` that demonstrate where we can't agree with GeoPandas yet.

This PR adds boundary exclusion to our point-in-polygon algorithm. Previously, point-in-polygon had inconsistent inclusion or exclusion of the polygon boundary, based on floating-point error and implementation details of the RayCrossings algorithm. Due to that inconsistency I've added explicit boundary exclusion.

Boundary exclusion in this context means that any point in $b$ that is colinear with a line segment in $a$ is treated as an intersection, which then violates the requirements of `.contains`, returning false for $a.contains(b)$.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
