### PR TITLE
[FIX] Update quadtree spatial join docstrings

### DIFF
--- a/cpp/include/cuspatial/experimental/point_quadtree.cuh
+++ b/cpp/include/cuspatial/experimental/point_quadtree.cuh
@@ -41,10 +41,10 @@ struct point_quadtree {
   // uint8_t vector of quadtree levels
   rmm::device_uvector<uint8_t> level;
   // bool vector indicating whether the node is a parent (true) or leaf (false) node
-  rmm::device_uvector<bool> is_parent_node;
-  // uint32_t vector for the number of child nodes (if is_parent_node), or number of points
+  rmm::device_uvector<bool> is_internal_node;
+  // uint32_t vector for the number of child nodes (if is_internal_node), or number of points
   rmm::device_uvector<uint32_t> length;
-  // uint32_t vector for the first child position (if is_parent_node), or first point position
+  // uint32_t vector for the first child position (if is_internal_node), or first point position
   rmm::device_uvector<uint32_t> offset;
 };
 

--- a/cpp/include/cuspatial/experimental/point_quadtree.cuh
+++ b/cpp/include/cuspatial/experimental/point_quadtree.cuh
@@ -53,8 +53,8 @@ struct point_quadtree {
  *
  * @see http://www.adms-conf.org/2019-camera-ready/zhang_adms19.pdf for details.
  *
- * @note `scale` is applied to (x - min.x) and (y - min.y) to convert coordinates into a Morton code
- * in 2D space.
+ * @note 2D coordinates are converted into a 1D Morton code by dividing each x/y by the `scale`:
+ * (`(x - min_x) / scale` and `(y - min_y) / scale`).
  * @note `max_depth` should be less than 16, since Morton codes are represented as `uint32_t`. The
  * eventual number of levels may be less than `max_depth` if the number of points is small or
  * `max_size` is large.

--- a/cpp/include/cuspatial/point_quadtree.hpp
+++ b/cpp/include/cuspatial/point_quadtree.hpp
@@ -59,9 +59,10 @@ namespace cuspatial {
  * columns for a complete quadtree:
  *     key - UINT32 column of quad node keys
  *   level - UINT8 column of quadtree levels
- * is_quad - BOOL8 column indicating whether the node is a quad (true) or leaf (false)
- *  length - UINT32 column for the number of child nodes (if is_quad), or number of points
- *  offset - UINT32 column for the first child position (if is_quad), or first point position
+ * is_internal_node - BOOL8 column indicating whether the node is a quad (true) or leaf (false)
+ *  length - UINT32 column for the number of child nodes (if is_internal_node), or number of points
+ *  offset - UINT32 column for the first child position (if is_internal_node), or first point
+ *           position
  */
 std::pair<std::unique_ptr<cudf::column>, std::unique_ptr<cudf::table>> quadtree_on_points(
   cudf::column_view const& x,

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -38,7 +38,8 @@ namespace cuspatial {
  * eventual number of levels may be less than `max_depth` if the number of points is small or
  * `max_size` is large.
  *
- * @param quadtree: cudf table representing a quadtree (key, level, is_quad, length, offset).
+ * @param quadtree: cudf table representing a quadtree (key, level, is_internal_node, length,
+ * offset).
  * @param bbox: cudf table of bounding boxes as four columns (x_min, y_min, x_max, y_max).
  * @param x_min The lower-left x-coordinate of the area of interest bounding box.
  * @param x_max The upper-right x-coordinate of the area of interest bounding box.
@@ -85,7 +86,8 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(
  *
  * @param poly_quad_pairs cudf table of (polygon, quadrant) index pairs returned by
  * `cuspatial::join_quadtree_and_bounding_boxes`
- * @param quadtree cudf table representing a quadtree (key, level, is_quad, length, offset).
+ * @param quadtree cudf table representing a quadtree (key, level, is_internal_node, length,
+ * offset).
  * @param point_indices Sorted point indices returned by `cuspatial::quadtree_on_points`
  * @param point_x x-coordinates of points to test
  * @param point_y y-coordinates of points to test
@@ -132,7 +134,8 @@ std::unique_ptr<cudf::table> quadtree_point_in_polygon(
  *
  * @param linestring_quad_pairs cudf table of (linestring, quadrant) index pairs returned by
  * `cuspatial::join_quadtree_and_bounding_boxes`
- * @param quadtree cudf table representing a quadtree (key, level, is_quad, length, offset).
+ * @param quadtree cudf table representing a quadtree (key, level, is_internal_node, length,
+ * offset).
  * @param point_indices Sorted point indices returned by `cuspatial::quadtree_on_points`
  * @param point_x x-coordinates of points to test
  * @param point_y y-coordinates of points to test

--- a/cpp/include/cuspatial/spatial_join.hpp
+++ b/cpp/include/cuspatial/spatial_join.hpp
@@ -32,9 +32,11 @@ namespace cuspatial {
 /**
  * @brief Search a quadtree for polygon or linestring bounding box intersections.
  *
- * @note `scale` is applied to (x - x_min) and (y - y_min) to convert coordinates into a Morton code
- * in 2D space.
- * @note `max_depth` should be less than 16, since Morton codes are represented as `uint32_t`.
+ * @note 2D coordinates are converted into a 1D Morton code by dividing each x/y by the `scale`:
+ * (`(x - min_x) / scale` and `(y - min_y) / scale`).
+ * @note `max_depth` should be less than 16, since Morton codes are represented as `uint32_t`. The
+ * eventual number of levels may be less than `max_depth` if the number of points is small or
+ * `max_size` is large.
  *
  * @param quadtree: cudf table representing a quadtree (key, level, is_quad, length, offset).
  * @param bbox: cudf table of bounding boxes as four columns (x_min, y_min, x_max, y_max).
@@ -104,8 +106,8 @@ std::unique_ptr<cudf::table> join_quadtree_and_bounding_boxes(
  * polygon_offset - UINT32 column of polygon indices
  *   point_offset - UINT32 column of point indices
  *
- * @note The returned polygon and point indices are offsets into the poly_quad_pairs inputs and
- * (point_x, point_y), respectively.
+ * @note The returned polygon and point indices are offsets into the `poly_quad_pairs` inputs and
+ * `point_indices`, respectively.
  *
  **/
 std::unique_ptr<cudf::table> quadtree_point_in_polygon(
@@ -153,8 +155,8 @@ std::unique_ptr<cudf::table> quadtree_point_in_polygon(
  *   distance          - FLOAT or DOUBLE column (based on input point data type) of distances
  *                       between each point and linestring
  *
- * @note The returned point and linestring indices are offsets into the (point_x, point_y) and
- * linestring_quad_pairs inputs, respectively.
+ * @note The returned point and linestring indices are offsets into the `point_indices` and
+ * `linestring_quad_pairs` inputs, respectively.
  *
  **/
 std::unique_ptr<cudf::table> quadtree_point_to_nearest_linestring(

--- a/cpp/src/indexing/construction/point_quadtree.cu
+++ b/cpp/src/indexing/construction/point_quadtree.cu
@@ -94,7 +94,7 @@ struct dispatch_construct_quadtree {
     cols.push_back(std::make_unique<cudf::column>(
       cudf::data_type{cudf::type_id::UINT8}, size, tree.level.release()));
     cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::BOOL8}, size, tree.is_parent_node.release()));
+      cudf::data_type{cudf::type_id::BOOL8}, size, tree.is_internal_node.release()));
     cols.push_back(std::make_unique<cudf::column>(
       cudf::data_type{cudf::type_id::UINT32}, size, tree.length.release()));
     cols.push_back(std::make_unique<cudf::column>(

--- a/cpp/tests/experimental/indexing/point_quadtree_test.cu
+++ b/cpp/tests/experimental/indexing/point_quadtree_test.cu
@@ -29,7 +29,7 @@ struct QuadtreeOnPointIndexingTest : public ::testing::Test {
             const int32_t max_size,
             std::vector<uint32_t> const& expected_key,
             std::vector<uint8_t> const& expected_level,
-            std::vector<bool> const& expected_is_parent_node,
+            std::vector<bool> const& expected_is_internal_node,
             std::vector<uint32_t> const& expected_length,
             std::vector<uint32_t> const& expected_offset)
   {
@@ -40,15 +40,15 @@ struct QuadtreeOnPointIndexingTest : public ::testing::Test {
 
     EXPECT_EQ(point_indices.size(), points.size());
 
-    auto& key_d            = tree.key;
-    auto& level_d          = tree.level;
-    auto& is_parent_node_d = tree.is_parent_node;
-    auto& length_d         = tree.length;
-    auto& offset_d         = tree.offset;
+    auto& key_d              = tree.key;
+    auto& level_d            = tree.level;
+    auto& is_internal_node_d = tree.is_internal_node;
+    auto& length_d           = tree.length;
+    auto& offset_d           = tree.offset;
 
     EXPECT_EQ(key_d.size(), expected_key.size());
     EXPECT_EQ(level_d.size(), expected_level.size());
-    EXPECT_EQ(is_parent_node_d.size(), expected_is_parent_node.size());
+    EXPECT_EQ(is_internal_node_d.size(), expected_is_internal_node.size());
     EXPECT_EQ(length_d.size(), expected_length.size());
     EXPECT_EQ(offset_d.size(), expected_offset.size());
 
@@ -56,7 +56,7 @@ struct QuadtreeOnPointIndexingTest : public ::testing::Test {
 
     expect_vector_equivalent(expected_key, key_d);
     expect_vector_equivalent(expected_level, level_d);
-    expect_vector_equivalent(expected_is_parent_node, is_parent_node_d);
+    expect_vector_equivalent(expected_is_internal_node, is_internal_node_d);
     expect_vector_equivalent(expected_length, length_d);
     expect_vector_equivalent(expected_offset, offset_d);
   }

--- a/docs/source/api_docs/spatial.rst
+++ b/docs/source/api_docs/spatial.rst
@@ -22,7 +22,9 @@ Measurement Functions
 
 .. autofunction:: cuspatial.directed_hausdorff_distance
 .. autofunction:: cuspatial.haversine_distance
+.. autofunction:: cuspatial.pairwise_point_distance
 .. autofunction:: cuspatial.pairwise_linestring_distance
+.. autofunction:: cuspatial.pairwise_point_linestring_distance
 
 Nearest Points Function
 +++++++++++++++++++++++

--- a/python/cuspatial/cuspatial/_lib/quadtree.pyx
+++ b/python/cuspatial/cuspatial/_lib/quadtree.pyx
@@ -34,6 +34,6 @@ cpdef quadtree_on_points(Column x, Column y,
         Column.from_unique_ptr(move(result.first)),
         data_from_unique_ptr(
             move(result.second),
-            column_names=["key", "level", "is_quad", "length", "offset"]
+            column_names=["key", "level", "is_internal_node", "length", "offset"]
         )
     )

--- a/python/cuspatial/cuspatial/_lib/quadtree.pyx
+++ b/python/cuspatial/cuspatial/_lib/quadtree.pyx
@@ -34,6 +34,12 @@ cpdef quadtree_on_points(Column x, Column y,
         Column.from_unique_ptr(move(result.first)),
         data_from_unique_ptr(
             move(result.second),
-            column_names=["key", "level", "is_internal_node", "length", "offset"]
+            column_names=[
+                "key",
+                "level",
+                "is_internal_node",
+                "length",
+                "offset"
+            ]
         )
     )

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -37,6 +37,9 @@ class GeoSeries(cudf.Series):
     stored in the `GeoArrowBuffers` object, accessible with the `points`,
     `multipoints`, `lines`, and `polygons` accessors.
 
+    Examples
+    --------
+
     >>> from shapely.geometry import Point
         import geopandas
         import cuspatial

--- a/python/cuspatial/cuspatial/core/spatial/indexing.py
+++ b/python/cuspatial/cuspatial/core/spatial/indexing.py
@@ -61,20 +61,19 @@ def quadtree_on_points(
                 An int32 column of quadrant keys
             level       : cudf.Series(dtype=np.int8)
                 An int8 column of quadtree levels
-            is_quad     : cudf.Series(dtype=np.bool_)
-                A boolean column indicating whether the node is a parent (true)
-                or leaf (false) node
+            is_internal_node : cudf.Series(dtype=np.bool_)
+                A boolean column indicating whether the node is a quad or leaf
             length      : cudf.Series(dtype=np.int32)
-                If this is a non-leaf quadrant (i.e. ``is_quad`` is ``True``),
-                this column's value is the number of children in the non-leaf
-                quadrant.
+                If this is a non-leaf quadrant (i.e. ``is_internal_node`` is
+                ``True``), this column's value is the number of children in
+                the non-leaf quadrant.
 
                 Otherwise this column's value is the number of points
                 contained in the leaf quadrant.
             offset      : cudf.Series(dtype=np.int32)
-                If this is a non-leaf quadrant (i.e. ``is_quad`` is ``True``),
-                this column's value is the position of the non-leaf quadrant's
-                first child.
+                If this is a non-leaf quadrant (i.e. ``is_internal_node`` is
+                ``True``), this column's value is the position of the non-leaf
+                quadrant's first child.
 
                 Otherwise this column's value is the position of the leaf
                 quadrant's first point.
@@ -143,19 +142,19 @@ def quadtree_on_points(
             )
 
         >>> print(quadtree)
-            key  level  is_quad  length  offset
-        0     0      0    False      15       0
-        1     1      0    False      27      15
-        2     2      0    False      12      42
-        3     3      0     True       4       8
-        4     4      0    False       5     106
-        5     6      0    False       6     111
-        6     9      0    False       2     117
-        7    12      0    False       1     119
-        8    12      1    False      22      54
-        9    13      1    False      18      76
-        10   14      1    False       9      94
-        11   15      1    False       3     103
+            key  level  is_internal_node  length  offset
+        0     0      0             False      15       0
+        1     1      0             False      27      15
+        2     2      0             False      12      42
+        3     3      0              True       4       8
+        4     4      0             False       5     106
+        5     6      0             False       6     111
+        6     9      0             False       2     117
+        7    12      0             False       1     119
+        8    12      1             False      22      54
+        9    13      1             False      18      76
+        10   14      1             False       9      94
+        11   15      1             False       3     103
 
         >>> print(key_to_point)
         0       63

--- a/python/cuspatial/cuspatial/core/spatial/indexing.py
+++ b/python/cuspatial/cuspatial/core/spatial/indexing.py
@@ -12,9 +12,17 @@ from cuspatial.utils.column_utils import normalize_point_columns
 
 
 def quadtree_on_points(
-    xs, ys, x_min, x_max, y_min, y_max, scale, max_depth, max_size,
+    xs,
+    ys,
+    x_min,
+    x_max,
+    y_min,
+    y_max,
+    scale,
+    max_depth,
+    max_size,
     # Deprecated, renamed to `max_size`
-    min_size
+    min_size,
 ):
     """Construct a quadtree from a set of points for a given area-of-interest
     bounding box.

--- a/python/cuspatial/cuspatial/core/spatial/indexing.py
+++ b/python/cuspatial/cuspatial/core/spatial/indexing.py
@@ -22,7 +22,7 @@ def quadtree_on_points(
     max_depth,
     max_size,
     # Deprecated, renamed to `max_size`
-    min_size,
+    min_size=None,
 ):
     """Construct a quadtree from a set of points for a given area-of-interest
     bounding box.

--- a/python/cuspatial/cuspatial/core/spatial/indexing.py
+++ b/python/cuspatial/cuspatial/core/spatial/indexing.py
@@ -12,31 +12,34 @@ from cuspatial.utils.column_utils import normalize_point_columns
 
 
 def quadtree_on_points(
-    xs, ys, x_min, x_max, y_min, y_max, scale, max_depth, min_size
+    xs, ys, x_min, x_max, y_min, y_max, scale, max_depth, max_size,
+    # Deprecated, renamed to `max_size`
+    min_size
 ):
     """Construct a quadtree from a set of points for a given area-of-interest
-        bounding box.
+    bounding box.
 
     Parameters
     ----------
     xs
-        Column of x-coordinates for each point
+        Column of x-coordinates for each point.
     ys
-        Column of y-coordinates for each point
+        Column of y-coordinates for each point.
     x_min
-        The lower-left x-coordinate of the area of interest bounding box
+        The lower-left x-coordinate of the area of interest bounding box.
     x_max
-        The upper-right x-coordinate of the area of interest bounding box
+        The upper-right x-coordinate of the area of interest bounding box.
     y_min
-        The lower-left y-coordinate of the area of interest bounding box
+        The lower-left y-coordinate of the area of interest bounding box.
     y_max
-        The upper-right y-coordinate of the area of interest bounding box
+        The upper-right y-coordinate of the area of interest bounding box.
     scale
-        Scale to apply to each point's distance from ``(x_min, y_min)``
+        Scale to apply to each point's distance from ``(x_min, y_min)``.
     max_depth
-        Maximum quadtree depth
-    min_size
-        Minimum number of points for a non-leaf quadtree node
+        Maximum quadtree depth.
+    max_size
+        Maximum number of points allowed in a node before it's split into
+        4 leaf nodes.
 
     Returns
     -------
@@ -51,7 +54,8 @@ def quadtree_on_points(
             level       : cudf.Series(dtype=np.int8)
                 An int8 column of quadtree levels
             is_quad     : cudf.Series(dtype=np.bool_)
-                A boolean column indicating whether the node is a quad or leaf
+                A boolean column indicating whether the node is a parent (true)
+                or leaf (false) node
             length      : cudf.Series(dtype=np.int32)
                 If this is a non-leaf quadrant (i.e. ``is_quad`` is ``True``),
                 this column's value is the number of children in the non-leaf
@@ -69,13 +73,26 @@ def quadtree_on_points(
 
     Notes
     -----
+
     * Swaps ``min_x`` and ``max_x`` if ``min_x > max_x``
+
     * Swaps ``min_y`` and ``max_y`` if ``min_y > max_y``
+
+    * 2D coordinates are converted into a 1D Morton code by dividing each x/y
+    by the ``scale``: (``(x - min_x) / scale`` and ``(y - min_y) / scale``).
+
+    * `max_depth` should be less than 16, since Morton codes are represented
+    as `uint32_t`. The eventual number of levels may be less than `max_depth`
+    if the number of points is small or `max_size` is large.
+
+    * All intermediate quadtree nodes will have fewer than `max_size` number of
+    points. Leaf nodes are permitted (but not guaranteed) to have >= `max_size`
+    number of points.
 
     Examples
     --------
 
-    An example of selecting the ``min_size`` and ``scale`` based on input::
+    An example of selecting the ``max_size`` and ``scale`` based on input::
 
         >>> np.random.seed(0)
         >>> points = cudf.DataFrame({
@@ -84,14 +101,14 @@ def quadtree_on_points(
             })
 
         >>> max_depth = 3
-        >>> min_size = 50
+        >>> max_size = 50
         >>> min_x, min_y, max_x, max_y = (points["x"].min(),
                                           points["y"].min(),
                                           points["x"].max(),
                                           points["y"].max())
         >>> scale = max(max_x - min_x, max_y - min_y) // (1 << max_depth)
         >>> print(
-                "min_size:   " + str(min_size) + "\\n"
+                "max_size:   " + str(max_size) + "\\n"
                 "num_points: " + str(len(points)) + "\\n"
                 "min_x:      " + str(min_x) + "\\n"
                 "max_x:      " + str(max_x) + "\\n"
@@ -99,7 +116,7 @@ def quadtree_on_points(
                 "max_y:      " + str(max_y) + "\\n"
                 "scale:      " + str(scale) + "\\n"
             )
-        min_size:   50
+        max_size:   50
         num_points: 120
         min_x:      -1577.4949079170394
         max_x:      1435.877311993804
@@ -114,7 +131,7 @@ def quadtree_on_points(
                 max_x,
                 min_y,
                 max_y,
-                scale, max_depth, min_size
+                scale, max_depth, max_size
             )
 
         >>> print(quadtree)
@@ -147,6 +164,15 @@ def quadtree_on_points(
         Length: 120, dtype: int32
     """
 
+    if min_size is not None and max_size is None:
+        max_size = min_size
+        min_size = None
+        warnings.warn(
+            "Deprecation warning: `min_size` argument has been renamed to "
+            "`max_size`. Support for the old name will be removed in the "
+            "next version."
+        )
+
     xs, ys = normalize_point_columns(as_column(xs), as_column(ys))
     x_min, x_max, y_min, y_max = (
         min(x_min, x_max),
@@ -171,6 +197,6 @@ def quadtree_on_points(
         y_max,
         max(scale, min_scale),
         max_depth,
-        min_size,
+        max_size,
     )
     return Series(key_to_point), DataFrame._from_data(*quadtree)

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -66,12 +66,13 @@ def point_in_polygon(
     # Point 1: (-8, -8) falls in the first polygon
     # Point 2: (6.0, 6.0) falls in the second polygon
 
-    note
-    input Series x and y will not be index aligned, but computed as
+    Notes
+    -----
+
+    * input Series x and y will not be index aligned, but computed as
     sequential arrays.
 
-    note
-    poly_ring_offsets must contain only the rings that make up the polygons
+    * poly_ring_offsets must contain only the rings that make up the polygons
     indexed by poly_offsets. If there are rings in poly_ring_offsets that
     are not part of the polygons in poly_offsets, results are likely to be
     incorrect and behavior is undefined.
@@ -238,7 +239,8 @@ def quadtree_point_in_polygon(
         polygon_index : cudf.Series
             Indices of each polygon with which a point intersected.
         point_index : cudf.Series
-            Indices of each point that intersects with a polygon.
+            Indices of each point (in ``point_indices``) that intersects with a
+            polygon.
     """
 
     (
@@ -311,7 +313,8 @@ def quadtree_point_to_nearest_linestring(
         between the two.
 
         point_index : cudf.Series
-            Indices of each point that intersects with a linestring.
+            Indices of each point (in ``point_indices``) that intersects with
+            a linestring.
         linestring_index : cudf.Series
             Indices of each linestring with which a point intersected.
         distance : cudf.Series

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -237,10 +237,10 @@ def quadtree_point_in_polygon(
         Indices for each intersecting point and polygon pair.
 
         polygon_index : cudf.Series
-            Indices of each polygon with which a point intersected.
+            Index of containing polygon.
         point_index : cudf.Series
-            Indices of each point (in ``point_indices``) that intersects with a
-            polygon.
+            Index of contained point. This index refers to ``point_indices``,
+            so it is an index to an index.
     """
 
     (
@@ -313,12 +313,12 @@ def quadtree_point_to_nearest_linestring(
         between the two.
 
         point_index : cudf.Series
-            Indices of each point (in ``point_indices``) that intersects with
-            a linestring.
+            Index of point. This index refers to ``point_indices``, so it is
+            an index to an index.
         linestring_index : cudf.Series
-            Indices of each linestring with which a point intersected.
+            Index of the nearest linestring to the point.
         distance : cudf.Series
-            Distances between each point and its nearest linestring.
+            Distance between point and its nearest linestring.
     """
     (
         points_x,

--- a/python/cuspatial/cuspatial/tests/spatial/indexing/test_indexing.py
+++ b/python/cuspatial/cuspatial/tests/spatial/indexing/test_indexing.py
@@ -26,7 +26,7 @@ def test_empty():
             {
                 "key": cudf.Series([], dtype=np.uint32),
                 "level": cudf.Series([], dtype=np.uint8),
-                "is_quad": cudf.Series([], dtype=np.bool_),
+                "is_internal_node": cudf.Series([], dtype=np.bool_),
                 "length": cudf.Series([], dtype=np.uint32),
                 "offset": cudf.Series([], dtype=np.uint32),
             }
@@ -50,7 +50,7 @@ def test_one_point(dtype):
             {
                 "key": cudf.Series([0], dtype=np.uint32),
                 "level": cudf.Series([0], dtype=np.uint8),
-                "is_quad": cudf.Series([0], dtype=np.bool_),
+                "is_internal_node": cudf.Series([0], dtype=np.bool_),
                 "length": cudf.Series([1], dtype=np.uint32),
                 "offset": cudf.Series([0], dtype=np.uint32),
             }
@@ -74,7 +74,7 @@ def test_two_points(dtype):
             {
                 "key": cudf.Series([0, 3], dtype=np.uint32),
                 "level": cudf.Series([0, 0], dtype=np.uint8),
-                "is_quad": cudf.Series([0, 0], dtype=np.bool_),
+                "is_internal_node": cudf.Series([0, 0], dtype=np.bool_),
                 "length": cudf.Series([1, 1], dtype=np.uint32),
                 "offset": cudf.Series([0, 1], dtype=np.uint32),
             }
@@ -258,7 +258,7 @@ def test_small_number_of_points(dtype):
                 "level": cudf.Series(
                     [0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2], dtype=np.uint8
                 ),
-                "is_quad": cudf.Series(
+                "is_internal_node": cudf.Series(
                     [1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0], dtype=np.bool_
                 ),
                 "length": cudf.Series(


### PR DESCRIPTION
* Aligns docstrings between C++ and Python
* Adds missing methods to Python docs
* Fixes #733 
* Fixes #397