### PR TITLE
Allow initialization of a `GeoDataFrame` using a `cudf.DataFrame`

### DIFF
--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -179,20 +179,6 @@ class GeoColumn(ColumnBase):
         )
         return result
 
-    @property
-    def valid_count(self) -> int:
-        """
-        Returns the number of valid geometries stored in this GeoColumn.
-        """
-        return self._meta.input_types.valid_count
-
-    def has_nulls(self) -> bool:
-        """
-        Returns True if any of the geometries stored in this GeoColumn are
-        null.
-        """
-        return self._meta.input_types.has_nulls
-
     @classmethod
     def _from_points_xy(cls, points_xy: ColumnBase):
         """

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -179,6 +179,20 @@ class GeoColumn(ColumnBase):
         )
         return result
 
+    @property
+    def valid_count(self) -> int:
+        """
+        Returns the number of valid geometries stored in this GeoColumn.
+        """
+        return self._meta.input_types.valid_count
+
+    def has_nulls(self) -> bool:
+        """
+        Returns True if any of the geometries stored in this GeoColumn are
+        null.
+        """
+        return self._meta.input_types.has_nulls
+
     @classmethod
     def _from_points_xy(cls, points_xy: ColumnBase):
         """

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -27,7 +27,8 @@ class GeoDataFrame(cudf.DataFrame):
 
         Parameters
         ----------
-        data : A geopandas.GeoDataFrame object
+        data : A geopandas.GeoDataFrame object, a cudf.DataFrame object,
+        or a dictionary of objects that can be converted to a GeoDataFrame.
         """
         super().__init__()
         if isinstance(data, (gpGeoDataFrame, cudf.DataFrame)):

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -19,7 +19,9 @@ class GeoDataFrame(cudf.DataFrame):
     A GPU GeoDataFrame object.
     """
 
-    def __init__(self, data: Union[Dict, gpGeoDataFrame] = None):
+    def __init__(
+        self, data: Union[Dict, gpGeoDataFrame, cudf.DataFrame] = None
+    ):
         """
         Constructs a GPU GeoDataFrame from a GeoPandas dataframe.
 
@@ -28,7 +30,7 @@ class GeoDataFrame(cudf.DataFrame):
         data : A geopandas.GeoDataFrame object
         """
         super().__init__()
-        if isinstance(data, gpGeoDataFrame):
+        if isinstance(data, (gpGeoDataFrame, cudf.DataFrame)):
             self.index = data.index
             for col in data.columns:
                 if is_geometry_type(data[col]):

--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -440,3 +440,9 @@ def test_reset_index(level, drop, inplace, col_level, col_fill):
         expected = gpdf
         got = gdf
     pd.testing.assert_frame_equal(expected, got.to_pandas())
+
+
+def test_cudf_dataframe_init():
+    df = cudf.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    gdf = cuspatial.GeoDataFrame(df)
+    assert_eq_geo_df(gdf.to_pandas(), df.to_pandas())


### PR DESCRIPTION
## Description
Certain cudf operations like `.merge` return a `cudf.DataFrame`, which then doesn't understand the `geometry` column contained within. Until we've worked out a way to build `ExtensionDtypes` for cudf, the `cudf.DataFrame` needs to be converted back to a `GeoDataFrame` for use with cuspatial. This PR adds a new valid constructor argument of type `cudf.DataFrame` to `__init__` for `GeoDataFrame`.

Closes #893 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
