### PR TITLE
Don't use CMake 3.25.0 as it has a FindCUDAToolkit show stopping bug

### DIFF
--- a/conda/environments/cuspatial_dev_cuda11.5.yml
+++ b/conda/environments/cuspatial_dev_cuda11.5.yml
@@ -11,7 +11,7 @@ dependencies:
   - cudatoolkit=11.5
   - gdal>=3.0.2
   - geopandas>=0.11.0
-  - cmake>=3.23.1
+  - cmake>=3.23.1,!=3.25.0
   - cython>=0.29,<0.30
   - scikit-build>=0.13.1
   - gtest=1.10.0

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   host:
     - python
     - cython >=0.29,<0.30
-    - cmake>=3.23.1
+    - cmake>=3.23.1,!=3.25.0
     - scikit-build>=0.13.1
     - setuptools
     - cudf {{ minor_version }}.*

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 gdal_version:
   - ">3.5.0"

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -19,6 +19,6 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]


### PR DESCRIPTION
## Description
Avoid CMake 3.25.0 as it has an issue that stops cmake execution on conda envs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
