### PR TITLE
Fix broken `point_indices` methods in `PolygonGeoColumnAccessor`

### DIFF
--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -209,7 +209,6 @@ class GeoSeries(cudf.Series):
         def point_indices(self):
             # Return a cupy.ndarray containing the index values from the
             # LineString GeoSeries that each individual point is member of.
-            # offsets = cp.array(self.part_offset)
             offsets = self.part_offset.take(self.geometry_offset)
             sizes = offsets[1:] - offsets[:-1]
             return cp.repeat(self._series.index, sizes)

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -209,7 +209,8 @@ class GeoSeries(cudf.Series):
         def point_indices(self):
             # Return a cupy.ndarray containing the index values from the
             # LineString GeoSeries that each individual point is member of.
-            offsets = cp.array(self.part_offset)
+            # offsets = cp.array(self.part_offset)
+            offsets = self.part_offset.take(self.geometry_offset)
             sizes = offsets[1:] - offsets[:-1]
             return cp.repeat(self._series.index, sizes)
 
@@ -237,9 +238,12 @@ class GeoSeries(cudf.Series):
         def point_indices(self):
             # Return a cupy.ndarray containing the index values from the
             # Polygon GeoSeries that each individual point is member of.
-            offsets = cp.array(self.ring_offset)
+            offsets = self.ring_offset.take(self.part_offset).take(
+                self.geometry_offset
+            )
             sizes = offsets[1:] - offsets[:-1]
-            return cp.repeat(self._series.index, sizes)
+
+            return self._series.index.repeat(sizes).values
 
     @property
     def points(self):

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -624,7 +624,7 @@ def test_reset_index(level, drop, name, inplace):
         pd.testing.assert_frame_equal(expected, got.to_pandas())
 
 
-def test_geocolumn_polygon_accessor(naturalearth_lowres):
+def test_geocolumn_polygon_accessor():
     s = gpd.GeoSeries(
         [
             Polygon([(0.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Closes #891 , fixes an issue in `point_indices`. Previously, the point indices are computed with the ring offset, but the target index is mean to denote the (multi)polygon index, so we need to compute an array of offset corresponding to geometry offset. This can be computed via nested gathers.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
