### PR TITLE
Add print_env.sh to improve bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,17 +66,18 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please paste relevant error and log output here
+      description: Please paste relevant errdor and log output here
       render: shell
 
   - type: textarea
     id: env-details
     attributes:
       label: Environment details
-      description: Please provide any relevant environment details
+      description: Please specify installation info and paste the results from print_env.sh here
       placeholder: |
-       Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
-       If method of install is Docker, provide `docker pull` & `docker run` commands used
+       + Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
+       + If method of install is Docker, provide `docker pull` & `docker run` commands used
+       + print_env.sh output
       render: shell
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,11 +73,11 @@ body:
     id: env-details
     attributes:
       label: Environment details
-      description: Please specify installation info and paste the results from print_env.sh here
+      description: Please specify installation info and paste the results from [print_env.sh](https://github.com/rapidsai/cuspatial/blob/main/print_env.sh) here
       placeholder: |
        + Environment location: [Bare-metal, Docker, Cloud(specify cloud provider)]
        + If method of install is Docker, provide `docker pull` & `docker run` commands used
-       + print_env.sh output
+       + Paste in print_env.sh (linked above) output here
       render: shell
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please paste relevant errdor and log output here
+      description: Please paste relevant error and log output here
       render: shell
 
   - type: textarea

--- a/print_env.sh
+++ b/print_env.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022, NVIDIA CORPORATION.
+# Reports relevant environment information useful for diagnosing and
+# debugging cuSpatial issues.
+# Usage:
+# "./print_env.sh" - prints to stdout
+# "./print_env.sh > env.txt" - prints to file "env.txt"
+
+print_env() {
+echo "**git***"
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]; then
+git log --decorate -n 1
+echo "**git submodules***"
+git submodule status --recursive
+else
+echo "Not inside a git repository"
+fi
+echo
+
+echo "***OS Information***"
+cat /etc/*-release
+uname -a
+echo
+
+echo "***GPU Information***"
+nvidia-smi
+echo
+
+echo "***CPU***"
+lscpu
+echo
+
+echo "***CMake***"
+which cmake && cmake --version
+echo
+
+echo "***g++***"
+which g++ && g++ --version
+echo
+
+echo "***nvcc***"
+which nvcc && nvcc --version
+echo
+
+echo "***Python***"
+which python && python -c "import sys; print('Python {0}.{1}.{2}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))"
+echo
+
+echo "***Environment Variables***"
+
+printf '%-32s: %s\n' PATH $PATH
+
+printf '%-32s: %s\n' LD_LIBRARY_PATH $LD_LIBRARY_PATH
+
+printf '%-32s: %s\n' NUMBAPRO_NVVM $NUMBAPRO_NVVM
+
+printf '%-32s: %s\n' NUMBAPRO_LIBDEVICE $NUMBAPRO_LIBDEVICE
+
+printf '%-32s: %s\n' CONDA_PREFIX $CONDA_PREFIX
+
+printf '%-32s: %s\n' PYTHON_PATH $PYTHON_PATH
+
+echo
+
+
+# Print conda packages if conda exists
+if type "conda" &> /dev/null; then
+echo '***conda packages***'
+which conda && conda list
+echo
+# Print pip packages if pip exists
+elif type "pip" &> /dev/null; then
+echo "conda not found"
+echo "***pip packages***"
+which pip && pip list
+echo
+else
+echo "conda not found"
+echo "pip not found"
+fi
+}
+
+echo "<details><summary>Click here to see environment details</summary><pre>"
+echo "     "
+print_env | while read -r line; do
+    echo "     $line"
+done
+echo "</pre></details>"


### PR DESCRIPTION
## Description
Closes #774 

- This PR adds the `print_env.sh` file from cudf to get specific environment information during bug reports. 
- The bug report template is also updated, requesting reporters to run the script and include its results.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
