### PR TITLE
Update aarch64 to GCC 11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
           - matrix:
               arch: aarch64
             packages:
-              - &gcc_aarch64 gcc_linux-aarch64=9.*
+              - &gcc_aarch64 gcc_linux-aarch64=11.*
               - &sysroot_aarch64 sysroot_linux-aarch64==2.17
       - output_types: conda
         matrices:


### PR DESCRIPTION
This PR updates aarch64 dependencies to use GCC 11. Follow-up to #961.