### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Python:
   - 'python/**'
   - 'notebooks/**'
   
-cpp:
+libcuspatial:
   - 'cpp/**'
 
 CMake:
@@ -18,7 +18,6 @@ gpuCI:
 
 conda:
     - 'conda/**'
-  
+    
 Java:
   - 'java/**'
-  


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.