### PR TITLE
Better slicing via `union_offsets`

### DIFF
--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -148,6 +148,9 @@ class GeoSeries(cudf.Series):
             return cudf.Series(result)
 
         def _get_current_features(self, type):
+            # Resample the existing features so that the offsets returned
+            # by `_offset` methods reflect previous slicing, and match
+            # the values returned by .xy.
             existing_indices = self._meta.union_offsets[
                 self._meta.input_types == type.value
             ]

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -141,11 +141,9 @@ class GeoSeries(cudf.Series):
 
         @property
         def xy(self):
-            types = self._meta.input_types
-            offsets = self._meta.union_offsets
-            indices = offsets[types == self._type.value]
-            result = self._col.take(indices._column).leaves().values
-            return cudf.Series(result)
+            return cudf.Series(
+                self._get_current_features(self._type).leaves().values
+            )
 
         def _get_current_features(self, type):
             # Resample the existing features so that the offsets returned

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -174,16 +174,17 @@ class GeoSeries(cudf.Series):
             super().__init__(list_series, meta)
             self._type = Feature_Enum.POLYGON
 
-        def _get_sliced_offset(self):
+        def _get_current_features(self):
             existing_indices = self._meta.union_offsets[
                 self._meta.input_types == Feature_Enum.POLYGON.value
             ]
-            existing_members = self._col.take(existing_indices._column)
-            return existing_members.offsets.values
+            existing_features = self._col.take(existing_indices._column)
+            return existing_features
 
         @property
         def geometry_offset(self):
-            return self._get_sliced_offset()
+            sliced_features = self._get_current_features()
+            return sliced_features.offsets.values
 
         @property
         def part_offset(self):

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -174,9 +174,16 @@ class GeoSeries(cudf.Series):
             super().__init__(list_series, meta)
             self._type = Feature_Enum.POLYGON
 
+        def _get_sliced_offset(self):
+            existing_indices = self._meta.union_offsets[
+                self._meta.input_types == Feature_Enum.POLYGON.value
+            ]
+            existing_members = self._col.take(existing_indices._column)
+            return existing_members.offsets.values
+
         @property
         def geometry_offset(self):
-            return cudf.Series(self._col.offsets.values)
+            return self._get_sliced_offset()
 
         @property
         def part_offset(self):

--- a/python/cuspatial/cuspatial/core/spatial/distance.py
+++ b/python/cuspatial/cuspatial/core/spatial/distance.py
@@ -402,10 +402,10 @@ def pairwise_point_linestring_distance(
         {
             None: c_pairwise_point_linestring_distance(
                 point_xy_col,
-                linestrings.lines.part_offset._column,
+                as_column(linestrings.lines.part_offset),
                 linestrings.lines.xy._column,
                 points_geometry_offset,
-                linestrings.lines.geometry_offset._column,
+                as_column(linestrings.lines.geometry_offset),
             )
         }
     )
@@ -421,5 +421,5 @@ def _flatten_point_series(
         return points.points.xy._column, None
     return (
         points.multipoints.xy._column,
-        points.multipoints.geometry_offset._column,
+        as_column(points.multipoints.geometry_offset),
     )

--- a/python/cuspatial/cuspatial/core/spatial/nearest_points.py
+++ b/python/cuspatial/cuspatial/core/spatial/nearest_points.py
@@ -1,5 +1,7 @@
 import cupy as cp
 
+from cudf.core.column import as_column
+
 import cuspatial._lib.nearest_points as nearest_points
 from cuspatial.core._column.geocolumn import GeoColumn
 from cuspatial.core.geodataframe import GeoDataFrame
@@ -78,7 +80,7 @@ def pairwise_point_linestring_nearest_points(
     points_geometry_offset = (
         None
         if len(points.points.xy) > 0
-        else points.multipoints.geometry_offset._column
+        else as_column(points.multipoints.geometry_offset)
     )
 
     (
@@ -88,10 +90,10 @@ def pairwise_point_linestring_nearest_points(
         point_on_linestring_xy,
     ) = nearest_points.pairwise_point_linestring_nearest_points(
         points_xy._column,
-        linestrings.lines.part_offset._column,
+        as_column(linestrings.lines.part_offset),
         linestrings.lines.xy._column,
         points_geometry_offset,
-        linestrings.lines.geometry_offset._column,
+        as_column(linestrings.lines.geometry_offset),
     )
 
     point_on_linestring = GeoColumn._from_points_xy(point_on_linestring_xy)

--- a/python/cuspatial/cuspatial/tests/conftest.py
+++ b/python/cuspatial/cuspatial/tests/conftest.py
@@ -204,3 +204,14 @@ def multilinestring_generator(linestring_generator):
             )
 
     return generator
+
+
+@pytest.fixture
+def slice_twenty():
+    return [
+        slice(0, 4),
+        slice(4, 8),
+        slice(8, 12),
+        slice(12, 16),
+        slice(16, 20),
+    ]

--- a/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
+++ b/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
@@ -218,9 +218,9 @@ def test_multipolygons_part_offset(range, expected):
     [
         [[0, 2], [0, 4, 8, 12]],
         [[0, 1, 2], [0, 4, 8, 12, 16]],
-        [[2, 4], [0, 4, 8, 14, 18]],
-        [[4, 5], [0, 6, 10, 14]],
-        [[4, 3, 2], [0, 6, 10, 14, 18, 22]],
+        [[2, 4], [0, 4, 8, 13, 17]],
+        [[4, 5], [0, 5, 9, 13]],
+        [[4, 3, 2], [0, 5, 9, 13, 17, 21]],
     ],
 )
 def test_multipolygons_ring_offset(range, expected):
@@ -238,7 +238,7 @@ def test_multipolygons_ring_offset(range, expected):
                 Polygon([(0, 9), (0, 10), (0, 22), (0, 9)]),
                 MultiPolygon(
                     [
-                        Polygon([(0, 11), (0, 12), (0, 13), (0, 22), (0, 12)]),
+                        Polygon([(0, 11), (0, 12), (0, 13), (0, 22), (0, 11)]),
                         Polygon([(0, 14), (0, 15), (0, 23), (0, 14)]),
                     ]
                 ),

--- a/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
+++ b/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
@@ -1,0 +1,129 @@
+# Copyright 2022 NVIDIA Corporation
+
+import cupy as cp
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, MultiLineString, MultiPoint
+
+import cuspatial
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [[slice(0, 3), [0, 3, 4, 5]], [slice(3, 6), [0, 30, 40, 41]]],
+)
+def test_GeoColumnAccessor_polygon_offset(range, expected):
+    gpdf = cuspatial.from_geopandas(
+        gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
+    )
+    shorter = gpdf[range]["geometry"]
+    expected = cp.array(expected)
+    got = shorter.polygons.geometry_offset
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 2, 5]],
+        [[0, 1, 2], [0, 2, 4, 7]],
+        [[2, 4], [0, 3, 6]],
+        [[4, 5], [0, 3, 5]],
+        [[4, 3, 2], [0, 3, 5, 8]],
+    ],
+)
+def test_multipoint(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                MultiPoint([(0, 1), (0, 2)]),
+                MultiPoint([(0, 3), (0, 4)]),
+                MultiPoint([(0, 5), (0, 6), (0, 7)]),
+                MultiPoint([(0, 8), (0, 9)]),
+                MultiPoint([(0, 10), (0, 11), (0, 12)]),
+                MultiPoint([(0, 13), (0, 14)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.multipoints.geometry_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 1, 3]],
+        [[0, 1, 2], [0, 1, 2, 4]],
+        [[2, 4], [0, 2, 4]],
+        [[4, 5], [0, 2, 3]],
+        [[4, 3, 2], [0, 2, 3, 5]],
+    ],
+)
+def test_multilines_geometry_offset(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                LineString([(0, 1), (0, 2)]),
+                LineString([(0, 3), (0, 4)]),
+                MultiLineString(
+                    [
+                        LineString([(0, 5), (0, 6)]),
+                        LineString([(0, 7), (0, 8)]),
+                    ]
+                ),
+                LineString([(0, 9), (0, 10)]),
+                MultiLineString(
+                    [
+                        LineString([(0, 11), (0, 12)]),
+                        LineString([(0, 13), (0, 14)]),
+                    ]
+                ),
+                LineString([(0, 15), (0, 16)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.lines.geometry_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 2, 4, 6]],
+        [[0, 1, 2], [0, 2, 4, 6, 8]],
+        [[2, 4], [0, 2, 4, 7, 9]],
+        [[4, 5], [0, 3, 5, 7]],
+        [[4, 3, 2], [0, 3, 5, 7, 9, 11]],
+    ],
+)
+def test_multilines_part_offset(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                LineString([(0, 1), (0, 2)]),
+                LineString([(0, 3), (0, 4)]),
+                MultiLineString(
+                    [
+                        LineString([(0, 5), (0, 6)]),
+                        LineString([(0, 7), (0, 8)]),
+                    ]
+                ),
+                LineString([(0, 9), (0, 10)]),
+                MultiLineString(
+                    [
+                        LineString([(0, 11), (0, 12), (0, 13)]),
+                        LineString([(0, 14), (0, 15)]),
+                    ]
+                ),
+                LineString([(0, 16), (0, 17)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.lines.part_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)

--- a/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
+++ b/python/cuspatial/cuspatial/tests/test_geocolumn_accessor.py
@@ -3,7 +3,13 @@
 import cupy as cp
 import geopandas as gpd
 import pytest
-from shapely.geometry import LineString, MultiLineString, MultiPoint
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Polygon,
+)
 
 import cuspatial
 
@@ -125,5 +131,122 @@ def test_multilines_part_offset(range, expected):
     )
     t1 = gs[range]
     got = t1.lines.part_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 1, 3]],
+        [[0, 1, 2], [0, 1, 2, 4]],
+        [[2, 4], [0, 2, 4]],
+        [[4, 5], [0, 2, 3]],
+        [[4, 3, 2], [0, 2, 3, 5]],
+    ],
+)
+def test_multipolygons_geometry_offset(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                Polygon([(0, 1), (0, 2), (0, 18)]),
+                Polygon([(0, 3), (0, 4), (0, 19)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 5), (0, 6), (0, 20)]),
+                        Polygon([(0, 7), (0, 8), (0, 21)]),
+                    ]
+                ),
+                Polygon([(0, 9), (0, 10), (0, 22)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 11), (0, 12), (0, 13), (0, 22)]),
+                        Polygon([(0, 14), (0, 15), (0, 23)]),
+                    ]
+                ),
+                Polygon([(0, 16), (0, 17), (0, 24)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.polygons.geometry_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 1, 2, 3]],
+        [[0, 1, 2], [0, 1, 2, 3, 4]],
+        [[2, 4], [0, 1, 2, 3, 4]],
+        [[4, 5], [0, 1, 2, 3]],
+        [[4, 3, 2], [0, 1, 2, 3, 4, 5]],
+    ],
+)
+def test_multipolygons_part_offset(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                Polygon([(0, 1), (0, 2), (0, 18)]),
+                Polygon([(0, 3), (0, 4), (0, 19)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 5), (0, 6), (0, 20)]),
+                        Polygon([(0, 7), (0, 8), (0, 21)]),
+                    ]
+                ),
+                Polygon([(0, 9), (0, 10), (0, 22)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 11), (0, 12), (0, 13), (0, 22)]),
+                        Polygon([(0, 14), (0, 15), (0, 23)]),
+                    ]
+                ),
+                Polygon([(0, 16), (0, 17), (0, 24)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.polygons.part_offset
+    expected = cp.array(expected)
+    assert cp.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(
+    "range, expected",
+    [
+        [[0, 2], [0, 4, 8, 12]],
+        [[0, 1, 2], [0, 4, 8, 12, 16]],
+        [[2, 4], [0, 4, 8, 14, 18]],
+        [[4, 5], [0, 6, 10, 14]],
+        [[4, 3, 2], [0, 6, 10, 14, 18, 22]],
+    ],
+)
+def test_multipolygons_ring_offset(range, expected):
+    gs = cuspatial.from_geopandas(
+        gpd.GeoSeries(
+            [
+                Polygon([(0, 1), (0, 2), (0, 18), (0, 1)]),
+                Polygon([(0, 3), (0, 4), (0, 19), (0, 3)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 5), (0, 6), (0, 20), (0, 5)]),
+                        Polygon([(0, 7), (0, 8), (0, 21), (0, 7)]),
+                    ]
+                ),
+                Polygon([(0, 9), (0, 10), (0, 22), (0, 9)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 11), (0, 12), (0, 13), (0, 22), (0, 12)]),
+                        Polygon([(0, 14), (0, 15), (0, 23), (0, 14)]),
+                    ]
+                ),
+                Polygon([(0, 16), (0, 17), (0, 24), (0, 16)]),
+            ]
+        )
+    )
+    t1 = gs[range]
+    got = t1.polygons.ring_offset
     expected = cp.array(expected)
     assert cp.array_equal(got, expected)

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -3,7 +3,6 @@
 from enum import Enum
 from numbers import Integral
 
-import cupy as cp
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -595,13 +594,3 @@ def test_memory_usage_large():
     geometry = cuspatial.from_geopandas(host_dataframe)["geometry"]
     # the geometry column from naturalearth_lowres is 217kb of coordinates
     assert geometry.memory_usage() == 217021
-
-
-def test_GeoColumnAccessor_polygon_offset():
-    geoseries = cuspatial.from_geopandas(
-        gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
-    )
-    shorter = geoseries[0:3]["geometry"]
-    expected = cp.array([0, 3, 4, 5])
-    got = shorter.polygons.geometry_offset
-    assert cp.array_equal(expected, got)

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -3,6 +3,7 @@
 from enum import Enum
 from numbers import Integral
 
+import cupy as cp
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -594,3 +595,13 @@ def test_memory_usage_large():
     geometry = cuspatial.from_geopandas(host_dataframe)["geometry"]
     # the geometry column from naturalearth_lowres is 217kb of coordinates
     assert geometry.memory_usage() == 217021
+
+
+def test_GeoColumnAccessor_polygon_offset():
+    geoseries = cuspatial.from_geopandas(
+        gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
+    )
+    shorter = geoseries[0:3]["geometry"]
+    expected = cp.array([0, 3, 4, 5])
+    got = shorter.polygons.geometry_offset
+    assert cp.array_equal(expected, got)

--- a/python/cuspatial/cuspatial/tests/test_point_linestring_distance.py
+++ b/python/cuspatial/cuspatial/tests/test_point_linestring_distance.py
@@ -167,3 +167,85 @@ def test_mixed_geometry_series_raise(lhs, rhs):
 
     with pytest.raises(ValueError, match=".*must contain only.*"):
         pairwise_point_linestring_distance(lhs, rhs)
+
+
+def test_multipoint_multilinestring_sliced_pairs(
+    multipoint_generator, multilinestring_generator
+):
+    num_pairs = 2
+    max_num_linestring_per_multilinestring = 2
+    max_num_segments_per_linestring = 2
+    max_num_points_per_multipoint = 2
+
+    hpts = gpd.GeoSeries(
+        [*multipoint_generator(num_pairs, max_num_points_per_multipoint)]
+    )
+    hlines = gpd.GeoSeries(
+        [
+            *multilinestring_generator(
+                num_pairs,
+                max_num_linestring_per_multilinestring,
+                max_num_segments_per_linestring,
+            )
+        ]
+    )
+
+    gpts = from_geopandas(hpts)
+    glines = from_geopandas(hlines)
+
+    hslicepts = hpts[0:1]
+    hslicelines = hlines[0:1]
+    slicegpts = gpts[0:1]
+    sliceglines = glines[0:1]
+    got = pairwise_point_linestring_distance(slicegpts, sliceglines)
+    expected = hslicepts.distance(hslicelines)
+
+    cudf.testing.assert_series_equal(got, cudf.Series(expected))
+
+    hslicepts = hpts[1:2]
+    hslicelines = hlines[1:2]
+    slicegpts = gpts[1:2]
+    sliceglines = glines[1:2]
+    got = pairwise_point_linestring_distance(slicegpts, sliceglines)
+    expected = hslicepts.distance(hslicelines)
+
+    # Just dropping the index for now, that is not libcuSpatial's problem
+    got.index = [1]
+    cudf.testing.assert_series_equal(got, cudf.Series(expected))
+
+
+@pytest.mark.parametrize("slice_index", [0, 1, 2, 3, 4])
+def test_multipoint_multilinestring_sliced_many(
+    multipoint_generator, multilinestring_generator, slice_twenty, slice_index
+):
+    num_pairs = 20
+    max_num_linestring_per_multilinestring = 5
+    max_num_segments_per_linestring = 5
+    max_num_points_per_multipoint = 5
+
+    hpts = gpd.GeoSeries(
+        [*multipoint_generator(num_pairs, max_num_points_per_multipoint)]
+    )
+    hlines = gpd.GeoSeries(
+        [
+            *multilinestring_generator(
+                num_pairs,
+                max_num_linestring_per_multilinestring,
+                max_num_segments_per_linestring,
+            )
+        ]
+    )
+
+    gpts = from_geopandas(hpts)
+    glines = from_geopandas(hlines)
+
+    pslice = slice_twenty[slice_index]
+    hslicepts = hpts[pslice]
+    hslicelines = hlines[pslice]
+    slicegpts = gpts[pslice]
+    sliceglines = glines[pslice]
+    got = pairwise_point_linestring_distance(slicegpts, sliceglines)
+    expected = hslicepts.distance(hslicelines)
+    got.index = cudf.RangeIndex(pslice.start, pslice.stop)
+
+    cudf.testing.assert_series_equal(got, cudf.Series(expected))


### PR DESCRIPTION
## Description
Closes #771 

This PR modifies the production of `geometry_offset`, `part_offset`, and `ring_offset` by sampling the existing values in a `GeoSeries` before returning their various offsets. This has the effect of using `cudf.ListSeries` to re-pack any features into a new, dense `GeoColumn`, then returning the offsets based on it.

Previously, `GeoSeries` that had been modified by slicing would have the appearance of the sliced elements, but when `_offset` buffers were used they would return the full original offset buffer that the sliced `GeoSeries` had originated from. This was a problem because it made slicing useless for our algorithms.

I also modify the `core/spatial/distance.py` and `core/spatial/nearest_points.py` files to use `as_column(linestrings.lines.geometry_offset)` instead of `linestrings.lines.geometry_offset._column` because there doesn't appear to be a reason to use a `cudf.Series` to wrap the offset buffers. They are private methods essentially, don't need indexes, and will eventually be factored out so that they're hidden from the user.

I wrote a new test file `test_geocolumn_accessor.py` to exercise the new {`geometry_buffer`...} accessors for all geometry types. 

Finally I added tests for a base case, a more complicated case, and a case with noncontiugous slices to the inputs of `test_point_linestring_distance.py`, validating that the changes have exactly the effect we need.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
