### PR TITLE
Update `memory_usage` with tweaked sizes

### DIFF
--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -326,7 +326,7 @@ def test_memory_usage(gs):
     )
     gpu_dataframe = cuspatial.from_geopandas(host_dataframe)
     # The df size is 8kb of cudf rows and 217kb of the geometry column
-    assert gpu_dataframe.memory_usage().sum() == 225173
+    assert gpu_dataframe.memory_usage().sum() == 224945
 
 
 def test_from_dict():

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -593,4 +593,4 @@ def test_memory_usage_large():
     )
     geometry = cuspatial.from_geopandas(host_dataframe)["geometry"]
     # the geometry column from naturalearth_lowres is 217kb of coordinates
-    assert geometry.memory_usage() == 217021
+    assert geometry.memory_usage() == 216793


### PR DESCRIPTION
Upstream in cudf the `memory_usage` method seems to have changed its reporting size slightly.

This breaks CI in cuSpatial. This PR changes the memory usage test result values to reflect the minor update in cudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
