### PR TITLE
Force using old fmt in nvbench. 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -220,7 +220,10 @@ if(CUSPATIAL_BUILD_BENCHMARKS)
         OPTIONS         "BENCHMARK_ENABLE_TESTING OFF"
                         "BENCHMARK_ENABLE_INSTALL OFF")
 
-    # Find or install NVBench
+    # Find or install NVBench Temporarily force downloading of fmt because current versions of nvbench
+    # do not support the latest version of fmt, which is automatically pulled into our conda
+    # environments by mamba.
+    set(CPM_DOWNLOAD_fmt TRUE)
     include(${rapids-cmake-dir}/cpm/nvbench.cmake)
     rapids_cpm_nvbench()
     add_subdirectory(benchmarks)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This is a port of https://github.com/rapidsai/cudf/pull/12067. 

Original post:
> The current version of nvbench is not compatible with the latest changes to fmt. This PR decouples us from needing to wait on upstreaming the compatibility changes to nvbench. These changes are necessary for building libcudf benchmarks until then.



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
