### PR TITLE
Reduce gtest times

### DIFF
--- a/cpp/tests/experimental/spatial/hausdorff_test.cu
+++ b/cpp/tests/experimental/spatial/hausdorff_test.cu
@@ -167,6 +167,6 @@ void generic_hausdorff_test()
 
 TYPED_TEST(HausdorffTest, 500Spaces100Points) { generic_hausdorff_test<TypeParam, 500, 100>(); }
 
-TYPED_TEST(HausdorffTest, 10000Spaces10Points) { generic_hausdorff_test<TypeParam, 10000, 10>(); }
+TYPED_TEST(HausdorffTest, 1000Spaces10Points) { generic_hausdorff_test<TypeParam, 1000, 10>(); }
 
 TYPED_TEST(HausdorffTest, 10Spaces10000Points) { generic_hausdorff_test<TypeParam, 10, 10000>(); }

--- a/cpp/tests/experimental/spatial/point_bounding_boxes_test.cu
+++ b/cpp/tests/experimental/spatial/point_bounding_boxes_test.cu
@@ -60,13 +60,13 @@ struct PointBoundingBoxesTest : public ::testing::Test {
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(PointBoundingBoxesTest, TestTypes);
 
-TYPED_TEST(PointBoundingBoxesTest, OneMillionSmallTrajectories) { this->run_test(1'000'000, 50); }
+TYPED_TEST(PointBoundingBoxesTest, TenThousandSmallTrajectories) { this->run_test(10'000, 50); }
 
-TYPED_TEST(PointBoundingBoxesTest, OneHundredLargeTrajectories) { this->run_test(100, 1'000'000); }
+TYPED_TEST(PointBoundingBoxesTest, OneHundredLargeTrajectories) { this->run_test(100, 10'000); }
 
-TYPED_TEST(PointBoundingBoxesTest, OneVeryLargeTrajectory) { this->run_test(1, 100'000'000); }
+TYPED_TEST(PointBoundingBoxesTest, OneVeryLargeTrajectory) { this->run_test(1, 1'000'000); }
 
 TYPED_TEST(PointBoundingBoxesTest, TrajectoriesWithExpansion)
 {
-  this->run_test(1'000'000, 50, TypeParam{0.5});
+  this->run_test(10'000, 50, TypeParam{0.5});
 }

--- a/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
+++ b/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
@@ -37,15 +37,14 @@
 #include <cstdint>
 
 template <typename T>
-struct DeriveTrajectoriesTest : public ::testing::Test {
-};
+struct DeriveTrajectoriesTest : public ::testing::Test {};
 
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(DeriveTrajectoriesTest, TestTypes);
 
-TYPED_TEST(DeriveTrajectoriesTest, OneMillionSmallTrajectories)
+TYPED_TEST(DeriveTrajectoriesTest, TenThousandSmallTrajectories)
 {
-  auto data = cuspatial::test::trajectory_test_data<TypeParam>(1'000'000, 50);
+  auto data = cuspatial::test::trajectory_test_data<TypeParam>(10'000, 50);
 
   auto traj_ids    = rmm::device_vector<std::int32_t>(data.ids.size());
   auto traj_points = rmm::device_vector<cuspatial::vec_2d<TypeParam>>(data.points.size());
@@ -66,7 +65,7 @@ TYPED_TEST(DeriveTrajectoriesTest, OneMillionSmallTrajectories)
 
 TYPED_TEST(DeriveTrajectoriesTest, OneHundredLargeTrajectories)
 {
-  auto data = cuspatial::test::trajectory_test_data<TypeParam>(100, 1'000'000);
+  auto data = cuspatial::test::trajectory_test_data<TypeParam>(100, 10'000);
 
   auto traj_ids    = rmm::device_vector<std::int32_t>(data.ids.size());
   auto traj_points = rmm::device_vector<cuspatial::vec_2d<TypeParam>>(data.points.size());
@@ -87,7 +86,7 @@ TYPED_TEST(DeriveTrajectoriesTest, OneHundredLargeTrajectories)
 
 TYPED_TEST(DeriveTrajectoriesTest, OneVeryLargeTrajectory)
 {
-  auto data = cuspatial::test::trajectory_test_data<TypeParam>(1, 100'000'000);
+  auto data = cuspatial::test::trajectory_test_data<TypeParam>(1, 1'000'000);
 
   auto traj_ids    = rmm::device_vector<std::int32_t>(data.ids.size());
   auto traj_points = rmm::device_vector<cuspatial::vec_2d<TypeParam>>(data.points.size());

--- a/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
+++ b/cpp/tests/experimental/trajectory/derive_trajectories_test.cu
@@ -37,7 +37,8 @@
 #include <cstdint>
 
 template <typename T>
-struct DeriveTrajectoriesTest : public ::testing::Test {};
+struct DeriveTrajectoriesTest : public ::testing::Test {
+};
 
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(DeriveTrajectoriesTest, TestTypes);

--- a/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
+++ b/cpp/tests/experimental/trajectory/trajectory_distances_and_speeds_test.cu
@@ -88,19 +88,19 @@ struct TrajectoryDistancesAndSpeedsTest : public ::testing::Test {
 using TestTypes = ::testing::Types<float, double>;
 TYPED_TEST_CASE(TrajectoryDistancesAndSpeedsTest, TestTypes);
 
-TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneMillionSmallTrajectories)
+TYPED_TEST(TrajectoryDistancesAndSpeedsTest, TenThousandSmallTrajectories)
 {
-  CUSPATIAL_RUN_TEST(this->run_test, 1'000'000, 50);
+  CUSPATIAL_RUN_TEST(this->run_test, 10'000, 50);
 }
 
 TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneHundredLargeTrajectories)
 {
-  CUSPATIAL_RUN_TEST(this->run_test, 100, 1'000'000);
+  CUSPATIAL_RUN_TEST(this->run_test, 100, 10'000);
 }
 
 TYPED_TEST(TrajectoryDistancesAndSpeedsTest, OneVeryLargeTrajectory)
 {
-  CUSPATIAL_RUN_TEST(this->run_test, 1, 100'000'000);
+  CUSPATIAL_RUN_TEST(this->run_test, 1, 1'000'000);
 }
 
 struct time_point_generator {

--- a/cpp/tests/utility_test/test_geometry_generators.cu
+++ b/cpp/tests/utility_test/test_geometry_generators.cu
@@ -315,8 +315,8 @@ TEST_P(GeometryFactoryCountVerificationTest, CountsVerification)
 INSTANTIATE_TEST_SUITE_P(
   GeometryFactoryCountVerificationTests,
   GeometryFactoryCountVerificationTest,
-  ::testing::Combine(::testing::Values<std::size_t>(1, 1000),  // num_multipolygons
-                     ::testing::Values<std::size_t>(1, 30),    // num_polygons_per_multipolygon
-                     ::testing::Values<std::size_t>(0, 100),   // num_holes_per_polygon
-                     ::testing::Values<std::size_t>(3, 100)    // num_sides_per_ring
+  ::testing::Combine(::testing::Values<std::size_t>(1, 100),  // num_multipolygons
+                     ::testing::Values<std::size_t>(1, 30),   // num_polygons_per_multipolygon
+                     ::testing::Values<std::size_t>(0, 100),  // num_holes_per_polygon
+                     ::testing::Values<std::size_t>(3, 100)   // num_sides_per_ring
                      ));


### PR DESCRIPTION
## Description
Fixes #1017. 

Reduces C++ gtest total time (on my PC) from 47.9 seconds to 20.08 seconds.

Several tests were running large datasets and combinations of size parameters that would be better to run as benchmarks rather than gtests. Reducing these by a factor of 10-100 saves a lot of development time and still exercises the code. In the case of `HausdorffTest/1.10000Spaces10Points (4850 ms)`, reducing it to 1000 spaces, 10 points reduced the time by nearly 100x, likely because it's $O(N^2)$. 

I modified any test that used close to 1s or more total time, since most column-API tests use under that, and most header-only tests use under 0.2s. 


| Test | Time Before (s) | Time After (s)  | Speedup |
|---|---|---|---|
| DERIVE_TRAJECTORIES_TEST_EXP | 14.49 | 0.27 | 53.7x |
| HAUSDORFF_TEST_EXP | 9.21 | 0.26 | 35.4x |
| UTILITY_TEST | 1.86 | 0.30 | 6.2x |
|  POINT_BOUNDING_BOXES_TEST_EXP | 1.35 | 0.15 | 9x |
| TRAJECTORY_DISTANCES_AND_SPEEDS_TEST_EXP | 0.80 | 0.13 | 6.2x |
| TOTAL | 47.9 | 20.08 | 2.4x |


Before:

```
(rapids) coder ➜ ~/cuspatial/cpp/build/release $ ninja test
[0/1] Running tests...
Test project /home/coder/cuspatial/cpp/build/release
      Start  1: SINUSOIDAL_PROJECTION_TEST
 1/45 Test  #1: SINUSOIDAL_PROJECTION_TEST .................   Passed    0.81 sec
      Start  2: HAVERSINE_TEST
 2/45 Test  #2: HAVERSINE_TEST .............................   Passed    0.77 sec
      Start  3: HAUSDORFF_TEST
 3/45 Test  #3: HAUSDORFF_TEST .............................   Passed    0.75 sec
      Start  4: JOIN_POINT_TO_LINESTRING_SMALL_TEST
 4/45 Test  #4: JOIN_POINT_TO_LINESTRING_SMALL_TEST ........   Passed    0.73 sec
      Start  5: JOIN_POINT_IN_POLYGON_TEST
 5/45 Test  #5: JOIN_POINT_IN_POLYGON_TEST .................   Passed    0.79 sec
      Start  6: POINT_IN_POLYGON_TEST
 6/45 Test  #6: POINT_IN_POLYGON_TEST ......................   Passed    0.80 sec
      Start  7: PAIRWISE_POINT_IN_POLYGON_TEST
 7/45 Test  #7: PAIRWISE_POINT_IN_POLYGON_TEST .............   Passed    0.76 sec
      Start  8: POINT_QUADTREE_TEST
 8/45 Test  #8: POINT_QUADTREE_TEST ........................   Passed    0.76 sec
      Start  9: LINESTRING_BOUNDING_BOXES_TEST
 9/45 Test  #9: LINESTRING_BOUNDING_BOXES_TEST .............   Passed    0.76 sec
      Start 10: POLYGON_BOUNDING_BOXES_TEST
10/45 Test #10: POLYGON_BOUNDING_BOXES_TEST ................   Passed    0.80 sec
      Start 11: POINT_DISTANCE_TEST
11/45 Test #11: POINT_DISTANCE_TEST ........................   Passed    0.79 sec
      Start 12: POINT_LINESTRING_DISTANCE_TEST
12/45 Test #12: POINT_LINESTRING_DISTANCE_TEST .............   Passed    0.78 sec
      Start 13: LINESTRING_DISTANCE_TEST
13/45 Test #13: LINESTRING_DISTANCE_TEST ...................   Passed    0.78 sec
      Start 14: POINT_POLYGON_DISTANCE_TEST
14/45 Test #14: POINT_POLYGON_DISTANCE_TEST ................   Passed    0.76 sec
      Start 15: LINESTRING_INTERSECTION_TEST
15/45 Test #15: LINESTRING_INTERSECTION_TEST ...............   Passed    0.83 sec
      Start 16: POINT_LINESTRING_NEAREST_POINT_TEST
16/45 Test #16: POINT_LINESTRING_NEAREST_POINT_TEST ........   Passed    0.77 sec
      Start 17: QUADTREE_POLYGON_FILTERING_TEST
17/45 Test #17: QUADTREE_POLYGON_FILTERING_TEST ............   Passed    0.79 sec
      Start 18: QUADTREE_LINESTRING_FILTERING_TEST
18/45 Test #18: QUADTREE_LINESTRING_FILTERING_TEST .........   Passed    0.76 sec
      Start 19: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST
19/45 Test #19: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST .......   Passed    0.79 sec
      Start 20: DERIVE_TRAJECTORIES_TEST
20/45 Test #20: DERIVE_TRAJECTORIES_TEST ...................   Passed    0.76 sec
      Start 21: TRAJECTORY_BOUNDING_BOXES_TEST
21/45 Test #21: TRAJECTORY_BOUNDING_BOXES_TEST .............   Passed    0.75 sec
      Start 22: SPATIAL_WINDOW_POINT_TEST
22/45 Test #22: SPATIAL_WINDOW_POINT_TEST ..................   Passed    0.75 sec
      Start 23: UTILITY_TEST
23/45 Test #23: UTILITY_TEST ...............................   Passed    1.86 sec
      Start 24: HAVERSINE_TEST_EXP
24/45 Test #24: HAVERSINE_TEST_EXP .........................   Passed    0.14 sec
      Start 25: POINT_DISTANCE_TEST_EXP
25/45 Test #25: POINT_DISTANCE_TEST_EXP ....................   Passed    0.11 sec
      Start 26: POINT_LINESTRING_DISTANCE_TEST_EXP
26/45 Test #26: POINT_LINESTRING_DISTANCE_TEST_EXP .........   Passed    0.11 sec
      Start 27: POINT_POLYGON_DISTANCE_TEST_EXP
27/45 Test #27: POINT_POLYGON_DISTANCE_TEST_EXP ............   Passed    0.13 sec
      Start 28: HAUSDORFF_TEST_EXP
28/45 Test #28: HAUSDORFF_TEST_EXP .........................   Passed    9.21 sec
      Start 29: LINESTRING_DISTANCE_TEST_EXP
29/45 Test #29: LINESTRING_DISTANCE_TEST_EXP ...............   Passed    0.17 sec
      Start 30: LINESTRING_INTERSECTION_TEST_EXP
30/45 Test #30: LINESTRING_INTERSECTION_TEST_EXP ...........   Passed    0.19 sec
      Start 31: POINT_LINESTRING_NEAREST_POINT_TEST_EXP
31/45 Test #31: POINT_LINESTRING_NEAREST_POINT_TEST_EXP ....   Passed    0.12 sec
      Start 32: SINUSOIDAL_PROJECTION_TEST_EXP
32/45 Test #32: SINUSOIDAL_PROJECTION_TEST_EXP .............   Passed    0.12 sec
      Start 33: POINTS_IN_RANGE_TEST_EXP
33/45 Test #33: POINTS_IN_RANGE_TEST_EXP ...................   Passed    0.11 sec
      Start 34: POINT_IN_POLYGON_TEST_EXP
34/45 Test #34: POINT_IN_POLYGON_TEST_EXP ..................   Passed    0.12 sec
      Start 35: PAIRWISE_POINT_IN_POLYGON_TEST_EXP
35/45 Test #35: PAIRWISE_POINT_IN_POLYGON_TEST_EXP .........   Passed    0.11 sec
      Start 36: DERIVE_TRAJECTORIES_TEST_EXP
36/45 Test #36: DERIVE_TRAJECTORIES_TEST_EXP ...............   Passed   14.49 sec
      Start 37: POINT_BOUNDING_BOXES_TEST_EXP
37/45 Test #37: POINT_BOUNDING_BOXES_TEST_EXP ..............   Passed    1.35 sec
      Start 38: POLYGON_BOUNDING_BOXES_TEST_EXP
38/45 Test #38: POLYGON_BOUNDING_BOXES_TEST_EXP ............   Passed    0.11 sec
      Start 39: LINESTRING_BOUNDING_BOXES_TEST_EXP
39/45 Test #39: LINESTRING_BOUNDING_BOXES_TEST_EXP .........   Passed    0.11 sec
      Start 40: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST_EXP
40/45 Test #40: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST_EXP ...   Passed    0.80 sec
      Start 41: POINT_QUADTREE_TEST_EXP
41/45 Test #41: POINT_QUADTREE_TEST_EXP ....................   Passed    0.12 sec
      Start 42: OPERATOR_TEST_EXP
42/45 Test #42: OPERATOR_TEST_EXP ..........................   Passed    0.14 sec
      Start 43: FIND_TEST_EXP
43/45 Test #43: FIND_TEST_EXP ..............................   Passed    0.13 sec
      Start 44: JOIN_POINT_IN_POLYGON_SMALL_TEST_EXP
44/45 Test #44: JOIN_POINT_IN_POLYGON_SMALL_TEST_EXP .......   Passed    0.11 sec
      Start 45: JOIN_POINT_IN_POLYGON_LARGE_TEST_EXP
45/45 Test #45: JOIN_POINT_IN_POLYGON_LARGE_TEST_EXP .......   Passed    0.13 sec

100% tests passed, 0 tests failed out of 45

Total Test time (real) =  47.07 sec
```

After:

```
(rapids) coder ➜ ~/cuspatial/cpp/build/release $ ninja test
[0/1] Running tests...
Test project /home/coder/cuspatial/cpp/build/release
      Start  1: SINUSOIDAL_PROJECTION_TEST
 1/45 Test  #1: SINUSOIDAL_PROJECTION_TEST .................   Passed    0.78 sec
      Start  2: HAVERSINE_TEST
 2/45 Test  #2: HAVERSINE_TEST .............................   Passed    0.75 sec
      Start  3: HAUSDORFF_TEST
 3/45 Test  #3: HAUSDORFF_TEST .............................   Passed    0.74 sec
      Start  4: JOIN_POINT_TO_LINESTRING_SMALL_TEST
 4/45 Test  #4: JOIN_POINT_TO_LINESTRING_SMALL_TEST ........   Passed    0.77 sec
      Start  5: JOIN_POINT_IN_POLYGON_TEST
 5/45 Test  #5: JOIN_POINT_IN_POLYGON_TEST .................   Passed    0.76 sec
      Start  6: POINT_IN_POLYGON_TEST
 6/45 Test  #6: POINT_IN_POLYGON_TEST ......................   Passed    0.78 sec
      Start  7: PAIRWISE_POINT_IN_POLYGON_TEST
 7/45 Test  #7: PAIRWISE_POINT_IN_POLYGON_TEST .............   Passed    0.74 sec
      Start  8: POINT_QUADTREE_TEST
 8/45 Test  #8: POINT_QUADTREE_TEST ........................   Passed    0.75 sec
      Start  9: LINESTRING_BOUNDING_BOXES_TEST
 9/45 Test  #9: LINESTRING_BOUNDING_BOXES_TEST .............   Passed    0.75 sec
      Start 10: POLYGON_BOUNDING_BOXES_TEST
10/45 Test #10: POLYGON_BOUNDING_BOXES_TEST ................   Passed    0.73 sec
      Start 11: POINT_DISTANCE_TEST
11/45 Test #11: POINT_DISTANCE_TEST ........................   Passed    0.73 sec
      Start 12: POINT_LINESTRING_DISTANCE_TEST
12/45 Test #12: POINT_LINESTRING_DISTANCE_TEST .............   Passed    0.74 sec
      Start 13: LINESTRING_DISTANCE_TEST
13/45 Test #13: LINESTRING_DISTANCE_TEST ...................   Passed    0.76 sec
      Start 14: POINT_POLYGON_DISTANCE_TEST
14/45 Test #14: POINT_POLYGON_DISTANCE_TEST ................   Passed    0.76 sec
      Start 15: LINESTRING_INTERSECTION_TEST
15/45 Test #15: LINESTRING_INTERSECTION_TEST ...............   Passed    0.78 sec
      Start 16: POINT_LINESTRING_NEAREST_POINT_TEST
16/45 Test #16: POINT_LINESTRING_NEAREST_POINT_TEST ........   Passed    0.77 sec
      Start 17: QUADTREE_POLYGON_FILTERING_TEST
17/45 Test #17: QUADTREE_POLYGON_FILTERING_TEST ............   Passed    0.75 sec
      Start 18: QUADTREE_LINESTRING_FILTERING_TEST
18/45 Test #18: QUADTREE_LINESTRING_FILTERING_TEST .........   Passed    0.77 sec
      Start 19: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST
19/45 Test #19: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST .......   Passed    0.74 sec
      Start 20: DERIVE_TRAJECTORIES_TEST
20/45 Test #20: DERIVE_TRAJECTORIES_TEST ...................   Passed    0.75 sec
      Start 21: TRAJECTORY_BOUNDING_BOXES_TEST
21/45 Test #21: TRAJECTORY_BOUNDING_BOXES_TEST .............   Passed    0.74 sec
      Start 22: SPATIAL_WINDOW_POINT_TEST
22/45 Test #22: SPATIAL_WINDOW_POINT_TEST ..................   Passed    0.75 sec
      Start 23: UTILITY_TEST
23/45 Test #23: UTILITY_TEST ...............................   Passed    0.30 sec
      Start 24: HAVERSINE_TEST_EXP
24/45 Test #24: HAVERSINE_TEST_EXP .........................   Passed    0.12 sec
      Start 25: POINT_DISTANCE_TEST_EXP
25/45 Test #25: POINT_DISTANCE_TEST_EXP ....................   Passed    0.12 sec
      Start 26: POINT_LINESTRING_DISTANCE_TEST_EXP
26/45 Test #26: POINT_LINESTRING_DISTANCE_TEST_EXP .........   Passed    0.12 sec
      Start 27: POINT_POLYGON_DISTANCE_TEST_EXP
27/45 Test #27: POINT_POLYGON_DISTANCE_TEST_EXP ............   Passed    0.13 sec
      Start 28: HAUSDORFF_TEST_EXP
28/45 Test #28: HAUSDORFF_TEST_EXP .........................   Passed    0.26 sec
      Start 29: LINESTRING_DISTANCE_TEST_EXP
29/45 Test #29: LINESTRING_DISTANCE_TEST_EXP ...............   Passed    0.14 sec
      Start 30: LINESTRING_INTERSECTION_TEST_EXP
30/45 Test #30: LINESTRING_INTERSECTION_TEST_EXP ...........   Passed    0.19 sec
      Start 31: POINT_LINESTRING_NEAREST_POINT_TEST_EXP
31/45 Test #31: POINT_LINESTRING_NEAREST_POINT_TEST_EXP ....   Passed    0.11 sec
      Start 32: SINUSOIDAL_PROJECTION_TEST_EXP
32/45 Test #32: SINUSOIDAL_PROJECTION_TEST_EXP .............   Passed    0.11 sec
      Start 33: POINTS_IN_RANGE_TEST_EXP
33/45 Test #33: POINTS_IN_RANGE_TEST_EXP ...................   Passed    0.13 sec
      Start 34: POINT_IN_POLYGON_TEST_EXP
34/45 Test #34: POINT_IN_POLYGON_TEST_EXP ..................   Passed    0.11 sec
      Start 35: PAIRWISE_POINT_IN_POLYGON_TEST_EXP
35/45 Test #35: PAIRWISE_POINT_IN_POLYGON_TEST_EXP .........   Passed    0.14 sec
      Start 36: DERIVE_TRAJECTORIES_TEST_EXP
36/45 Test #36: DERIVE_TRAJECTORIES_TEST_EXP ...............   Passed    0.27 sec
      Start 37: POINT_BOUNDING_BOXES_TEST_EXP
37/45 Test #37: POINT_BOUNDING_BOXES_TEST_EXP ..............   Passed    0.15 sec
      Start 38: POLYGON_BOUNDING_BOXES_TEST_EXP
38/45 Test #38: POLYGON_BOUNDING_BOXES_TEST_EXP ............   Passed    0.13 sec
      Start 39: LINESTRING_BOUNDING_BOXES_TEST_EXP
39/45 Test #39: LINESTRING_BOUNDING_BOXES_TEST_EXP .........   Passed    0.12 sec
      Start 40: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST_EXP
40/45 Test #40: TRAJECTORY_DISTANCES_AND_SPEEDS_TEST_EXP ...   Passed    0.13 sec
      Start 41: POINT_QUADTREE_TEST_EXP
41/45 Test #41: POINT_QUADTREE_TEST_EXP ....................   Passed    0.14 sec
      Start 42: OPERATOR_TEST_EXP
42/45 Test #42: OPERATOR_TEST_EXP ..........................   Passed    0.14 sec
      Start 43: FIND_TEST_EXP
43/45 Test #43: FIND_TEST_EXP ..............................   Passed    0.15 sec
      Start 44: JOIN_POINT_IN_POLYGON_SMALL_TEST_EXP
44/45 Test #44: JOIN_POINT_IN_POLYGON_SMALL_TEST_EXP .......   Passed    0.12 sec
      Start 45: JOIN_POINT_IN_POLYGON_LARGE_TEST_EXP
45/45 Test #45: JOIN_POINT_IN_POLYGON_LARGE_TEST_EXP .......   Passed    0.13 sec

100% tests passed, 0 tests failed out of 45

Total Test time (real) =  20.08 sec
```

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
