### PR TITLE
Fix a bug preventing `align` from working with a basic slice.

### DIFF
--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -670,6 +670,12 @@ class GeoSeries(cudf.Series):
         """
 
         # Merge the two indices and sort them
+        if (
+            len(self.index) == len(other.index)
+            and (self.index == other.index).all()
+        ):
+            return self, other
+
         idx1 = cudf.DataFrame({"idx": self.index})
         idx2 = cudf.DataFrame({"idx": other.index})
         index = idx1.merge(idx2, how="outer").sort_values("idx")["idx"]

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -9,21 +9,21 @@ import cuspatial
 
 
 def test_align_more_values():
-    gpdpdf = gpd.GeoSeries(
+    gpdlhs = gpd.GeoSeries(
         [
             Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
             Polygon(((-2, -2), (-2, 2), (2, 2), (2, -2))),
         ]
     )
-    gpdshort = gpdpdf.iloc[0:1]
-    pdf = cuspatial.from_geopandas(gpdpdf)
-    short = cuspatial.from_geopandas(gpdshort)
-    expected = gpdshort.align(gpdpdf)
-    got = short.align(pdf)
+    gpdrhs = gpdlhs.iloc[0:1]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
-    expected = gpdpdf.align(gpdshort)
-    got = pdf.align(short)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
 

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -129,3 +129,55 @@ def test_align_out_of_orders_values():
     got = rhs.align(lhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_same_index():
+    gpdlhs = gpd.GeoSeries(
+        [
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdrhs = gpdlhs
+    gpdlhs.index = [0, 1, 2, 3, 4, 5]
+    gpdrhs.index = [0, 1, 2, 3, 4, 5]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_similar_index():
+    gpdlhs = gpd.GeoSeries(
+        [
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdrhs = gpdlhs
+    gpdlhs.index = [0, 1, 2, 3, 4, 5]
+    gpdrhs.index = [1, 2, 3, 4, 5, 6]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -145,8 +145,9 @@ def test_align_different_out_of_orders_values():
             Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
         ]
     )
-    gpdrhs = gpdlhs.iloc[np.random.permutation(len(gpdlhs))]
-    lhs = cuspatial.from_geopandas(gpdrhs)
+    rstate = np.random.RandomState(0)
+    gpdrhs = gpdlhs.iloc[rstate.permutation(len(gpdlhs))][0:3]
+    lhs = cuspatial.from_geopandas(gpdlhs)
     rhs = cuspatial.from_geopandas(gpdrhs)
     expected = gpdlhs.align(gpdrhs)
     got = lhs.align(rhs)

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -29,7 +29,7 @@ def test_align_more_values():
 
 
 def test_align_some_different_values():
-    gpdalign = gpd.GeoSeries(
+    gpdlhs = gpd.GeoSeries(
         [
             Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
             Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
@@ -39,9 +39,9 @@ def test_align_some_different_values():
             Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
         ]
     )
-    gpdlhs = gpdalign
-    gpdalign.index = [0, 1, 2, 6, 7, 8]
-    gpdrhs = gpdalign
+    gpdlhs = gpdlhs
+    gpdlhs.index = [0, 1, 2, 6, 7, 8]
+    gpdrhs = gpdlhs
     gpdrhs.index = [0, 1, 2, 3, 4, 5]
     lhs = cuspatial.from_geopandas(gpdlhs)
     rhs = cuspatial.from_geopandas(gpdrhs)
@@ -52,7 +52,7 @@ def test_align_some_different_values():
 
 
 def test_align_more_and_some_different_values():
-    gpdalign = gpd.GeoSeries(
+    gpdlhs = gpd.GeoSeries(
         [
             Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
             Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
@@ -62,9 +62,9 @@ def test_align_more_and_some_different_values():
             Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
         ]
     )
-    gpdrhs = gpdalign[0:3]
+    gpdrhs = gpdlhs[0:3]
     gpdrhs.index = [0, 1, 2]
-    gpdlhs = gpdalign
+    gpdlhs = gpdlhs
     gpdlhs.index = [0, 1, 2, 3, 4, 5]
     lhs = cuspatial.from_geopandas(gpdlhs)
     rhs = cuspatial.from_geopandas(gpdrhs)
@@ -79,7 +79,7 @@ def test_align_more_and_some_different_values():
 
 
 def test_align_with_slice():
-    gpdalign = gpd.GeoSeries(
+    gpdlhs = gpd.GeoSeries(
         [
             Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
             Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
@@ -89,19 +89,23 @@ def test_align_with_slice():
             Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
         ]
     )
-    align = cuspatial.from_geopandas(gpdalign)
-    gpdlhs = gpdalign[0:3]
-    gpdrhs = gpdalign[3:6]
-    lhs = align[0:3]
-    rhs = align[3:6]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    gpdlhs = gpdlhs[0:3]
+    gpdrhs = gpdlhs[3:6]
+    lhs = lhs[0:3]
+    rhs = lhs[3:6]
     expected = gpdlhs.align(gpdrhs)
     got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
 
 
 def test_align_out_of_orders_values():
-    gpdalign = gpd.GeoSeries(
+    gpdlhs = gpd.GeoSeries(
         [
             None,
             None,
@@ -114,14 +118,41 @@ def test_align_out_of_orders_values():
             Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
         ]
     )
-    gpdreordered = gpdalign.iloc[np.random.permutation(len(gpdalign))]
-    align = cuspatial.from_geopandas(gpdalign)
-    reordered = cuspatial.from_geopandas(gpdreordered)
-    expected = gpdalign.align(gpdreordered)
-    got = align.align(reordered)
+    gpdrhs = gpdlhs.iloc[np.random.permutation(len(gpdlhs))]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
-    expected = gpdreordered.align(gpdalign)
-    got = reordered.align(align)
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_different_out_of_orders_values():
+    gpdlhs = gpd.GeoSeries(
+        [
+            None,
+            None,
+            None,
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdrhs = gpdlhs.iloc[np.random.permutation(len(gpdlhs))]
+    lhs = cuspatial.from_geopandas(gpdrhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -129,31 +129,3 @@ def test_align_out_of_orders_values():
     got = rhs.align(lhs)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
-
-
-def test_align_different_out_of_orders_values():
-    gpdlhs = gpd.GeoSeries(
-        [
-            None,
-            None,
-            None,
-            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
-            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
-            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
-            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
-            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
-            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
-        ]
-    )
-    rstate = np.random.RandomState(0)
-    gpdrhs = gpdlhs.iloc[rstate.permutation(len(gpdlhs))][0:3]
-    lhs = cuspatial.from_geopandas(gpdlhs)
-    rhs = cuspatial.from_geopandas(gpdrhs)
-    expected = gpdlhs.align(gpdrhs)
-    got = lhs.align(rhs)
-    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
-    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
-    expected = gpdrhs.align(gpdlhs)
-    got = rhs.align(lhs)
-    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
-    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())

--- a/python/cuspatial/cuspatial/tests/test_align.py
+++ b/python/cuspatial/cuspatial/tests/test_align.py
@@ -8,7 +8,7 @@ from shapely.geometry import Polygon
 import cuspatial
 
 
-def test_align():
+def test_align_more_values():
     gpdpdf = gpd.GeoSeries(
         [
             Polygon(((-8, -8), (-8, 8), (8, 8), (8, -8))),
@@ -22,9 +22,85 @@ def test_align():
     got = short.align(pdf)
     pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
     pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdpdf.align(gpdshort)
+    got = pdf.align(short)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
 
 
-def test_align_reorder():
+def test_align_some_different_values():
+    gpdalign = gpd.GeoSeries(
+        [
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdlhs = gpdalign
+    gpdalign.index = [0, 1, 2, 6, 7, 8]
+    gpdrhs = gpdalign
+    gpdrhs.index = [0, 1, 2, 3, 4, 5]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_more_and_some_different_values():
+    gpdalign = gpd.GeoSeries(
+        [
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    gpdrhs = gpdalign[0:3]
+    gpdrhs.index = [0, 1, 2]
+    gpdlhs = gpdalign
+    gpdlhs.index = [0, 1, 2, 3, 4, 5]
+    lhs = cuspatial.from_geopandas(gpdlhs)
+    rhs = cuspatial.from_geopandas(gpdrhs)
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+    expected = gpdrhs.align(gpdlhs)
+    got = rhs.align(lhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_with_slice():
+    gpdalign = gpd.GeoSeries(
+        [
+            Polygon(((1, 2), (3, 4), (5, 6), (7, 8))),
+            Polygon(((9, 10), (11, 12), (13, 14), (15, 16))),
+            Polygon(((17, 18), (19, 20), (21, 22), (23, 24))),
+            Polygon(((25, 26), (27, 28), (29, 30), (31, 32))),
+            Polygon(((33, 34), (35, 36), (37, 38), (39, 40))),
+            Polygon(((41, 42), (43, 44), (45, 46), (47, 48))),
+        ]
+    )
+    align = cuspatial.from_geopandas(gpdalign)
+    gpdlhs = gpdalign[0:3]
+    gpdrhs = gpdalign[3:6]
+    lhs = align[0:3]
+    rhs = align[3:6]
+    expected = gpdlhs.align(gpdrhs)
+    got = lhs.align(rhs)
+    pd.testing.assert_series_equal(expected[0], got[0].to_pandas())
+    pd.testing.assert_series_equal(expected[1], got[1].to_pandas())
+
+
+def test_align_out_of_orders_values():
     gpdalign = gpd.GeoSeries(
         [
             None,


### PR DESCRIPTION
Closes #848 

## Description
This PR fixes a bug with `align` so that slicing a `GeoSeries`, then calling a binpred with slices of the `GeoSeries` with unmatching indexes works. It also adds a few more valid tests.

As of this PR one test still fails, I'm working on it but it feels like a rabbit hole. I'm inclined to leave the case for later:
The case that doesn't work is the hardest case wherein two `GeoSeries` have different length as well as indexes in one that is not present in the other.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
