### PR TITLE
Enable copy_prs. [skip gpuci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -6,3 +6,5 @@ branch_checker: true
 label_checker: true
 release_drafter: true
 external_contributors: false
+copy_prs: true
+rerun_tests: true

--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -7,4 +7,3 @@ label_checker: true
 release_drafter: true
 external_contributors: false
 copy_prs: true
-rerun_tests: true


### PR DESCRIPTION
## Description
Enables copying PRs so that GitHub Actions CI can run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
