### PR TITLE
Update workflows for nightly tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true
@@ -31,7 +31,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/cuspatial
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -41,7 +40,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/cuspatial
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -51,7 +49,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/cuspatial
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true
@@ -19,7 +19,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@main
     with:
       build_type: nightly
-      repo: rapidsai/cuspatial
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -28,7 +27,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
       build_type: nightly
-      repo: rapidsai/cuspatial
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
Due to some limitations on the number of reusable workflows that can be used in a given GH Action workflow, I need to switch the nightly workflow files (`build.yaml` and `test.yaml`) to use `workflow_dispatch` instead of `workflow_call`.

Because of this switch, we can also remove the hardcoded `repo` field in `{build,test}.yaml`.
