### PR TITLE
Labeler: Change cpp label to libcuspatial

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Python:
   - 'python/**'
   - 'notebooks/**'
   
-c++:
+libcuspatial:
   - 'cpp/**'
 
 CMake:
@@ -18,3 +18,6 @@ gpuCI:
 
 conda:
     - 'conda/**'
+    
+Java:
+  - 'java/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Python:
   - 'python/**'
   - 'notebooks/**'
   
-cpp:
+c++:
   - 'cpp/**'
 
 CMake:
@@ -18,7 +18,3 @@ gpuCI:
 
 conda:
     - 'conda/**'
-  
-Java:
-  - 'java/**'
-  


### PR DESCRIPTION
## Description
This PR is part of a labeling cleanup and minimizaiton in cuSpatial. 

We have duplicate `cpp` and `c++` labels, but really they both refer to work on `libcuspatial`. Updating the labeler to reflect this.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
