### PR TITLE
pre-commit: Update isort version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
       - repo: https://github.com/PyCQA/isort
-        rev: 5.10.1
+        rev: 5.12.0
         hooks:
               - id: isort
                 # Use the config file specific to each subproject so that each


### PR DESCRIPTION
## Description

poetry version 1.5.0 broke installs of isort prior to 5.11.5 (see pycqa/isort#2077 and pycqa/isort#2078), so we need to upgrade.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
