### PR TITLE
`_from_point_xy` improvements

### DIFF
--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -187,7 +187,7 @@ class GeoColumn(ColumnBase):
         Create a GeoColumn of only single points from a cudf Series with
         interleaved xy coordinates.
         """
-        if not np.finfo(points_xy.dtypes).kind == "f":
+        if not points_xy.dtype.kind == "f":
             raise ValueError("Coordinates must be floating point numbers.")
 
         if len(points_xy) % 2 != 0:

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -3,7 +3,6 @@ from functools import cached_property
 from typing import Tuple, TypeVar
 
 import cupy as cp
-import numpy as np
 import pyarrow as pa
 
 import cudf

--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -3,12 +3,14 @@ from functools import cached_property
 from typing import Tuple, TypeVar
 
 import cupy as cp
+import numpy as np
 import pyarrow as pa
 
 import cudf
-from cudf.core.column import ColumnBase, as_column, build_list_column
+from cudf.core.column import ColumnBase, arange, as_column, build_list_column
 
 from cuspatial.core._column.geometa import Feature_Enum, GeoMeta
+from cuspatial.utils.column_utils import empty_geometry_column
 
 T = TypeVar("T", bound="GeoColumn")
 
@@ -185,6 +187,9 @@ class GeoColumn(ColumnBase):
         Create a GeoColumn of only single points from a cudf Series with
         interleaved xy coordinates.
         """
+        if not np.finfo(points_xy.dtypes).kind == "f":
+            raise ValueError("Coordinates must be floating point numbers.")
+
         if len(points_xy) % 2 != 0:
             raise ValueError("points_xy must have an even number of elements")
 
@@ -202,16 +207,23 @@ class GeoColumn(ColumnBase):
             }
         )
 
-        indices = as_column(cp.arange(0, num_points * 2 + 1, 2), dtype="int32")
+        indices = arange(0, num_points * 2 + 1, 2, dtype="int32")
         point_col = build_list_column(
             indices=indices, elements=points_xy, size=num_points
         )
+        coord_dtype = points_xy.dtype
         return cls(
             (
                 cudf.Series(point_col),
-                cudf.Series(),
-                cudf.Series(),
-                cudf.Series(),
+                cudf.Series(
+                    empty_geometry_column(Feature_Enum.MULTIPOINT, coord_dtype)
+                ),
+                cudf.Series(
+                    empty_geometry_column(Feature_Enum.LINESTRING, coord_dtype)
+                ),
+                cudf.Series(
+                    empty_geometry_column(Feature_Enum.POLYGON, coord_dtype)
+                ),
             ),
             meta,
         )

--- a/python/cuspatial/cuspatial/core/dtypes.py
+++ b/python/cuspatial/cuspatial/core/dtypes.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+from cudf.core.dtypes import ListDtype
+
+
+def point_dtype(base_dtype):
+    return ListDtype(base_dtype)
+
+
+def multipoint_dtype(base_dtype):
+    return ListDtype(ListDtype(base_dtype))
+
+
+def linestring_dtype(base_dtype):
+    return ListDtype(ListDtype(ListDtype(base_dtype)))
+
+
+def polygon_dtype(base_dtype):
+    return ListDtype(ListDtype(ListDtype(ListDtype(base_dtype))))

--- a/python/cuspatial/cuspatial/utils/column_utils.py
+++ b/python/cuspatial/cuspatial/utils/column_utils.py
@@ -1,10 +1,19 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from typing import TypeVar
 
 import numpy as np
 
 from cudf.api.types import is_datetime_dtype
+from cudf.core.column.column import column_empty
+
+from cuspatial.core._column.geometa import Feature_Enum
+from cuspatial.core.dtypes import (
+    linestring_dtype,
+    multipoint_dtype,
+    point_dtype,
+    polygon_dtype,
+)
 
 GeoSeries = TypeVar("GeoSeries", bound="GeoSeries")
 
@@ -115,3 +124,15 @@ def has_same_geometry(lhs: GeoSeries, rhs: GeoSeries):
         return True
     else:
         return False
+
+
+def empty_geometry_column(feature: Feature_Enum, base_type):
+    """Return a geometry column of type `feature`. Length is 0."""
+    if feature == Feature_Enum.POINT:
+        return column_empty(0, point_dtype(base_type), masked=False)
+    elif feature == Feature_Enum.MULTIPOINT:
+        return column_empty(0, multipoint_dtype(base_type), masked=False)
+    elif feature == Feature_Enum.LINESTRING:
+        return column_empty(0, linestring_dtype(base_type), masked=False)
+    elif feature == Feature_Enum.POLYGON:
+        return column_empty(0, polygon_dtype(base_type), masked=False)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR fixes #888, raises when input is not an integer array.

This PR also fixes a bug in `_from_point_xy` where empty series other than points are incorrectly constructed. An empty linestring array should be properly nested with the leaf column containing 0 elements. Currently it is constructed as a flat array, resulting in a ill-constructed geocolumn.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
