### PR TITLE
Enable `Recently Updated` Check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,5 +5,5 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-external_contributors: false
 copy_prs: true
+recently_updated: true


### PR DESCRIPTION
## Description

This PR enables a new PR check, `Recently Updated`, that is intended to be used alongside GitHub Actions.

Details on this check can be found here: https://docs.rapids.ai/resources/recently-updated/.

**Note:** The new `Recently Updated` check won't appear on PRs until _after_ this change is merged to the default branch.

Additionally, it removes the entry `external_contributors` from `ops-bot.yaml` since that setting is no longer in use.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
