### PR TITLE
Pass `AWS_SESSION_TOKEN` and `SCCACHE_S3_USE_SSL` vars to conda build

### DIFF
--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -19,6 +19,7 @@ build:
   script_env:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
@@ -29,6 +30,7 @@ build:
     - SCCACHE_REGION
     - SCCACHE_S3_KEY_PREFIX=cuspatial-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=cuspatial-linux64 # [linux64]
+    - SCCACHE_S3_USE_SSL
   ignore_run_exports_from:
     - {{ compiler('cuda') }}
 

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -17,6 +17,7 @@ build:
   script_env:
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
@@ -27,6 +28,7 @@ build:
     - SCCACHE_REGION
     - SCCACHE_S3_KEY_PREFIX=libcuspatial-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=libcuspatial-linux64 # [linux64]
+    - SCCACHE_S3_USE_SSL
 
 requirements:
   build:


### PR DESCRIPTION
This PR ensures that the `AWS_SESSION_TOKEN` and `SCCACHE_S3_USE_SSL` environment variables are passed to our conda build process.

`AWS_SESSION_TOKEN` is necessary in order to support using temporary credentials via AWS STS (we recently adopted this method in CI).

`SCCACHE_S3_USE_SSL` has been reported to increase cache performance for S3.
