### PR TITLE
[REVIEW] Fix docs build to be `pydata-sphinx-theme=0.13.0` compatible

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@ extensions = [
     "myst_parser"
 ]
 
-jupyter_execute_notebooks = "force"
-execution_timeout = 300
+nb_execution_mode = "force"
+nb_execution_timeout = 300
 
 copybutton_prompt_text = ">>> "
 autosummary_generate = True
@@ -74,6 +74,8 @@ todo_include_todos = False
 
 html_theme_options = {
     "external_links": [],
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "github_url": "https://github.com/rapidsai/cuspatial",
     "twitter_url": "https://twitter.com/rapidsai",
     "show_toc_level": 1,


### PR DESCRIPTION
## Description
This PR fixes `cuspatial` docs build to be compatible with `pydata-sphinx-theme=0.13.0` by adding an empty `icon_links` entry.



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
