### PR TITLE
Fix a Bug in Segment Intersection Primitive

### DIFF
--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -154,19 +154,19 @@ __forceinline__ thrust::optional<segment<T>> __device__ collinear_or_parallel_ov
   // Parallel
   if (not_float_equal(det(ab, ac), T{0})) return thrust::nullopt;
 
-  // Must be on the same line, test if intersect
-  if ((a < c && c < b) || (a < d && d < b)) {
-    // Compute smallest interval between the segments
-    if (b < a) thrust::swap(a, b);
-    if (d < c) thrust::swap(c, d);
-    auto e0 = a > c ? a : c;
-    auto e1 = b < d ? b : d;
+  // Must be on the same line, sort the endpoints
+  if (b < a) thrust::swap(a, b);
+  if (d < c) thrust::swap(c, d);
 
-    // Decondition the coordinates
-    return segment<T>{e0 + center, e1 + center};
-  }
+  // Test if not overlap
+  if (b < c || d < a) return thrust::nullopt;
 
-  return thrust::nullopt;
+  // Compute smallest interval between the segments
+  auto e0 = a > c ? a : c;
+  auto e1 = b < d ? b : d;
+
+  // Decondition the coordinates
+  return segment<T>{e0 + center, e1 + center};
 }
 
 /**

--- a/cpp/tests/experimental/operators/linestrings_test.cu
+++ b/cpp/tests/experimental/operators/linestrings_test.cu
@@ -393,3 +393,29 @@ TYPED_TEST(SegmentIntersectionTest, Overlap8)
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
+
+TYPED_TEST(SegmentIntersectionTest, Overlap9)
+{
+  using T = TypeParam;
+
+  segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
+  segment<T> cd{{0.0, 0.25}, {0.0, 0.75}};
+
+  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
+  std::vector<thrust::optional<segment<T>>> segments_expected{cd};
+
+  run_single_intersection_test(ab, cd, points_expected, segments_expected);
+}
+
+TYPED_TEST(SegmentIntersectionTest, Overlap10)
+{
+  using T = TypeParam;
+
+  segment<T> ab{{0.0, 0.25}, {0.0, 0.75}};
+  segment<T> cd{{0.0, 0.0}, {0.0, 1.0}};
+
+  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
+  std::vector<thrust::optional<segment<T>>> segments_expected{ab};
+
+  run_single_intersection_test(ab, cd, points_expected, segments_expected);
+}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

#778 introduced segment intersection primitive, but there's a subtle bug in the code. This PR fixes that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
