### PR TITLE
Add codespell as a linter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Describe the issue
       description: Please provide a complete and succinct description of the problem, including what you expected to happen.
-      placeholder: XYZ occured, I expected QRS results
+      placeholder: XYZ occurred, I expected QRS results
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -61,7 +61,7 @@ body:
     attributes:
       label: Describe any alternatives you have considered
       description: List any other libraries, or approaches you have looked at or tried.
-      placeholder: I have looked at library xyz and qrs, but they do not offer GPU accleration
+      placeholder: I have looked at library xyz and qrs, but they do not offer GPU acceleration
 
   - type: textarea
     id: misc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,15 @@ repos:
               - id: clang-format
                 types_or: [c, c++, cuda]
                 args: ["-fallback-style=none", "-style=file", "-i"]
+      - repo: https://github.com/codespell-project/codespell
+        rev: v2.2.4
+        hooks:
+              - id: codespell
+                exclude: |
+                  (?x)^(
+                    pyproject.toml|
+                    data/
+                  )
+
 default_language_version:
       python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,8 @@ repos:
         rev: v2.2.4
         hooks:
               - id: codespell
-                exclude: |
-                  (?x)^(
-                    pyproject.toml|
-                    data/
-                  )
+                args: ["--config pyproject.toml"]
+                additional_dependencies: ["tomli"]
 
 default_language_version:
       python: python3

--- a/cpp/include/cuspatial/detail/utility/device_atomics.cuh
+++ b/cpp/include/cuspatial/detail/utility/device_atomics.cuh
@@ -62,7 +62,7 @@ const T __device__ max_(const T a, const T b)
  * @tparam ToRepFuncType The type of function to cast `T` to `RepresentationType`
  * @tparam FromRepFuncType The type of function to cast `RepresentationType` to T
  * @param addr The address where the atomic operation will be performed
- * @param val The right hand side value of the opeartion
+ * @param val The right hand side value of the operation
  * @param op The atomic operation to perform
  * @param to_rep_func The function to cast `T` to `RepresentationType`, see notes below.
  * @param from_rep_func The function to cast `RepresentationType` to `T`, see notes below.

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -225,7 +225,7 @@ bool __device__ is_point_on_segment(segment<T> const& segment, vec_2d<T> const& 
 }
 
 /*
- * @brief Given two segments, if they are mergable, return the merged result. Otherwise return
+ * @brief Given two segments, if they are mergeable, return the merged result. Otherwise return
  * nullopt.
  */
 template <typename T>

--- a/cpp/include/cuspatial/experimental/detail/find/find_duplicate_points.cuh
+++ b/cpp/include/cuspatial/experimental/detail/find/find_duplicate_points.cuh
@@ -57,7 +57,7 @@ void __global__ find_duplicate_points_kernel_simple(MultiPointRange multipoints,
  * @brief For each multipoint, find the duplicate points.
  *
  * If a point has duplicates, all but one flags for the duplicates will be set to 1.
- * There is no gaurentee which of the duplicates will not be set.
+ * There is no guarantee which of the duplicates will not be set.
  */
 template <typename MultiPointRange, typename OutputIt>
 void find_duplicate_points(MultiPointRange multipoints,

--- a/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
+++ b/cpp/include/cuspatial/experimental/detail/hausdorff.cuh
@@ -61,7 +61,7 @@ constexpr auto magnitude_squared(T a, T b)
  * this is the first step to computing Hausdorff distance. The second step of computing Hausdorff
  * distance is to determine the maximum of these minimums, which is done by each thread writing
  * it's minimum to the output using atomicMax. This is done once per thread per RHS space. Once
- * all threads have run to completion, all "maximums of the minumum distances" (aka, directed
+ * all threads have run to completion, all "maximums of the minimum distances" (aka, directed
  * Hausdorff distances) reside in the output.
  *
  * @tparam T type of coordinate, either float or double.

--- a/cpp/include/cuspatial/experimental/detail/indexing/construction/phase_2.cuh
+++ b/cpp/include/cuspatial/experimental/detail/indexing/construction/phase_2.cuh
@@ -189,7 +189,7 @@ inline rmm::device_uvector<uint32_t> compute_parent_positions(
   rmm::cuda_stream_view stream)
 {
   // Compute parent node start positions
-  // Wraped in an IIFE so `position_map` is freed on return
+  // Wrapped in an IIFE so `position_map` is freed on return
   auto parent_pos = [&]() {
     rmm::device_uvector<uint32_t> position_map(num_parent_nodes, stream);
     // line 1 of algorithm in Fig. 5 in ref.

--- a/cpp/include/cuspatial/experimental/detail/is_point_in_polygon.cuh
+++ b/cpp/include/cuspatial/experimental/detail/is_point_in_polygon.cuh
@@ -28,7 +28,7 @@ namespace detail {
  *
  * Implemented based on Eric Haines's crossings-multiply algorithm:
  * See "Crossings test" section of http://erich.realtimerendering.com/ptinpoly/
- * The improvement in addenda is also addopted to remove divisions in this kernel.
+ * The improvement in addenda is also adopted to remove divisions in this kernel.
  *
  * TODO: the ultimate goal of refactoring this as independent function is to remove
  * src/utility/point_in_polygon.cuh and its usage in quadtree_point_in_polygon.cu. It isn't

--- a/cpp/include/cuspatial/experimental/detail/linestring_intersection.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_intersection.cuh
@@ -156,7 +156,7 @@ std::unique_ptr<rmm::device_uvector<types_t>> compute_types_buffer(
 /**
  * @brief Compute union column's offset buffer
  *
- * This is performing a group-by cummulative sum (pandas semantic) operation
+ * This is performing a group-by cumulative sum (pandas semantic) operation
  * to an "all 1s vector", using `types_buffer` as the key column.
  */
 template <typename index_t>
@@ -233,7 +233,7 @@ linestring_intersection_result<T, index_t> pairwise_linestring_intersection(
   points.remove_if(range(point_flags.begin(), point_flags.end()), stream);
   point_flags.resize(points.geoms->size(), stream);
 
-  // Merge mergable segments
+  // Merge mergeable segments
   rmm::device_uvector<uint8_t> segment_flags(num_segments, stream);
   detail::find_and_combine_segment(
     segments.offset_range(), segments.geom_range(), segment_flags.begin(), stream);

--- a/cpp/include/cuspatial/experimental/detail/linestring_intersection_with_duplicates.cuh
+++ b/cpp/include/cuspatial/experimental/detail/linestring_intersection_with_duplicates.cuh
@@ -80,7 +80,7 @@ namespace intersection_functors {
  *  `GeometryCollectionOffset[reduced_key[0]] == 1`.
  *  `reduced_values[0] == 0` geometries should be subtracted from offset.
  *
- *  `i == 4`, `j == 1`, the last non-empty list that preceds list 4 ends at
+ *  `i == 4`, `j == 1`, the last non-empty list that precedes list 4 ends at
  *  `GeometryCollectionOffset[reduced_key[1]] == 3`.
  *  `reduced_values[1] == 2` geometries should be subtracted from offset.
  *
@@ -116,7 +116,7 @@ struct offsets_update_functor {
       reduced_keys_begin,
       thrust::prev(thrust::upper_bound(thrust::seq, reduced_keys_begin, reduced_keys_end, i)));
     // j < 0 happens when all groups that precedes `i` don't contain any geometry
-    // offset must be 0 and shouldn't be subracted.
+    // offset must be 0 and shouldn't be subtracted.
     if (j < 0) return offset;
 
     return offset - reduced_values_begin[j];

--- a/cpp/include/cuspatial/experimental/iterator_factory.cuh
+++ b/cpp/include/cuspatial/experimental/iterator_factory.cuh
@@ -210,7 +210,7 @@ auto make_vec_2d_iterator(FirstIter first, SecondIter second)
 /**
  * @brief Create an iterator to `vec_2d` data from a single iterator.
  *
- * Creates a vec2d view from an interator to the starting range of interleaved x-y coordinates.
+ * Creates a vec2d view from an iterator to the starting range of interleaved x-y coordinates.
  *
  * @tparam
  * @param d_points_begin

--- a/cpp/include/cuspatial/experimental/ranges/range.cuh
+++ b/cpp/include/cuspatial/experimental/ranges/range.cuh
@@ -33,7 +33,7 @@ namespace cuspatial {
  * provide implicit device-host transfer. It is up to developer's prudence not to access device
  * memory from host or the reverse.
  *
- * @tparam Type of both start and end iterator. IteratorType must statisfy
+ * @tparam Type of both start and end iterator. IteratorType must satisfy
  * LegacyRandomAccessIterator[LinkLRAI].
  *
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator

--- a/cpp/include/cuspatial_test/random.cuh
+++ b/cpp/include/cuspatial_test/random.cuh
@@ -46,7 +46,7 @@ enum class distribution_id : int8_t {
 };
 
 /**
- * @brief Real Type that has atleast number of bits of integral type in its mantissa.
+ * @brief Real Type that has at least number of bits of integral type in its mantissa.
  *  number of bits of integrals < 23 bits of mantissa in float
  * to allow full range of integer bits to be generated.
  * @tparam T integral type

--- a/cpp/include/cuspatial_test/vector_factories.cuh
+++ b/cpp/include/cuspatial_test/vector_factories.cuh
@@ -150,7 +150,7 @@ class multipoint_array {
  * make_multipoints_array({{P{0.0, 1.0}, P{2.0, 0.0}}, {}, {P{3.0, 4.0}}});
  *
  * Example: Construct an empty multilinestring array:
- * make_multipoints_array<float>({}); // Explict parameter required to deduce type.
+ * make_multipoints_array<float>({}); // Explicit parameter required to deduce type.
  *
  * @tparam T Type of coordinate
  * @param inl List of multipoints

--- a/cpp/src/join/quadtree_point_to_nearest_linestring.cu
+++ b/cpp/src/join/quadtree_point_to_nearest_linestring.cu
@@ -194,7 +194,7 @@ struct compute_quadtree_point_to_nearest_linestring {
       //     pl_pairs_and_dist.append((point, linestring, min_distance(point, linestring)))
       // ```
       //
-      // However, the above psuedocode produces values in an order such that the distance
+      // However, the above pseudocode produces values in an order such that the distance
       // from a point to each linestring cannot be reduced with `thrust::reduce_by_key`:
       // ```
       //   point | linestring | distance

--- a/cpp/src/utility/double_boolean_dispatch.hpp
+++ b/cpp/src/utility/double_boolean_dispatch.hpp
@@ -22,7 +22,7 @@
 namespace cuspatial {
 
 /**
- * @brief Invokes an `operator()` template with the instantiation based on the specificed
+ * @brief Invokes an `operator()` template with the instantiation based on the specified
  * `opt1` and `opt2` value.
  * This dispatcher effectively converts the runtime information of two boolean variables
  * to compile time. This is useful when an API accepts an `std::optional` argument,

--- a/cpp/src/utility/multi_geometry_dispatch.hpp
+++ b/cpp/src/utility/multi_geometry_dispatch.hpp
@@ -25,7 +25,7 @@ namespace cuspatial {
 using T = collection_type_id;
 
 /**
- * @brief Invokes an `operator()` template with the instantiation based on the specificed
+ * @brief Invokes an `operator()` template with the instantiation based on the specified
  * `lhs_type` and `rhs_type` value.
  *
  * This dispatcher effectively converts the runtime information of `collection_type_id` variables

--- a/cpp/tests/experimental/spatial/haversine_test.cu
+++ b/cpp/tests/experimental/spatial/haversine_test.cu
@@ -29,7 +29,7 @@ template <typename T>
 struct HaversineTest : public ::testing::Test {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(HaversineTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_distance_test.cu
@@ -35,7 +35,7 @@ struct PairwiseLinestringDistanceTest : public ::testing::Test {
 struct PairwiseLinestringDistanceTestUntyped : public ::testing::Test {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(PairwiseLinestringDistanceTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/linestring_intersection_count_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_count_test.cu
@@ -42,7 +42,7 @@ struct LinestringIntersectionCountTest : public ::testing::Test {
   rmm::cuda_stream_view default_stream() { return rmm::cuda_stream_default; }
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(LinestringIntersectionCountTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/linestring_intersection_intermediates_remove_if_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_intermediates_remove_if_test.cu
@@ -91,7 +91,7 @@ struct LinestringIntersectionIntermediatesRemoveIfTest : public ::testing::Test 
   }
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(LinestringIntersectionIntermediatesRemoveIfTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/linestring_intersection_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_test.cu
@@ -232,7 +232,7 @@ struct LinestringIntersectionTest : public ::testing::Test {
   }
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(LinestringIntersectionTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
@@ -200,7 +200,7 @@ struct LinestringIntersectionDuplicatesTest : public ::testing::Test {
   }
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(LinestringIntersectionDuplicatesTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_distance_test.cu
@@ -39,7 +39,7 @@ template <typename T>
 struct PairwisePointLinestringDistanceTest : public ::testing::Test {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(PairwisePointLinestringDistanceTest, TestTypes);
 
@@ -225,7 +225,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePartFiftyPairsCompareWithShap
   using T       = TypeParam;
   using CartVec = std::vector<vec_2d<T>>;
 
-  // All point coordinates are confined in [-1e9, 0] inverval
+  // All point coordinates are confined in [-1e9, 0] interval
   auto d_points_x = rmm::device_vector<T>(std::vector<T>{
     -561549155.2815765,  -539635297.7968571,  -749785291.9823582,  -505256232.2383667,
     -946988876.2831948,  -662300741.9693683,  -603237481.1662251,  -125581339.4351779,
@@ -256,7 +256,7 @@ TYPED_TEST(PairwisePointLinestringDistanceTest, OnePartFiftyPairsCompareWithShap
     -815538168.7101089,  -805543247.7590245,  -213668210.4341381,  -734828450.688499,
     -718181825.0574478,  -646533731.4391378});
 
-  // All point coordinates are confined in [0, 1e9] inverval
+  // All point coordinates are confined in [0, 1e9] interval
   auto d_linestring_points_x = rmm::device_vector<T>(
     std::vector<T>{409740620.3189557,  136924984.5824146,  380403413.55319613, 870222466.1573819,
                    635018282.0970114,  525659618.01626,    571907477.7659363,  275007048.105586,

--- a/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
+++ b/cpp/tests/experimental/spatial/point_linestring_nearest_points_test.cu
@@ -38,7 +38,7 @@ template <typename T>
 struct PairwisePointLinestringNearestPointsTest : public ::testing::Test {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(PairwisePointLinestringNearestPointsTest, TestTypes);
 

--- a/cpp/tests/experimental/spatial/sinusoidal_projection_test.cu
+++ b/cpp/tests/experimental/spatial/sinusoidal_projection_test.cu
@@ -85,7 +85,7 @@ struct SinusoidalProjectionTest : public ::testing::Test {
   }
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(SinusoidalProjectionTest, TestTypes);
 

--- a/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
+++ b/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
@@ -74,7 +74,7 @@ struct TrajectoryDistancesAndSpeedsTest : public ::testing::Test {
     // For speed, there is an additional division. There is also accumulated error in the reductions
     // and we find k_ulps == 10 reliably results in the expected computation matching the actual
     // computation for large trajectories with disparate positions and increasing timestamps.
-    // This value and the magnitude of the values involed (e.g. max distance) are used to scale
+    // This value and the magnitude of the values involved (e.g. max distance) are used to scale
     // the machine epsilon to come up with an absolute error tolerance.
 
     int k_ulps           = 10;

--- a/cpp/tests/join/point_in_polygon_test_small.cpp
+++ b/cpp/tests/join/point_in_polygon_test_small.cpp
@@ -31,7 +31,7 @@
 
 /*
  * A small test that it is suitable for manually visualizing point-polygon pairing results in a GIS
- * environment GPU results are compared with expected values embeded in code However, the number of
+ * environment GPU results are compared with expected values embedded in code However, the number of
  * points in each quadrant is less than 32, the two kernels for point-in-polygon test are not fully
  * tested. This is left for pip_refine_test_large.
  */

--- a/cpp/tests/join/point_to_nearest_linestring_test_small.cpp
+++ b/cpp/tests/join/point_to_nearest_linestring_test_small.cpp
@@ -33,7 +33,7 @@
 
 /*
  * A small test that it is suitable for manually visualizing point-polygon pairing results in a GIS
- * environment GPU results are compared with expected values embeded in code However, the number of
+ * environment GPU results are compared with expected values embedded in code However, the number of
  * points in each quadrant is less than 32, the two kernels for point-in-polygon test are not fully
  * tested. This is left for pip_refine_test_large.
  */

--- a/cpp/tests/spatial/haversine_test.cpp
+++ b/cpp/tests/spatial/haversine_test.cpp
@@ -35,7 +35,7 @@ template <typename T>
 struct HaversineTest : public BaseFixture {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = Types<double>;
 TYPED_TEST_CASE(HaversineTest, TestTypes);
 

--- a/cpp/tests/spatial/sinusoidal_projection_test.cu
+++ b/cpp/tests/spatial/sinusoidal_projection_test.cu
@@ -33,7 +33,7 @@ template <typename T>
 struct SinusoidalProjectionTest : public BaseFixture {
 };
 
-// float and double are logically the same but would require seperate tests due to precision.
+// float and double are logically the same but would require separate tests due to precision.
 using TestTypes = Types<double>;
 TYPED_TEST_CASE(SinusoidalProjectionTest, TestTypes);
 

--- a/data/json2soa.cpp
+++ b/data/json2soa.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
     }
     const char * in_name=argv[1];
     const char * out_root=argv[2];
- 	enum FILEDS {time_id=0, objid_id,bbox_id,location_id,coordinate_id};
+ 	enum FIELDS {time_id=0, objid_id,bbox_id,location_id,coordinate_id};
     const char * out_ext[NUM_FIELDS]={".time",".objectid",".bbox",".location",".coordinate"};
 
  	FILE *in_fp=fopen(in_name,"r");
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
 		//printf("s=%s t=%s:%3d %d\n",t_str,asctime(&it),in_mili,it.tm_year);
 
 		Time ot;
-        ot.y = it.tm_year - 100;//shifting starting year from 1900 to 2000, max 64 years allowd
+        ot.y = it.tm_year - 100;//shifting starting year from 1900 to 2000, max 64 years allowed
         ot.m =it.tm_mon;
         ot.d =it.tm_mday;
         ot.hh=it.tm_hour;

--- a/docs/source/developer_guide/library_design.md
+++ b/docs/source/developer_guide/library_design.md
@@ -96,7 +96,7 @@ APIs should accept a `GeoSeries` or `GeoDataFrame` as input. Developers
 may extract geometry offsets and coordinates via cuSpatial's geometry
 accessors such as `GeoSeries.points`, `GeoSeries.multipoints`,
 `GeoSeries.lines`, `GeoSeries.polygons`. Developer can then pass the geometries
-offsets and corrdinate arrays to Cython APIs.
+offsets and coordinate arrays to Cython APIs.
 
 ## Cython Layer
 

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -61,7 +61,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_70,code=sm_70 -g
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")
 
 # set warnings as errors
-# TODO: remove `no-maybe-unitialized` used to suppress warnings in rmm::exec_policy
+# TODO: remove `no-maybe-uninitialized` used to suppress warnings in rmm::exec_policy
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ force-exclude = '''
 [tool.codespell]
 # note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
 # this is only to allow you to run codespell interactively
-skip = "./pyproject.toml,./.git,./.github,./cpp/build,.*egg-info.*,./.mypy_cache,./data"
+skip = "./pyproject.toml,./.git,./cpp/build,.*egg-info.*,./.mypy_cache"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout"
+ignore-words-list = "inout,unparseable"
 builtin = "clear"
 quiet-level = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,13 @@ force-exclude = '''
     dist
 )/
 '''
+
+[tool.codespell]
+# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
+# this is only to allow you to run codespell interactively
+skip = "./pyproject.toml,./.git,./.github,./cpp/build,.*egg-info.*,./.mypy_cache,./data"
+# ignore short words, and typename parameters like OffsetT
+ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
+ignore-words-list = "inout"
+builtin = "clear"
+quiet-level = 3

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 if(NOT cuspatial_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will
   # pull in the required languages for the C++ project even if this project
-  # does not require those languges.
+  # does not require those languages.
   include(rapids-cuda)
   rapids_cuda_init_architectures(cuspatial)
   enable_language(CUDA)

--- a/python/cuspatial/versioneer.py
+++ b/python/cuspatial/versioneer.py
@@ -179,7 +179,7 @@ two common reasons why `setup.py` might not be in the root:
   `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
   distributions (and upload multiple independently-installable tarballs).
 * Source trees whose main purpose is to contain a C library, but which also
-  provide bindings to Python (and perhaps other langauges) in subdirectories.
+  provide bindings to Python (and perhaps other languages) in subdirectories.
 
 Versioneer will look for `.git` in parent directories, and most operations
 should get the right version string. However `pip` and `setuptools` have bugs


### PR DESCRIPTION
## Description
Following the example of https://github.com/rapidsai/cudf/pull/12097, this PR adds [codespell](https://github.com/codespell-project/codespell) as a linter for cuspatial.

Note: I have not included a section in the CONTRIBUTING.md about how to use this (as was done in cudf's PR) because I plan to overhaul the contributing guides for all RAPIDS repos in the near term, and have a single source in docs.rapids.ai with common information about linters used in RAPIDS.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
