### PR TITLE
Use vector equivalence macros consistently in header-only API tests.

### DIFF
--- a/cpp/include/cuspatial_test/vector_equality.hpp
+++ b/cpp/include/cuspatial_test/vector_equality.hpp
@@ -231,10 +231,10 @@ void expect_vec_2d_pair_equivalent(PairVector1 const& expected, PairVector2 cons
   CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_second, got_second);
 }
 
-#define CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(lhs, rhs, ...)              \
-  do {                                                                  \
-    SCOPED_TRACE(" <--  line of failure\n");                            \
-    cuspatial::test::expect_vector_equivalent(lhs, rhs, ##__VA_ARGS__); \
+#define CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(lhs, rhs)     \
+  do {                                                        \
+    SCOPED_TRACE(" <--  line of failure\n");                  \
+    cuspatial::test::expect_vec_2d_pair_equivalent(lhs, rhs); \
   } while (0)
 
 #define CUSPATIAL_RUN_TEST(FUNC, ...)        \

--- a/cpp/tests/experimental/indexing/point_quadtree_test.cu
+++ b/cpp/tests/experimental/indexing/point_quadtree_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ struct QuadtreeOnPointIndexingTest : public ::testing::Test {
 
     using namespace cuspatial::test;
 
-    expect_vector_equivalent(expected_key, key_d);
-    expect_vector_equivalent(expected_level, level_d);
-    expect_vector_equivalent(expected_is_internal_node, is_internal_node_d);
-    expect_vector_equivalent(expected_length, length_d);
-    expect_vector_equivalent(expected_offset, offset_d);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_key, key_d);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_level, level_d);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_is_internal_node, is_internal_node_d);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_length, length_d);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_offset, offset_d);
   }
 };
 
@@ -74,7 +74,8 @@ TYPED_TEST(QuadtreeOnPointIndexingTest, test_empty)
   const int32_t max_size = 1;
   const T scale          = 1.0;
 
-  this->test({}, vertex_1, vertex_2, scale, max_depth, max_size, {}, {}, {}, {}, {});
+  CUSPATIAL_RUN_TEST(
+    this->test, {}, vertex_1, vertex_2, scale, max_depth, max_size, {}, {}, {}, {}, {});
 }
 
 TYPED_TEST(QuadtreeOnPointIndexingTest, test_single)
@@ -86,8 +87,18 @@ TYPED_TEST(QuadtreeOnPointIndexingTest, test_single)
   const int32_t max_size = 1;
   const T scale          = 1.0;
 
-  this->test(
-    {{0.45, 0.45}}, vertex_1, vertex_2, scale, max_depth, max_size, {0}, {0}, {false}, {1}, {0});
+  CUSPATIAL_RUN_TEST(this->test,
+                     {{0.45, 0.45}},
+                     vertex_1,
+                     vertex_2,
+                     scale,
+                     max_depth,
+                     max_size,
+                     {0},
+                     {0},
+                     {false},
+                     {1},
+                     {0});
 }
 
 TYPED_TEST(QuadtreeOnPointIndexingTest, test_two)
@@ -99,17 +110,18 @@ TYPED_TEST(QuadtreeOnPointIndexingTest, test_two)
   const int32_t max_size = 1;
   const T scale          = 1.0;
 
-  this->test({{0.45, 0.45}, {1.45, 1.45}},
-             vertex_1,
-             vertex_2,
-             scale,
-             max_depth,
-             max_size,
-             {0, 3},
-             {0, 0},
-             {false, false},
-             {1, 1},
-             {0, 1});
+  CUSPATIAL_RUN_TEST(this->test,
+                     {{0.45, 0.45}, {1.45, 1.45}},
+                     vertex_1,
+                     vertex_2,
+                     scale,
+                     max_depth,
+                     max_size,
+                     {0, 3},
+                     {0, 0},
+                     {false, false},
+                     {1, 1},
+                     {0, 1});
 }
 
 TYPED_TEST(QuadtreeOnPointIndexingTest, test_all_lowest_level_quads)
@@ -120,17 +132,18 @@ TYPED_TEST(QuadtreeOnPointIndexingTest, test_all_lowest_level_quads)
   const int8_t max_depth = 2;
   const int32_t max_size = 1;
 
-  this->test({{-100.0, -100.0}, {100.0, 100.0}},
-             vertex_1,
-             vertex_2,
-             -1,
-             max_depth,
-             max_size,
-             {3, 12, 15},
-             {0, 1, 1},
-             {true, false, false},
-             {2, 1, 1},
-             {1, 0, 1});
+  CUSPATIAL_RUN_TEST(this->test,
+                     {{-100.0, -100.0}, {100.0, 100.0}},
+                     vertex_1,
+                     vertex_2,
+                     -1,
+                     max_depth,
+                     max_size,
+                     {3, 12, 15},
+                     {0, 1, 1},
+                     {true, false, false},
+                     {2, 1, 1},
+                     {1, 0, 1});
 }
 
 TYPED_TEST(QuadtreeOnPointIndexingTest, test_small)
@@ -142,7 +155,8 @@ TYPED_TEST(QuadtreeOnPointIndexingTest, test_small)
   const int32_t max_size = 12;
   const T scale          = 1.0;
 
-  this->test(
+  CUSPATIAL_RUN_TEST(
+    this->test,
     {
       {1.9804558865545805, 1.3472225743317712},  {0.1895259128530169, 0.5431061133894604},
       {1.2591725716781235, 0.1448705855995005},  {0.8178039499335275, 0.8138440641113271},

--- a/cpp/tests/experimental/spatial/hausdorff_test.cu
+++ b/cpp/tests/experimental/spatial/hausdorff_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ struct HausdorffTest : public ::testing::Test {
 
     thrust::host_vector<T> h_distances(distances);
 
-    cuspatial::test::expect_vector_equivalent(distances, expected);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(distances, expected);
     EXPECT_EQ(num_distances, std::distance(distances.begin(), distances_end));
   }
 };
@@ -63,7 +63,7 @@ TYPED_TEST_CASE(HausdorffTest, TestTypes);
 
 TYPED_TEST(HausdorffTest, Empty)
 {
-  this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>({}, {}, {});
+  CUSPATIAL_RUN_TEST((this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>), {}, {}, {});
 }
 
 TYPED_TEST(HausdorffTest, Simple)
@@ -76,7 +76,10 @@ TYPED_TEST(HausdorffTest, Simple)
 
 TYPED_TEST(HausdorffTest, SingleTrajectorySinglePoint)
 {
-  this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>({{152.2, 2351.0}}, {{0}}, {{0.0}});
+  CUSPATIAL_RUN_TEST((this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>),
+                     {{152.2, 2351.0}},
+                     {{0}},
+                     {{0.0}});
 }
 
 TYPED_TEST(HausdorffTest, TwoShortSpaces)
@@ -87,44 +90,45 @@ TYPED_TEST(HausdorffTest, TwoShortSpaces)
 
 TYPED_TEST(HausdorffTest, TwoShortSpaces2)
 {
-  this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>(
-    {{1, 1}, {5, 12}, {4, 3}, {2, 8}, {3, 4}, {7, 7}},
-    {{0, 3, 4}},
-    {{0.0,
-      7.0710678118654755,
-      5.3851648071345037,
-      5.0000000000000000,
-      0.0,
-      4.1231056256176606,
-      5.0,
-      5.0990195135927854,
-      0.0}});
+  CUSPATIAL_RUN_TEST((this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>),
+                     {{1, 1}, {5, 12}, {4, 3}, {2, 8}, {3, 4}, {7, 7}},
+                     {{0, 3, 4}},
+                     {{0.0,
+                       7.0710678118654755,
+                       5.3851648071345037,
+                       5.0000000000000000,
+                       0.0,
+                       4.1231056256176606,
+                       5.0,
+                       5.0990195135927854,
+                       0.0}});
 }
 
 TYPED_TEST(HausdorffTest, ThreeSpacesLengths543)
 {
-  this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>({{0.0, 1.0},
-                                                               {1.0, 2.0},
-                                                               {2.0, 3.0},
-                                                               {3.0, 5.0},
-                                                               {1.0, 7.0},
-                                                               {3.0, 0.0},
-                                                               {5.0, 2.0},
-                                                               {6.0, 3.0},
-                                                               {5.0, 6.0},
-                                                               {4.0, 1.0},
-                                                               {7.0, 3.0},
-                                                               {4.0, 6.0}},
-                                                              {{0, 5, 9}},
-                                                              {{0.0000000000000000,
-                                                                4.1231056256176606,
-                                                                4.0000000000000000,
-                                                                3.6055512754639896,
-                                                                0.0000000000000000,
-                                                                1.4142135623730951,
-                                                                4.4721359549995796,
-                                                                1.4142135623730951,
-                                                                0.0000000000000000}});
+  CUSPATIAL_RUN_TEST((this->template test<cuspatial::vec_2d<TypeParam>, uint32_t>),
+                     {{0.0, 1.0},
+                      {1.0, 2.0},
+                      {2.0, 3.0},
+                      {3.0, 5.0},
+                      {1.0, 7.0},
+                      {3.0, 0.0},
+                      {5.0, 2.0},
+                      {6.0, 3.0},
+                      {5.0, 6.0},
+                      {4.0, 1.0},
+                      {7.0, 3.0},
+                      {4.0, 6.0}},
+                     {{0, 5, 9}},
+                     {{0.0000000000000000,
+                       4.1231056256176606,
+                       4.0000000000000000,
+                       3.6055512754639896,
+                       0.0000000000000000,
+                       1.4142135623730951,
+                       4.4721359549995796,
+                       1.4142135623730951,
+                       0.0000000000000000}});
 }
 
 TYPED_TEST(HausdorffTest, MoreSpacesThanPoints)
@@ -157,7 +161,7 @@ void generic_hausdorff_test()
                                                               space_offset_iter + num_spaces,
                                                               distances.begin());
 
-  cuspatial::test::expect_vector_equivalent(distances, expected);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(distances, expected);
   EXPECT_EQ(num_distances, std::distance(distances.begin(), distances_end));
 }
 

--- a/cpp/tests/experimental/spatial/haversine_test.cu
+++ b/cpp/tests/experimental/spatial/haversine_test.cu
@@ -26,7 +26,8 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct HaversineTest : public ::testing::Test {};
+struct HaversineTest : public ::testing::Test {
+};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;

--- a/cpp/tests/experimental/spatial/haversine_test.cu
+++ b/cpp/tests/experimental/spatial/haversine_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct HaversineTest : public ::testing::Test {
-};
+struct HaversineTest : public ::testing::Test {};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
@@ -47,7 +46,7 @@ TYPED_TEST(HaversineTest, Empty)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  cuspatial::test::expect_vector_equivalent(expected, distance);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, distance);
   EXPECT_EQ(0, std::distance(distance.begin(), distance_end));
 }
 
@@ -66,7 +65,7 @@ TYPED_TEST(HaversineTest, Zero)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  cuspatial::test::expect_vector_equivalent(expected, distance);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, distance);
   EXPECT_EQ(1, std::distance(distance.begin(), distance_end));
 }
 
@@ -106,7 +105,7 @@ TYPED_TEST(HaversineTest, EquivalentPoints)
   auto distance_end = cuspatial::haversine_distance(
     a_lonlat.begin(), a_lonlat.end(), b_lonlat.begin(), distance.begin());
 
-  cuspatial::test::expect_vector_equivalent(expected, distance);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, distance);
   EXPECT_EQ(2, std::distance(distance.begin(), distance_end));
 }
 
@@ -139,6 +138,6 @@ TYPED_TEST(HaversineTest, TransformIterator)
   auto distance_end =
     cuspatial::haversine_distance(xform_begin, xform_end, b_lonlat.begin(), distance.begin());
 
-  cuspatial::test::expect_vector_equivalent(expected, distance);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, distance);
   EXPECT_EQ(2, std::distance(distance.begin(), distance_end));
 }

--- a/cpp/tests/experimental/spatial/linestring_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_bounding_boxes_test.cu
@@ -25,7 +25,8 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct LinestringBoundingBoxTest : public ::testing::Test {};
+struct LinestringBoundingBoxTest : public ::testing::Test {
+};
 
 using cuspatial::vec_2d;
 using cuspatial::test::make_device_vector;

--- a/cpp/tests/experimental/spatial/linestring_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_bounding_boxes_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct LinestringBoundingBoxTest : public ::testing::Test {
-};
+struct LinestringBoundingBoxTest : public ::testing::Test {};
 
 using cuspatial::vec_2d;
 using cuspatial::test::make_device_vector;
@@ -71,7 +70,7 @@ TYPED_TEST(LinestringBoundingBoxTest, test_one)
   auto bboxes_expected =
     make_device_vector<cuspatial::box<T>>({{{1.333584, 4.586599}, {3.460720, 5.856625}}});
 
-  cuspatial::test::expect_vec_2d_pair_equivalent(bboxes, bboxes_expected);
+  CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(bboxes, bboxes_expected);
 }
 
 TYPED_TEST(LinestringBoundingBoxTest, test_small)
@@ -117,5 +116,5 @@ TYPED_TEST(LinestringBoundingBoxTest, test_small)
      {{5.5737199999999998, 0.086693000000000006}, {6.7035340000000003, 1.235638}},
      {{1.0348919999999999, 2.8969369999999999}, {3.2086600000000001, 4.5415289999999997}}});
 
-  cuspatial::test::expect_vec_2d_pair_equivalent(bboxes, bboxes_expected);
+  CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(bboxes, bboxes_expected);
 }

--- a/cpp/tests/experimental/spatial/linestring_intersection_intermediates_remove_if_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_intermediates_remove_if_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,15 +77,17 @@ struct LinestringIntersectionIntermediatesRemoveIfTest : public ::testing::Test 
     auto d_flags   = make_device_uvector<FlagType>(flags, this->stream(), this->mr());
     intermediates.remove_if(range(d_flags.begin(), d_flags.end()), this->stream());
 
-    expect_vector_equivalent(*intermediates.offsets, *expected.offsets);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.offsets, *expected.offsets);
     if constexpr (cuspatial::is_vec_2d<GeomType>())
-      expect_vector_equivalent(*intermediates.geoms, *expected.geoms);
+      CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.geoms, *expected.geoms);
     else
-      expect_vec_2d_pair_equivalent(*intermediates.geoms, *expected.geoms);
-    expect_vector_equivalent(*intermediates.lhs_linestring_ids, *expected.lhs_linestring_ids);
-    expect_vector_equivalent(*intermediates.lhs_segment_ids, *expected.lhs_segment_ids);
-    expect_vector_equivalent(*intermediates.rhs_linestring_ids, *expected.rhs_linestring_ids);
-    expect_vector_equivalent(*intermediates.rhs_segment_ids, *expected.rhs_segment_ids);
+      CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(*intermediates.geoms, *expected.geoms);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.lhs_linestring_ids,
+                                        *expected.lhs_linestring_ids);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.lhs_segment_ids, *expected.lhs_segment_ids);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.rhs_linestring_ids,
+                                        *expected.rhs_linestring_ids);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(*intermediates.rhs_segment_ids, *expected.rhs_segment_ids);
   }
 };
 

--- a/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ struct LinestringIntersectionDuplicatesTest : public ::testing::Test {
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_expected_points_offsets, *std::move(points.offsets));
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_expected_points_coords, *std::move(points.geoms));
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_expected_segments_offsets, *std::move(segments.offsets));
-    expect_vec_2d_pair_equivalent(d_expected_segments_coords, *std::move(segments.geoms));
+    CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(d_expected_segments_coords, *std::move(segments.geoms));
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_expected_point_lhs_linestring_ids,
                                         *std::move(points.lhs_linestring_ids));
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_expected_point_lhs_segment_ids,

--- a/cpp/tests/experimental/spatial/point_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/point_bounding_boxes_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ struct PointBoundingBoxesTest : public ::testing::Test {
 
     EXPECT_EQ(std::distance(bounding_boxes.begin(), boxes_end), data.num_trajectories);
 
-    cuspatial::test::expect_vec_2d_pair_equivalent(bounding_boxes, data.bounding_boxes());
+    CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(bounding_boxes, data.bounding_boxes());
   }
 };
 

--- a/cpp/tests/experimental/spatial/point_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_distance_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,7 +181,7 @@ TYPED_TEST(PairwisePointDistanceTest, Empty)
 
   auto ret_it = pairwise_point_distance(multipoint_1, multipoint_2, got.begin());
 
-  test::expect_vector_equivalent(expected, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -207,7 +207,7 @@ TYPED_TEST(PairwisePointDistanceTest, OnePairSingleComponent)
 
   auto ret_it = pairwise_point_distance(multipoint_1, multipoint_2, got.begin());
 
-  test::expect_vector_equivalent(expected, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -235,7 +235,7 @@ TYPED_TEST(PairwisePointDistanceTest, SingleComponentManyRandom)
   auto ret_it = pairwise_point_distance(multipoint_1, multipoint_2, got.begin());
   thrust::host_vector<T> hgot(got);
 
-  test::expect_vector_equivalent(hgot, expected);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(hgot, expected);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -394,7 +394,7 @@ TYPED_TEST(PairwisePointDistanceTest, SingleComponentCompareWithShapely)
   auto ret_it = pairwise_point_distance(multipoints_1, multipoints_2, got.begin());
 
   thrust::host_vector<T> hgot(got);
-  test::expect_vector_equivalent(hgot, expected);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(hgot, expected);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -419,7 +419,7 @@ TYPED_TEST(PairwisePointDistanceTest, MultiComponentSinglePair)
 
   auto ret_it = pairwise_point_distance(multipoint_1, multipoint_2, got.begin());
 
-  test::expect_vector_equivalent(expected, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 
@@ -446,7 +446,7 @@ TYPED_TEST(PairwisePointDistanceTest, MultiComponentRandom)
 
   auto ret_it = pairwise_point_distance(multipoint_1, multipoint_2, got.begin());
 
-  test::expect_vector_equivalent(expected, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, got);
   EXPECT_EQ(expected.size(), std::distance(got.begin(), ret_it));
 }
 

--- a/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,7 @@ namespace cuspatial {
 namespace test {
 
 template <typename T>
-struct PairwisePointLinestringDistanceTest : public ::testing::Test {
-};
+struct PairwisePointLinestringDistanceTest : public ::testing::Test {};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
@@ -69,7 +68,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, Empty)
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -105,7 +104,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromVectorSingleComponent
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -141,7 +140,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairFromCountingIteratorSingl
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -177,7 +176,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, TwoPairFromVectorSingleComponent
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -216,7 +215,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ManyPairsFromIteratorsSingleComp
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -377,7 +376,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePartFiftyPairsCompareWithShap
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -414,7 +413,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePairMultiPointMultiLinestring
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 
@@ -451,7 +450,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, ThreePairMultiPointMultiLinestri
 
   auto ret = pairwise_point_linestring_distance(multipoints, multilinestrings, got.begin());
 
-  expect_vector_equivalent(expect, got);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expect, got);
   EXPECT_EQ(ret, got.end());
 }
 

--- a/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
@@ -36,7 +36,8 @@ namespace cuspatial {
 namespace test {
 
 template <typename T>
-struct PairwisePointLinestringDistanceTest : public ::testing::Test {};
+struct PairwisePointLinestringDistanceTest : public ::testing::Test {
+};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;

--- a/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
@@ -35,7 +35,8 @@ using namespace cuspatial;
 using namespace cuspatial::test;
 
 template <typename T>
-struct PairwisePointLinestringNearestPointsTest : public ::testing::Test {};
+struct PairwisePointLinestringNearestPointsTest : public ::testing::Test {
+};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;

--- a/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,7 @@ using namespace cuspatial;
 using namespace cuspatial::test;
 
 template <typename T>
-struct PairwisePointLinestringNearestPointsTest : public ::testing::Test {
-};
+struct PairwisePointLinestringNearestPointsTest : public ::testing::Test {};
 
 // float and double are logically the same but would require seperate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
@@ -80,7 +79,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, Empty)
   EXPECT_EQ(nearest_point_id, std::vector<int32_t>{});
   EXPECT_EQ(nearest_linestring_parts_id, std::vector<int32_t>{});
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>{});
-  expect_vector_equivalent(neartest_point_coordinate, std::vector<vec_2d<T>>{});
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, std::vector<vec_2d<T>>{});
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -119,7 +118,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, OnePairSingleComponent)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>{1});
   auto expected_coordinate = CartVec{{0.5, 0.5}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -158,7 +157,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, NearestAtLeftEndPoint)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>{0});
   auto expected_coordinate = CartVec{{1, 1}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -197,7 +196,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, NearestAtRightEndPoint)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>{0});
   auto expected_coordinate = CartVec{{2, 2}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -237,7 +236,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, PointAtEndPoints)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>({0, 0, 1}));
   auto expected_coordinate = CartVec{{0, 0}, {1, 1}, {2, 2}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -277,7 +276,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, PointOnLineString)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>({0, 1}));
   auto expected_coordinate = CartVec{{0.5, 0.5}, {1.5, 1.5}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -317,7 +316,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, TwoPairsSingleComponent)
 
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>({1, 0}));
   auto expected_coordinate = CartVec{{0.5, 0.5}, {1.5, 0.5}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -361,7 +360,7 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, OnePairMultiComponent)
   EXPECT_EQ(nearest_linestring_linestring_id, std::vector<int32_t>({0}));
   EXPECT_EQ(nearest_linestring_segment_id, std::vector<int32_t>({0}));
   auto expected_coordinate = CartVec{{1.2189892802450228, 1.8705972434915774}};
-  expect_vector_equivalent(neartest_point_coordinate, expected_coordinate);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(neartest_point_coordinate, expected_coordinate);
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }
 
@@ -416,7 +415,8 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, ThreePairMultiComponent)
   EXPECT_EQ(thrust::host_vector<int32_t>(nearest_point_id), std::vector<int32_t>({1, 0, 0}));
   EXPECT_EQ(thrust::host_vector<int32_t>(nearest_linestring_id), std::vector<int32_t>({0, 1, 0}));
   EXPECT_EQ(thrust::host_vector<int32_t>(nearest_segment_id), std::vector<int32_t>({0, 0, 2}));
-  expect_vector_equivalent(neartest_point_coordinate,
-                           CartVec{{3.545131432802666, 2.30503517215846}, {9.9, 9.4}, {0.0, -8.7}});
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(
+    neartest_point_coordinate,
+    CartVec{{3.545131432802666, 2.30503517215846}, {9.9, 9.4}, {0.0, -8.7}});
   EXPECT_EQ(std::distance(output_it, ret), num_pairs);
 }

--- a/cpp/tests/experimental/spatial/points_in_range_test.cu
+++ b/cpp/tests/experimental/spatial/points_in_range_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ struct SpatialRangeTest : public testing::Test {
     auto result_points = DeviceVecVec<T>(result_size);
     cuspatial::copy_points_in_range(v1, v2, points.begin(), points.end(), result_points.begin());
 
-    cuspatial::test::expect_vector_equivalent(expected_points, result_points);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected_points, result_points);
   }
 };
 
@@ -66,7 +66,8 @@ TYPED_TEST(SpatialRangeTest, Empty)
   auto points          = DeviceVecVec<T>{};
   auto expected_points = DeviceVecVec<T>{};
 
-  this->spatial_range_test(Vec<T>{1.5, 1.5}, Vec<T>{5.5, 5.5}, points, expected_points);
+  CUSPATIAL_RUN_TEST(
+    this->spatial_range_test, Vec<T>{1.5, 1.5}, Vec<T>{5.5, 5.5}, points, expected_points);
 }
 
 TYPED_TEST(SpatialRangeTest, SimpleTest)
@@ -87,7 +88,8 @@ TYPED_TEST(SpatialRangeTest, SimpleTest)
 
   auto expected_points = DeviceVecVec<T>(VecVec<T>({{3.0, 2.0}, {5.0, 3.0}, {2.0, 5.0}}));
 
-  this->spatial_range_test(Vec<T>{1.5, 1.5}, Vec<T>{5.5, 5.5}, points, expected_points);
+  CUSPATIAL_RUN_TEST(
+    this->spatial_range_test, Vec<T>{1.5, 1.5}, Vec<T>{5.5, 5.5}, points, expected_points);
 }
 
 // Test that ranges with min/max reversed still work
@@ -109,7 +111,8 @@ TYPED_TEST(SpatialRangeTest, ReversedRange)
 
   auto expected_points = DeviceVecVec<T>(VecVec<T>({{3.0, 2.0}, {5.0, 3.0}, {2.0, 5.0}}));
 
-  this->spatial_range_test(Vec<T>{5.5, 5.5}, Vec<T>{1.5, 1.5}, points, expected_points);
+  CUSPATIAL_RUN_TEST(
+    this->spatial_range_test, Vec<T>{5.5, 5.5}, Vec<T>{1.5, 1.5}, points, expected_points);
 }
 
 TYPED_TEST(SpatialRangeTest, AllPointsInRange)
@@ -141,7 +144,8 @@ TYPED_TEST(SpatialRangeTest, AllPointsInRange)
                                                     {3.0, 7.0},
                                                     {6.0, 4.0}}));
 
-  this->spatial_range_test(Vec<T>{-10.0, -10.0}, Vec<T>{10.0, 10.0}, points, expected_points);
+  CUSPATIAL_RUN_TEST(
+    this->spatial_range_test, Vec<T>{-10.0, -10.0}, Vec<T>{10.0, 10.0}, points, expected_points);
 }
 
 TYPED_TEST(SpatialRangeTest, PointsOnOrNearEdges)
@@ -190,5 +194,5 @@ TYPED_TEST(SpatialRangeTest, PointsOnOrNearEdges)
   auto expected_points =
     DeviceVecVec<T>(VecVec<T>({in_ll, in_ul, in_lr, in_ur, in_left, in_right, in_bottom, in_top}));
 
-  this->spatial_range_test(v1, v2, points, expected_points);
+  CUSPATIAL_RUN_TEST(this->spatial_range_test, v1, v2, points, expected_points);
 }

--- a/cpp/tests/experimental/spatial/polygon_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/polygon_bounding_boxes_test.cu
@@ -25,7 +25,8 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct PolygonBoundingBoxTest : public ::testing::Test {};
+struct PolygonBoundingBoxTest : public ::testing::Test {
+};
 
 using cuspatial::vec_2d;
 using cuspatial::test::make_device_vector;

--- a/cpp/tests/experimental/spatial/polygon_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/polygon_bounding_boxes_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-struct PolygonBoundingBoxTest : public ::testing::Test {
-};
+struct PolygonBoundingBoxTest : public ::testing::Test {};
 
 using cuspatial::vec_2d;
 using cuspatial::test::make_device_vector;
@@ -83,7 +82,7 @@ TYPED_TEST(PolygonBoundingBoxTest, test_one)
   auto bboxes_expected =
     make_device_vector<cuspatial::box<T>>({{{1.333584, 4.586599}, {3.460720, 5.856625}}});
 
-  cuspatial::test::expect_vec_2d_pair_equivalent(bboxes, bboxes_expected);
+  CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(bboxes, bboxes_expected);
 }
 
 TYPED_TEST(PolygonBoundingBoxTest, test_small)
@@ -135,5 +134,5 @@ TYPED_TEST(PolygonBoundingBoxTest, test_small)
      {{5.5737199999999998, 0.086693000000000006}, {6.7035340000000003, 1.235638}},
      {{1.0348919999999999, 2.8969369999999999}, {3.2086600000000001, 4.5415289999999997}}});
 
-  cuspatial::test::expect_vec_2d_pair_equivalent(bboxes, bboxes_expected);
+  CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT(bboxes, bboxes_expected);
 }

--- a/cpp/tests/experimental/spatial/sinusoidal_projection_test.cu
+++ b/cpp/tests/experimental/spatial/sinusoidal_projection_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ struct SinusoidalProjectionTest : public ::testing::Test {
     auto xy_end =
       cuspatial::sinusoidal_projection(lonlats.begin(), lonlats.end(), xy_output.begin(), origin);
 
-    cuspatial::test::expect_vector_equivalent(h_expected, xy_output);
+    CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(h_expected, xy_output);
     EXPECT_EQ(h_expected.size(), std::distance(xy_output.begin(), xy_end));
   }
 };
@@ -98,7 +98,7 @@ TYPED_TEST(SinusoidalProjectionTest, Empty)
   auto origin = Loc{-90.66511046, 42.49197018};
 
   auto h_point_lonlat = std::vector<Loc>{};
-  this->run_test(h_point_lonlat, origin);
+  CUSPATIAL_RUN_TEST(this->run_test, h_point_lonlat, origin);
 }
 
 TYPED_TEST(SinusoidalProjectionTest, Single)
@@ -110,7 +110,7 @@ TYPED_TEST(SinusoidalProjectionTest, Single)
   auto origin = Loc{-90.66511046, 42.49197018};
 
   auto h_point_lonlat = std::vector<Loc>({{-90.664973, 42.493894}});
-  this->run_test(h_point_lonlat, origin);
+  CUSPATIAL_RUN_TEST(this->run_test, h_point_lonlat, origin);
 }
 
 TYPED_TEST(SinusoidalProjectionTest, Extremes)
@@ -123,7 +123,7 @@ TYPED_TEST(SinusoidalProjectionTest, Extremes)
 
   auto h_points_lonlat = std::vector<Loc>(
     {{0.0, -90.0}, {0.0, 90.0}, {-180.0, 0.0}, {180.0, 0.0}, {45.0, 0.0}, {-180.0, -90.0}});
-  this->run_test(h_points_lonlat, origin);
+  CUSPATIAL_RUN_TEST(this->run_test, h_points_lonlat, origin);
 }
 
 TYPED_TEST(SinusoidalProjectionTest, Multiple)
@@ -138,7 +138,7 @@ TYPED_TEST(SinusoidalProjectionTest, Multiple)
                                            {-90.665393, 42.491520},
                                            {-90.664976, 42.491420},
                                            {-90.664537, 42.493823}});
-  this->run_test(h_points_lonlat, origin);
+  CUSPATIAL_RUN_TEST(this->run_test, h_points_lonlat, origin);
 }
 
 TYPED_TEST(SinusoidalProjectionTest, OriginOutOfBounds)
@@ -198,6 +198,6 @@ TYPED_TEST(SinusoidalProjectionTest, TransformIterator)
 
   auto xy_end = cuspatial::sinusoidal_projection(xform_begin, xform_end, xy_output.begin(), origin);
 
-  EXPECT_EQ(expected, xy_output);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(expected, xy_output);
   EXPECT_EQ(4, std::distance(xy_output.begin(), xy_end));
 }

--- a/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
+++ b/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
@@ -37,7 +37,8 @@
 #include <cstdint>
 
 template <typename T>
-struct DeriveTrajectoriesTest : public ::testing::Test {};
+struct DeriveTrajectoriesTest : public ::testing::Test {
+};
 
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(DeriveTrajectoriesTest, TestTypes);

--- a/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
+++ b/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "cuspatial_test/vector_equality.hpp"
 #include "trajectory_test_utils.cuh"
 
 #include <cuspatial/detail/iterator.hpp>
@@ -36,8 +37,7 @@
 #include <cstdint>
 
 template <typename T>
-struct DeriveTrajectoriesTest : public ::testing::Test {
-};
+struct DeriveTrajectoriesTest : public ::testing::Test {};
 
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(DeriveTrajectoriesTest, TestTypes);
@@ -59,7 +59,7 @@ TYPED_TEST(DeriveTrajectoriesTest, OneMillionSmallTrajectories)
                                                      traj_times.begin());
 
   EXPECT_EQ(traj_ids, data.ids_sorted);
-  EXPECT_EQ(traj_points, data.points_sorted);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(traj_points, data.points_sorted);
   EXPECT_EQ(traj_times, data.times_sorted);
 }
 
@@ -80,7 +80,7 @@ TYPED_TEST(DeriveTrajectoriesTest, OneHundredLargeTrajectories)
                                                      traj_times.begin());
 
   EXPECT_EQ(traj_ids, data.ids_sorted);
-  EXPECT_EQ(traj_points, data.points_sorted);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(traj_points, data.points_sorted);
   EXPECT_EQ(traj_times, data.times_sorted);
 }
 
@@ -101,6 +101,6 @@ TYPED_TEST(DeriveTrajectoriesTest, OneVeryLargeTrajectory)
                                                      traj_times.begin());
 
   EXPECT_EQ(traj_ids, data.ids_sorted);
-  EXPECT_EQ(traj_points, data.points_sorted);
+  CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(traj_points, data.points_sorted);
   EXPECT_EQ(traj_times, data.times_sorted);
 }

--- a/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
+++ b/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,17 +90,17 @@ TYPED_TEST_CASE(TrajectoryDistancesAndSpeedsTest, TestTypes);
 
 TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneMillionSmallTrajectories)
 {
-  this->run_test(1'000'000, 50);
+  CUSPATIAL_RUN_TEST(this->run_test, 1'000'000, 50);
 }
 
 TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneHundredLargeTrajectories)
 {
-  this->run_test(100, 1'000'000);
+  CUSPATIAL_RUN_TEST(this->run_test, 100, 1'000'000);
 }
 
 TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneVeryLargeTrajectory)
 {
-  this->run_test(1, 100'000'000);
+  CUSPATIAL_RUN_TEST(this->run_test, 1, 100'000'000);
 }
 
 struct time_point_generator {


### PR DESCRIPTION
## Description

Updates all header-only API tests to consistently use the `CUSPATIAL_EXPECT_VECTORS_EQUIVALENT` and `CUSPATIAL_EXPECT_VEC2D_PAIRS_EQUIVALENT` macros. 

Fixes #638. (However there wasn't really a correctness issue.)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
