### PR TITLE
Fix issue with `.loc` returning values out of order.

### DIFF
--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -246,11 +246,17 @@ class GeoSeries(cudf.Series):
                 }
             )
             index_df = cudf.DataFrame({"map": item})
-            new_index = index_df.merge(map_df, how="left")["idx"]
+            new_index = index_df.merge(map_df, how="left", sort=False)
+            new_index.index = new_index.map
+            final_index = (
+                new_index._align_to_index(index_df["map"])
+                .dropna()
+                .reset_index(drop=True)
+            )
             if isinstance(item, Integral):
-                return self._sr.iloc[new_index[0]]
+                return self._sr.iloc[final_index["idx"][0]]
             else:
-                result = self._sr.iloc[new_index]
+                result = self._sr.iloc[final_index["idx"]]
                 result.index = item
                 return result
 

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -245,18 +245,14 @@ class GeoSeries(cudf.Series):
                     else 0,
                 }
             )
-            index_df = cudf.DataFrame({"map": item})
-            new_index = index_df.merge(map_df, how="left", sort=False)
-            new_index.index = new_index.map
-            final_index = (
-                new_index._align_to_index(index_df["map"])
-                .dropna()
-                .reset_index(drop=True)
-            )
+            index_df = cudf.DataFrame({"map": item}).reset_index()
+            new_index = index_df.merge(
+                map_df, how="left", sort=False
+            ).sort_values("index")
             if isinstance(item, Integral):
-                return self._sr.iloc[final_index["idx"][0]]
+                return self._sr.iloc[new_index["idx"][0]]
             else:
-                result = self._sr.iloc[final_index["idx"]]
+                result = self._sr.iloc[new_index["idx"]]
                 result.index = item
                 return result
 


### PR DESCRIPTION
## Description
`cudf.merge` doesn't guarantee item ordering, an important feature of `loc`. This PR fixes that by adding a reordering step to post processing the merge.

Fixes https://github.com/rapidsai/cuspatial/issues/781
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
