### PR TITLE
Add Floating Point Equality Tests to Build List

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -110,6 +110,10 @@ ConfigureTest(TRAJECTORY_BOUNDING_BOXES_TEST
 ConfigureTest(SPATIAL_WINDOW_POINT_TEST
     spatial_window/spatial_window_test.cpp)
 
+ConfigureTest(UTILITY_TEST
+    utility_test/test_float_equivalent.cu
+)
+
 # Experimental API
 ConfigureTest(HAVERSINE_TEST_EXP
     experimental/spatial/haversine_test.cu)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

#773 added a test utility that checks floating point equality based on ULP difference. However, as a blinded file checkout in #786, the line that builds tests for the floating point utility is removed by mistake. This PR adds that back.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
