### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/cpp/include/cuspatial/experimental/detail/distance_utils.cuh
+++ b/cpp/include/cuspatial/experimental/detail/distance_utils.cuh
@@ -106,6 +106,7 @@ rmm::device_uvector<uint8_t> point_polygon_intersects(MultiPointRange multipoint
                         point_intersects.begin(),
                         thrust::make_discard_iterator(),
                         multipoint_intersects.begin(),
+                        thrust::equal_to<index_t>(),
                         thrust::logical_or<uint8_t>());
 
   return multipoint_intersects;

--- a/cpp/tests/experimental/spatial/point_polygon_distance_test.cu
+++ b/cpp/tests/experimental/spatial/point_polygon_distance_test.cu
@@ -488,7 +488,7 @@ TYPED_TEST(PairwisePointPolygonDistanceTest, OnePairMultiPointOnePolygon2)
 }
 
 // Multipoint tests: 2 multipoints - 2 polygons.
-TYPED_TEST(PairwisePointPolygonDistanceTest, TwoPairMultiPointOnePolygon2)
+TYPED_TEST(PairwisePointPolygonDistanceTest, TwoPairMultiPointOnePolygon)
 {
   using T = TypeParam;
   using P = vec_2d<T>;
@@ -501,6 +501,21 @@ TYPED_TEST(PairwisePointPolygonDistanceTest, TwoPairMultiPointOnePolygon2)
     {0, 5, 9},
     {P{-1, -1}, P{1, -1}, P{1, 1}, P{-1, 1}, P{-1, -1}, P{-1, 1}, P{1, 1}, P{0, -1}, P{-1, 1}},
     {1.0, 0.0});
+}
+
+// Multipoint tests: 2 multipoints - 2 polygons.
+TYPED_TEST(PairwisePointPolygonDistanceTest, TwoPairMultiPointOnePolygon2)
+{
+  using T = TypeParam;
+  using P = vec_2d<T>;
+
+  CUSPATIAL_RUN_TEST(this->run_single,
+                     {{P{0, 2}}, {P{2, 3}, P{2, 1}}},
+                     {0, 1, 2},
+                     {0, 1, 2},
+                     {0, 4, 8},
+                     {P{0, 0}, P{2, 0}, P{1, 2}, P{0, 0}, P{2, 0}, P{3, 2}, P{1, 2}, P{2, 0}},
+                     {T{0.894427190999916}, 0.0});
 }
 
 // Large distance test


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.