### PR TITLE
Test/empty rows with null buffer

### DIFF
--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -114,7 +114,9 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
 {
   using Cart2d     = iterator_value_type<Cart2dItA>;
   using OffsetType = iterator_value_type<OffsetIteratorA>;
-
+  // grid-stride loop
+  // for (auto idx = threadIdx.x + blockIdx.x * blockDim.x; idx < multilinestrings1.num_points();
+  //     idx += gridDim.x * blockDim.x) {
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (idx >= num_test_points) { return; }

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -114,7 +114,8 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
 {
   using Cart2d     = iterator_value_type<Cart2dItA>;
   using OffsetType = iterator_value_type<OffsetIteratorA>;
-  auto idx         = blockIdx.x * blockDim.x + threadIdx.x;
+
+  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (idx >= num_test_points) { return; }
 

--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -114,10 +114,7 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
 {
   using Cart2d     = iterator_value_type<Cart2dItA>;
   using OffsetType = iterator_value_type<OffsetIteratorA>;
-  // grid-stride loop
-  // for (auto idx = threadIdx.x + blockIdx.x * blockDim.x; idx < multilinestrings1.num_points();
-  //     idx += gridDim.x * blockDim.x) {
-  auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+  auto idx         = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (idx >= num_test_points) { return; }
 

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -129,6 +129,7 @@ class GeoColumn(ColumnBase):
             self.lines.name = "lines"
             self.polygons = data[3]
             self.polygons.name = "polygons"
+            self.null = data[4]
         else:
             raise TypeError("All four Tuple arguments must be cudf.ListSeries")
         super().__init__(None, size=len(self), dtype="geometry")
@@ -142,6 +143,7 @@ class GeoColumn(ColumnBase):
                 self.mpoints.to_arrow(),
                 self.lines.to_arrow(),
                 self.polygons.to_arrow(),
+                self.null.to_arrow(),
             ],
         )
 
@@ -174,6 +176,7 @@ class GeoColumn(ColumnBase):
                 self.mpoints.copy(deep),
                 self.lines.copy(deep),
                 self.polygons.copy(deep),
+                self.null,
             ),
             self._meta.copy(),
         )

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -132,8 +132,6 @@ class GeoColumn(ColumnBase):
         else:
             raise TypeError("All four Tuple arguments must be cudf.ListSeries")
         super().__init__(None, size=len(self), dtype="geometry")
-        if shuffle_order is not None:
-            self._data = shuffle_order
 
     def to_arrow(self):
         return pa.UnionArray.from_dense(

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -131,8 +131,7 @@ class GeoColumn(ColumnBase):
             self.polygons.name = "polygons"
         else:
             raise TypeError("All four Tuple arguments must be cudf.ListSeries")
-        base = cudf.core.column.column.arange(0, len(self), dtype="int32").data
-        super().__init__(base, size=len(self), dtype="int32")
+        super().__init__(None, size=len(self), dtype="geometry")
         if shuffle_order is not None:
             self._data = shuffle_order
 
@@ -179,7 +178,6 @@ class GeoColumn(ColumnBase):
                 self.polygons.copy(deep),
             ),
             self._meta.copy(),
-            self.data.copy(),
         )
         return result
 

--- a/python/cuspatial/cuspatial/core/_column/geometa.py
+++ b/python/cuspatial/cuspatial/core/_column/geometa.py
@@ -12,11 +12,11 @@ import cudf
 # This causes arrow to encode NONE as =255, which I'll accept now
 # in order to keep the rest of the enums the same.
 class Feature_Enum(Enum):
-    NONE = -1
     POINT = 0
     MULTIPOINT = 1
     LINESTRING = 2
     POLYGON = 3
+    NONE = 4
 
 
 class GeoMeta:

--- a/python/cuspatial/cuspatial/core/_column/geometa.py
+++ b/python/cuspatial/cuspatial/core/_column/geometa.py
@@ -28,8 +28,10 @@ class GeoMeta:
 
     def __init__(self, meta: Union[GeoMeta, dict]):
         if isinstance(meta, dict):
-            self.input_types = cudf.Series(meta["input_types"])
-            self.union_offsets = cudf.Series(meta["union_offsets"])
+            self.input_types = cudf.Series(meta["input_types"], dtype="int8")
+            self.union_offsets = cudf.Series(
+                meta["union_offsets"], dtype="int32"
+            )
         else:
             self.input_types = cudf.Series(meta.input_types, dtype="int8")
             self.union_offsets = cudf.Series(meta.union_offsets, dtype="int32")

--- a/python/cuspatial/cuspatial/core/_column/geometa.py
+++ b/python/cuspatial/cuspatial/core/_column/geometa.py
@@ -9,7 +9,10 @@ from typing import Union
 import cudf
 
 
+# This causes arrow to encode NONE as =255, which I'll accept now
+# in order to keep the rest of the enums the same.
 class Feature_Enum(Enum):
+    NONE = -1
     POINT = 0
     MULTIPOINT = 1
     LINESTRING = 2

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -202,14 +202,6 @@ class GeoDataFrame(cudf.DataFrame):
         # return
         return result
 
-    def _get_sorted_inds(self, by=None, ascending=True, na_position="last"):
-        geo_data, cudf_data = self._split_out_geometry_columns()
-        df = cudf.DataFrame._from_data(data=cudf_data, index=self.index)
-        result = df._get_sorted_inds(
-            ascending=ascending, na_position=na_position
-        )
-        return result
-
 
 class _GeoSeriesUtility:
     @classmethod

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -550,8 +550,6 @@ class GeoSeries(cudf.Series):
                 "union_offsets": aligned_union_offsets,
             },
         )
-        print(aligned_input_types)
-        print(aligned_union_offsets)
         return GeoSeries(column)
 
     def align(self, other):
@@ -559,7 +557,6 @@ class GeoSeries(cudf.Series):
         aligned_left = self._align_to_index(index)
         aligned_right = other._align_to_index(index)
         aligned_right.index = index
-        breakpoint()
         return (
             aligned_left,
             aligned_right.loc[aligned_left.index],

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -274,10 +274,7 @@ class GeoSeries(cudf.Series):
                 Feature_Enum.POLYGON: self._sr.polygons,
             }
 
-        def __getitem__(self, item):
-            # Use the reordering _column._data if it is set
-            indexes = item
-
+        def __getitem__(self, indexes):
             # Slice the types and offsets
             union_offsets = self._sr._column._meta.union_offsets.iloc[indexes]
             union_types = self._sr._column._meta.input_types.iloc[indexes]
@@ -295,7 +292,7 @@ class GeoSeries(cudf.Series):
                 },
             )
 
-            if isinstance(item, Integral):
+            if isinstance(indexes, Integral):
                 return GeoSeries(column, name=self._sr.name).to_shapely()
             else:
                 return GeoSeries(

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -276,11 +276,7 @@ class GeoSeries(cudf.Series):
 
         def __getitem__(self, item):
             # Use the reordering _column._data if it is set
-            indexes = (
-                self._sr._column._data[item].to_pandas()
-                if self._sr._column._data is not None
-                else item
-            )
+            indexes = item
 
             # Slice the types and offsets
             union_offsets = self._sr._column._meta.union_offsets.iloc[indexes]

--- a/python/cuspatial/cuspatial/io/geopandas_reader.py
+++ b/python/cuspatial/cuspatial/io/geopandas_reader.py
@@ -30,6 +30,10 @@ def parse_geometries(geoseries: gpGeoSeries) -> tuple:
     polygon_offsets = [0]
 
     for geom in geoseries:
+        if geom is None:
+            all_offsets.append(-1)
+            type_buffer.append(Feature_Enum.NONE.value)
+            continue
         coords = mapping(geom)["coordinates"]
         if isinstance(geom, Point):
             point_coords.append(coords)

--- a/python/cuspatial/cuspatial/io/pygeoarrow.py
+++ b/python/cuspatial/cuspatial/io/pygeoarrow.py
@@ -34,6 +34,7 @@ def from_pyarrow_lists(
     mpoint_coords: pa.ListArray,
     line_coords: pa.ListArray,
     polygon_coords: pa.ListArray,
+    null_buffer: pa.ListArray,
 ) -> pa.lib.UnionArray:
     type_buffer = type_buffer
     all_offsets = all_offsets
@@ -42,13 +43,14 @@ def from_pyarrow_lists(
         mpoint_coords,
         line_coords,
         polygon_coords,
+        null_buffer,
     ]
 
     return pa.UnionArray.from_dense(
         type_buffer,
         all_offsets,
         children,
-        ["points", "mpoints", "lines", "polygons"],
+        ["points", "mpoints", "lines", "polygons", "null"],
     )
 
 
@@ -59,6 +61,7 @@ def from_lists(
     mpoint_coords: List,
     line_coords: List,
     polygon_coords: List,
+    null_buffer: List,
 ) -> pa.lib.UnionArray:
     return from_pyarrow_lists(
         pa.array(type_buffer).cast(pa.int8()),
@@ -67,4 +70,5 @@ def from_lists(
         pa.array(mpoint_coords, type=ArrowMultiPointsType),
         pa.array(line_coords, type=ArrowLinestringsType),
         pa.array(polygon_coords, type=ArrowPolygonsType),
+        pa.array(null_buffer, type=pa.null()),
     )

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2022 NVIDIA CORPORATION.
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -18,10 +18,10 @@ def test_align():
     gpdshort = gpdpdf.iloc[0:1]
     pdf = cuspatial.from_geopandas(gpdpdf)
     short = cuspatial.from_geopandas(gpdshort)
-    gpdaligned = gpdshort.align(gpdpdf)
-    shortaligned = short.align(pdf)
-    pd.testing.assert_series_equal(gpdaligned[0], shortaligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], shortaligned[1].to_pandas())
+    expected = gpdshort.align(gpdpdf)
+    got = short.align(pdf)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
 
 
 def test_align_reorder():
@@ -41,11 +41,11 @@ def test_align_reorder():
     gpdreordered = gpdalign.iloc[np.random.permutation(len(gpdalign))]
     align = cuspatial.from_geopandas(gpdalign)
     reordered = cuspatial.from_geopandas(gpdreordered)
-    gpdaligned = gpdalign.align(gpdreordered)
-    aligned = align.align(reordered)
-    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())
-    gpdaligned = gpdreordered.align(gpdalign)
-    aligned = reordered.align(align)
-    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())
+    expected = gpdalign.align(gpdreordered)
+    got = align.align(reordered)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdreordered.align(gpdalign)
+    got = reordered.align(align)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -1,0 +1,49 @@
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import Polygon
+
+import cuspatial
+
+
+def test_align():
+    gpdpdf = gpd.GeoSeries(
+        [
+            Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
+            Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
+        ]
+    )
+    gpdshort = gpdpdf.iloc[0:1]
+    pdf = cuspatial.from_geopandas(gpdpdf)
+    short = cuspatial.from_geopandas(gpdshort)
+    gpdaligned = gpdshort.align(gpdpdf)
+    shortaligned = short.align(pdf)
+    pd.testing.assert_series_equal(gpdaligned[0], shortaligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], shortaligned[1].to_pandas())
+
+
+def test_align_reorder():
+    gpdalign = gpd.GeoSeries(
+        [
+            None,
+            None,
+            None,
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdreordered = gpdalign.iloc[np.random.permutation(len(gpdalign))]
+    align = cuspatial.from_geopandas(gpdalign)
+    reordered = cuspatial.from_geopandas(gpdreordered)
+    gpdaligned = gpdalign.align(gpdreordered)
+    aligned = align.align(reordered)
+    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())
+    gpdaligned = gpdreordered.align(gpdalign)
+    aligned = reordered.align(align)
+    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_cudf_integration.py
+++ b/python/cuspatial/cuspatial/tests/test_cudf_integration.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 NVIDIA CORPORATION.
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 
@@ -8,32 +9,33 @@ import cuspatial
 def test_sort_index_series(gs):
     gs.index = np.random.permutation(len(gs))
     cugs = cuspatial.from_geopandas(gs)
-    pd.testing.assert_series_equal(
-        gs.sort_index(), cugs.sort_index().to_pandas()
-    )
+    expected = gs.sort_index()
+    got = cugs.sort_index().to_pandas()
+    gpd.testing.assert_geoseries_equal(got, expected)
 
 
 def test_sort_index_dataframe(gpdf):
     gpdf.index = np.random.permutation(len(gpdf))
     cugpdf = cuspatial.from_geopandas(gpdf)
-    pd.testing.assert_frame_equal(
-        gpdf.sort_index(), cugpdf.sort_index().to_pandas()
-    )
+    expected = gpdf.sort_index()
+    got = cugpdf.sort_index().to_pandas()
+    gpd.testing.assert_geodataframe_equal(got, expected)
 
 
 def test_sort_values(gpdf):
     cugpdf = cuspatial.from_geopandas(gpdf)
-    sort_gpdf = gpdf.sort_values("random")
-    sort_cugpdf = cugpdf.sort_values("random").to_pandas()
-    pd.testing.assert_frame_equal(sort_gpdf, sort_cugpdf)
+    expected = gpdf.sort_values("random")
+    got = cugpdf.sort_values("random").to_pandas()
+    gpd.testing.assert_geodataframe_equal(got, expected)
 
 
 def test_groupby(gpdf):
     cugpdf = cuspatial.from_geopandas(gpdf)
-    pd.testing.assert_frame_equal(
-        gpdf.groupby("key")[["integer", "random"]].min().sort_index(),
+    expected = gpdf.groupby("key")[["integer", "random"]].min().sort_index()
+    got = (
         cugpdf.groupby("key")[["integer", "random"]]
         .min()
         .sort_index()
-        .to_pandas(),
+        .to_pandas()
     )
+    pd.testing.assert_frame_equal(got, expected)

--- a/python/cuspatial/cuspatial/tests/test_cudf_integration.py
+++ b/python/cuspatial/cuspatial/tests/test_cudf_integration.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+
+import cuspatial
+
+
+def test_sort_index_series(gs):
+    gs.index = np.random.permutation(len(gs))
+    cugs = cuspatial.from_geopandas(gs)
+    pd.testing.assert_series_equal(
+        gs.sort_index(), cugs.sort_index().to_pandas()
+    )
+
+
+def test_sort_index_dataframe(gpdf):
+    gpdf.index = np.random.permutation(len(gpdf))
+    cugpdf = cuspatial.from_geopandas(gpdf)
+    pd.testing.assert_frame_equal(
+        gpdf.sort_index(), cugpdf.sort_index().to_pandas()
+    )
+
+
+def test_sort_values(gpdf):
+    cugpdf = cuspatial.from_geopandas(gpdf)
+    sort_gpdf = gpdf.sort_values("random")
+    sort_cugpdf = cugpdf.sort_values("random").to_pandas()
+    pd.testing.assert_frame_equal(sort_gpdf, sort_cugpdf)
+
+
+def test_groupby(gpdf):
+    cugpdf = cuspatial.from_geopandas(gpdf)
+    pd.testing.assert_frame_equal(
+        gpdf.groupby("key")[["integer", "random"]].min().sort_index(),
+        cugpdf.groupby("key")[["integer", "random"]]
+        .min()
+        .sort_index()
+        .to_pandas(),
+    )

--- a/python/cuspatial/cuspatial/tests/test_cudf_integration.py
+++ b/python/cuspatial/cuspatial/tests/test_cudf_integration.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 NVIDIA CORPORATION.
 import numpy as np
 import pandas as pd
 

--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -107,24 +107,6 @@ def test_select_multiple_columns(gpdf):
     )
 
 
-def test_sort_values(gpdf):
-    cugpdf = cuspatial.from_geopandas(gpdf)
-    sort_gpdf = gpdf.sort_values("random")
-    sort_cugpdf = cugpdf.sort_values("random").to_pandas()
-    pd.testing.assert_frame_equal(sort_gpdf, sort_cugpdf)
-
-
-def test_groupby(gpdf):
-    cugpdf = cuspatial.from_geopandas(gpdf)
-    pd.testing.assert_frame_equal(
-        gpdf.groupby("key")[["integer", "random"]].min().sort_index(),
-        cugpdf.groupby("key")[["integer", "random"]]
-        .min()
-        .sort_index()
-        .to_pandas(),
-    )
-
-
 def test_type_persistence(gpdf):
     cugpdf = cuspatial.from_geopandas(gpdf)
     assert type(cugpdf["geometry"]) == cuspatial.GeoSeries

--- a/python/cuspatial/cuspatial/tests/test_none.py
+++ b/python/cuspatial/cuspatial/tests/test_none.py
@@ -1,0 +1,91 @@
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import Point, Polygon
+
+import cuspatial
+
+
+def test_empty_from_geopandas():
+    gpdempty = gpd.GeoSeries([None])
+    empty = cuspatial.from_geopandas(gpdempty)
+    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+
+
+def test_mix_from_geopandas():
+    gpdempty = gpd.GeoSeries([None, Point(0, 1), None])
+    empty = cuspatial.from_geopandas(gpdempty)
+    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+
+
+def test_first_from_geopandas():
+    gpdempty = gpd.GeoSeries([Point(0, 1), None, None])
+    empty = cuspatial.from_geopandas(gpdempty)
+    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+
+
+def test_last_from_geopandas():
+    gpdempty = gpd.GeoSeries([None, None, Point(0, 1)])
+    empty = cuspatial.from_geopandas(gpdempty)
+    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+
+
+def test_middle_from_geopandas():
+    gpdempty = gpd.GeoSeries(
+        [
+            Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
+            Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
+            None,
+            Polygon(((-10, -2), (-10, 2), (-6, 2), (-6, -2))),
+            None,
+            Polygon(((-2, 8), (-2, 12), (2, 12), (2, 8))),
+            Polygon(((6, 0), (8, 2), (10, 0), (8, -2))),
+            None,
+            Polygon(((-2, -8), (-2, -4), (2, -4), (2, -8))),
+        ]
+    )
+    empty = cuspatial.from_geopandas(gpdempty)
+    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+
+
+def test_align():
+    gpdpdf = gpd.GeoSeries(
+        [
+            Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
+            Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
+        ]
+    )
+    gpdshort = gpdpdf.iloc[0:1]
+    pdf = cuspatial.from_geopandas(gpdpdf)
+    short = cuspatial.from_geopandas(gpdshort)
+    gpdaligned = gpdshort.align(gpdpdf)
+    shortaligned = short.align(pdf)
+    pd.testing.assert_series_equal(gpdaligned[0], shortaligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], shortaligned[1].to_pandas())
+
+
+def test_align_reorder():
+    gpdalign = gpd.GeoSeries(
+        [
+            None,
+            None,
+            None,
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdreordered = gpdalign.iloc[np.random.permutation(len(gpdalign))]
+    align = cuspatial.from_geopandas(gpdalign)
+    reordered = cuspatial.from_geopandas(gpdreordered)
+    gpdaligned = gpdalign.align(gpdreordered)
+    aligned = align.align(reordered)
+    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())
+    gpdaligned = gpdreordered.align(gpdalign)
+    aligned = reordered.align(align)
+    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
+    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_none.py
+++ b/python/cuspatial/cuspatial/tests/test_none.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 NVIDIA CORPORATION.
 import geopandas as gpd
 import pandas as pd
 from shapely.geometry import Point, Polygon

--- a/python/cuspatial/cuspatial/tests/test_none.py
+++ b/python/cuspatial/cuspatial/tests/test_none.py
@@ -1,5 +1,4 @@
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 from shapely.geometry import Point, Polygon
 
@@ -46,46 +45,3 @@ def test_middle_from_geopandas():
     )
     empty = cuspatial.from_geopandas(gpdempty)
     pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
-
-
-def test_align():
-    gpdpdf = gpd.GeoSeries(
-        [
-            Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
-            Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
-        ]
-    )
-    gpdshort = gpdpdf.iloc[0:1]
-    pdf = cuspatial.from_geopandas(gpdpdf)
-    short = cuspatial.from_geopandas(gpdshort)
-    gpdaligned = gpdshort.align(gpdpdf)
-    shortaligned = short.align(pdf)
-    pd.testing.assert_series_equal(gpdaligned[0], shortaligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], shortaligned[1].to_pandas())
-
-
-def test_align_reorder():
-    gpdalign = gpd.GeoSeries(
-        [
-            None,
-            None,
-            None,
-            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
-            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
-            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
-            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
-            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
-            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
-        ]
-    )
-    gpdreordered = gpdalign.iloc[np.random.permutation(len(gpdalign))]
-    align = cuspatial.from_geopandas(gpdalign)
-    reordered = cuspatial.from_geopandas(gpdreordered)
-    gpdaligned = gpdalign.align(gpdreordered)
-    aligned = align.align(reordered)
-    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())
-    gpdaligned = gpdreordered.align(gpdalign)
-    aligned = reordered.align(align)
-    pd.testing.assert_series_equal(gpdaligned[0], aligned[0].to_pandas())
-    pd.testing.assert_series_equal(gpdaligned[1], aligned[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_none.py
+++ b/python/cuspatial/cuspatial/tests/test_none.py
@@ -6,32 +6,32 @@ from shapely.geometry import Point, Polygon
 import cuspatial
 
 
-def test_empty_from_geopandas():
-    gpdempty = gpd.GeoSeries([None])
-    empty = cuspatial.from_geopandas(gpdempty)
-    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+def test_got_from_geopandas():
+    expected = gpd.GeoSeries([None])
+    got = cuspatial.from_geopandas(expected)
+    pd.testing.assert_series_equal(expected, got.to_geopandas())
 
 
 def test_mix_from_geopandas():
-    gpdempty = gpd.GeoSeries([None, Point(0, 1), None])
-    empty = cuspatial.from_geopandas(gpdempty)
-    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+    expected = gpd.GeoSeries([None, Point(0, 1), None])
+    got = cuspatial.from_geopandas(expected)
+    pd.testing.assert_series_equal(expected, got.to_geopandas())
 
 
 def test_first_from_geopandas():
-    gpdempty = gpd.GeoSeries([Point(0, 1), None, None])
-    empty = cuspatial.from_geopandas(gpdempty)
-    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+    expected = gpd.GeoSeries([Point(0, 1), None, None])
+    got = cuspatial.from_geopandas(expected)
+    pd.testing.assert_series_equal(expected, got.to_geopandas())
 
 
 def test_last_from_geopandas():
-    gpdempty = gpd.GeoSeries([None, None, Point(0, 1)])
-    empty = cuspatial.from_geopandas(gpdempty)
-    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+    expected = gpd.GeoSeries([None, None, Point(0, 1)])
+    got = cuspatial.from_geopandas(expected)
+    pd.testing.assert_series_equal(expected, got.to_geopandas())
 
 
 def test_middle_from_geopandas():
-    gpdempty = gpd.GeoSeries(
+    expected = gpd.GeoSeries(
         [
             Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
             Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
@@ -44,5 +44,5 @@ def test_middle_from_geopandas():
             Polygon(((-2, -8), (-2, -4), (2, -4), (2, -8))),
         ]
     )
-    empty = cuspatial.from_geopandas(gpdempty)
-    pd.testing.assert_series_equal(gpdempty, empty.to_geopandas())
+    got = cuspatial.from_geopandas(expected)
+    pd.testing.assert_series_equal(expected, got.to_geopandas())


### PR DESCRIPTION
## Description
Experimenting with using a fifth buffer to store one instance of `null`, then using `union_offsets` to pull it when necessary.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
