### PR TITLE
Update `.gitignore` for `ops-codeowners`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,5 @@ python/            @rapidsai/cuspatial-python-codeowners
 # build/ops code owners
 .github/           @rapidsai/ops-codeowners
 ci/                @rapidsai/ops-codeowners
-conda/             @rapidsai/ops-codeowners
-**/Dockerfile      @rapidsai/ops-codeowners
-**/.dockerignore   @rapidsai/ops-codeowners
+/conda/            @rapidsai/ops-codeowners
 dependencies.yaml  @rapidsai/ops-codeowners


### PR DESCRIPTION
This PR updates the `.gitignore` file to make the following changes:

- Removes `ops-codeowners` from being responsible for Dockerfiles. We don't need to be alerted about changes to Dockerfiles
- Ensures that we only get alerted about `conda/` directory changes from the root `conda/` directory (and not sub `conda/` directories like those added in https://github.com/rapidsai/cuspatial/pull/960).

I skipped CI on this PR since these changes aren't tested by CI.

This PR can be admin-merged pending approval.