### PR TITLE
New strict crossings multiply PIP algorithm

### DIFF
--- a/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/point_in_polygon.cuh
@@ -68,13 +68,13 @@ __global__ void point_in_polygon_kernel(Cart2dItA test_points_first,
     OffsetType poly_end =
       (poly_idx_next < num_polys) ? poly_offsets_first[poly_idx_next] : num_rings;
 
-    bool const point_is_within = is_point_in_polygon(test_point,
-                                                     poly_begin,
-                                                     poly_end,
-                                                     ring_offsets_first,
-                                                     num_rings,
-                                                     poly_points_first,
-                                                     num_poly_points);
+    bool const point_is_within = is_point_in_polygon2(test_point,
+                                                      poly_begin,
+                                                      poly_end,
+                                                      ring_offsets_first,
+                                                      num_rings,
+                                                      poly_points_first,
+                                                      num_poly_points);
 
     hit_mask |= point_is_within << poly_idx;
   }


### PR DESCRIPTION
## Description
This PR is in progress (draft).

This is a modification of the CrossingsMultiply algorithm worked out by @harrism and @isvoid that avoids explicit collinearity checks and consistently treats points on the polygon boundary as outside. While CrossingsMultiply works by shooting an imaginary ray in the +X direction from the test point and computing the inequality that results in crossings, this modification tests against +X and -X rays simultaneously.

Currently failing one of the tests, need to investigate. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
