### PR TITLE
Set max version pin for `gdal`

### DIFF
--- a/conda/environments/cuspatial_dev_cuda11.5.yml
+++ b/conda/environments/cuspatial_dev_cuda11.5.yml
@@ -9,7 +9,7 @@ dependencies:
   - clang-tools=11.1.0
   - cudf=22.12.*
   - cudatoolkit=11.5
-  - gdal>=3.0.2
+  - gdal>3.5.0,<3.6.0
   - geopandas>=0.11.0
   - cmake>=3.23.1
   - cython>=0.29,<0.30

--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -11,4 +11,4 @@ sysroot_version:
   - "2.17"
 
 gdal_version:
-  - ">3.5.0"
+  - ">3.5.0,<3.6.0"

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.23.1"
 
 gdal_version:
-  - ">3.5.0"
+  - ">3.5.0,<3.6.0"
 
 gtest_version:
   - "1.10.0"


### PR DESCRIPTION
## Description

This PR sets a maximum version pin for `gdal`. Recently, `gdal` version `3.6.0` was released, which has a different version number for the `libgdal` shared object (`libgdal.so.32` vs. `libgdal.so.31`).

Setting the max pin here will ensure that we use a consistent `libgdal` shared object version for building and at runtime.

This should solve the `ImportError: libgdal.so.32: cannot open shared object file: No such file or directory` errors that have been popping up in recent Jenkins logs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
