### PR TITLE
use make_device_vector in pairwise_point_in_polygon_test

### DIFF
--- a/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
@@ -59,7 +59,7 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonOneRing)
   auto expected = std::vector<int>{false, false, false, false, true, true, true, true};
 
   for (size_t i = 0; i < point_list.size(); ++i) {
-    auto point = make_device_vector({{point_list[i][0], point_list[i][1]}});
+    auto point = make_device_vector<vec_2d<T>>({{point_list[i][0], point_list[i][1]}});
     auto ret   = pairwise_point_in_polygon(point.begin(),
                                          point.end(),
                                          poly_offsets.begin(),
@@ -103,7 +103,7 @@ TYPED_TEST(PairwisePointInPolygonTest, TwoPolygonsOneRingEach)
   auto expected = std::vector<int>({false, false, false, false, true, true, true, true});
 
   for (size_t i = 0; i < point_list.size() / 2; i = i + 2) {
-    auto points = make_device_vector(
+    auto points = make_device_vector<vec_2d<T>>(
       {{point_list[i][0], point_list[i][1]}, {point_list[i + 1][0], point_list[i + 1][1]}});
     auto ret = pairwise_point_in_polygon(points.begin(),
                                          points.end(),
@@ -142,7 +142,7 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonTwoRings)
   auto expected = std::vector<int>{0b0, 0b0, 0b1, 0b0, 0b1};
 
   for (size_t i = 0; i < point_list.size(); ++i) {
-    auto point = make_device_vector({{point_list[i][0], point_list[i][1]}});
+    auto point = make_device_vector<vec_2d<T>>({{point_list[i][0], point_list[i][1]}});
     auto ret   = pairwise_point_in_polygon(point.begin(),
                                          point.end(),
                                          poly_offsets.begin(),

--- a/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
@@ -52,8 +52,8 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonOneRing)
                                                 {0.0, 0.5}};
   auto poly_offsets      = make_device_vector({0, 1});
   auto poly_ring_offsets = make_device_vector({0, 5});
-  auto poly_point =
-    make_device_vector<vec_2d<T>>({{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {-1.0, -1.0}});
+  auto poly_point        = make_device_vector<vec_2d<T>>(
+    {{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {-1.0, -1.0}});
 
   auto got      = rmm::device_vector<int32_t>(1);
   auto expected = std::vector<int>{false, false, false, false, true, true, true, true};
@@ -88,7 +88,7 @@ TYPED_TEST(PairwisePointInPolygonTest, TwoPolygonsOneRingEach)
 
   auto poly_offsets      = make_device_vector({0, 1, 2});
   auto poly_ring_offsets = make_device_vector({0, 5, 10});
-  auto poly_point = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
+  auto poly_point        = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
                                                    {-1.0, 1.0},
                                                    {1.0, 1.0},
                                                    {1.0, -1.0},
@@ -127,7 +127,7 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonTwoRings)
     std::vector<std::vector<T>>{{0.0, 0.0}, {-0.4, 0.0}, {-0.6, 0.0}, {0.0, 0.4}, {0.0, -0.6}};
   auto poly_offsets      = make_device_vector({0, 1});
   auto poly_ring_offsets = make_device_vector({0, 5, 10});
-  auto poly_point = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
+  auto poly_point        = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
                                                    {1.0, -1.0},
                                                    {1.0, 1.0},
                                                    {-1.0, 1.0},
@@ -160,8 +160,9 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonTwoRings)
 
 TYPED_TEST(PairwisePointInPolygonTest, EdgesOfSquare)
 {
-  auto test_point = make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets = make_device_vector({0, 1, 2, 3, 4});
+  auto test_point =
+    make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets      = make_device_vector({0, 1, 2, 3, 4});
   auto poly_ring_offsets = make_device_vector({0, 5, 10, 15, 20});
 
   // 0: rect on min x side
@@ -192,8 +193,9 @@ TYPED_TEST(PairwisePointInPolygonTest, EdgesOfSquare)
 
 TYPED_TEST(PairwisePointInPolygonTest, CornersOfSquare)
 {
-  auto test_point   = make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets = make_device_vector({0, 1, 2, 3, 4});
+  auto test_point =
+    make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets      = make_device_vector({0, 1, 2, 3, 4});
   auto poly_ring_offsets = make_device_vector({0, 5, 10, 15, 20});
 
   // 0: min x min y corner
@@ -328,8 +330,9 @@ TEST_F(PairwisePointInPolygonErrorTest, InsufficientPolyOffsets)
   auto test_point        = make_device_vector<vec_2d<T>>({{0.0, 0.0}, {0.0, 0.0}});
   auto poly_offsets      = make_device_vector({0});
   auto poly_ring_offsets = make_device_vector({0, 4});
-  auto poly_point = make_device_vector<vec_2d<T>>({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}});
-  auto got        = rmm::device_vector<int32_t>(test_point.size());
+  auto poly_point =
+    make_device_vector<vec_2d<T>>({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}});
+  auto got = rmm::device_vector<int32_t>(test_point.size());
 
   EXPECT_THROW(pairwise_point_in_polygon(test_point.begin(),
                                          test_point.end(),

--- a/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
+++ b/cpp/tests/experimental/spatial/pairwise_point_in_polygon_test.cu
@@ -18,6 +18,7 @@
 #include <cuspatial/experimental/iterator_factory.cuh>
 #include <cuspatial/experimental/pairwise_point_in_polygon.cuh>
 #include <cuspatial/vec_2d.hpp>
+#include <cuspatial_test/vector_factories.cuh>
 
 #include <rmm/device_vector.hpp>
 
@@ -28,19 +29,10 @@
 #include <gtest/gtest.h>
 
 using namespace cuspatial;
+using namespace cuspatial::test;
 
 template <typename T>
 struct PairwisePointInPolygonTest : public ::testing::Test {
- public:
-  rmm::device_vector<vec_2d<T>> make_device_points(std::initializer_list<vec_2d<T>> pts)
-  {
-    return rmm::device_vector<vec_2d<T>>(pts.begin(), pts.end());
-  }
-
-  rmm::device_vector<std::size_t> make_device_offsets(std::initializer_list<std::size_t> pts)
-  {
-    return rmm::device_vector<std::size_t>(pts.begin(), pts.end());
-  }
 };
 
 // float and double are logically the same but would require separate tests due to precision.
@@ -58,16 +50,16 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonOneRing)
                                                 {0.5, 0.0},
                                                 {0.0, -0.5},
                                                 {0.0, 0.5}};
-  auto poly_offsets      = this->make_device_offsets({0, 1});
-  auto poly_ring_offsets = this->make_device_offsets({0, 5});
+  auto poly_offsets      = make_device_vector({0, 1});
+  auto poly_ring_offsets = make_device_vector({0, 5});
   auto poly_point =
-    this->make_device_points({{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {-1.0, -1.0}});
+    make_device_vector<vec_2d<T>>({{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {-1.0, -1.0}});
 
   auto got      = rmm::device_vector<int32_t>(1);
   auto expected = std::vector<int>{false, false, false, false, true, true, true, true};
 
   for (size_t i = 0; i < point_list.size(); ++i) {
-    auto point = this->make_device_points({{point_list[i][0], point_list[i][1]}});
+    auto point = make_device_vector({{point_list[i][0], point_list[i][1]}});
     auto ret   = pairwise_point_in_polygon(point.begin(),
                                          point.end(),
                                          poly_offsets.begin(),
@@ -94,24 +86,24 @@ TYPED_TEST(PairwisePointInPolygonTest, TwoPolygonsOneRingEach)
                                                 {0.0, -0.5},
                                                 {0.0, 0.5}};
 
-  auto poly_offsets      = this->make_device_offsets({0, 1, 2});
-  auto poly_ring_offsets = this->make_device_offsets({0, 5, 10});
-  auto poly_point        = this->make_device_points({{-1.0, -1.0},
-                                              {-1.0, 1.0},
-                                              {1.0, 1.0},
-                                              {1.0, -1.0},
-                                              {-1.0, -1.0},
-                                              {0.0, 1.0},
-                                              {1.0, 0.0},
-                                              {0.0, -1.0},
-                                              {-1.0, 0.0},
-                                              {0.0, 1.0}});
+  auto poly_offsets      = make_device_vector({0, 1, 2});
+  auto poly_ring_offsets = make_device_vector({0, 5, 10});
+  auto poly_point = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
+                                                   {-1.0, 1.0},
+                                                   {1.0, 1.0},
+                                                   {1.0, -1.0},
+                                                   {-1.0, -1.0},
+                                                   {0.0, 1.0},
+                                                   {1.0, 0.0},
+                                                   {0.0, -1.0},
+                                                   {-1.0, 0.0},
+                                                   {0.0, 1.0}});
 
   auto got      = rmm::device_vector<int32_t>(2);
   auto expected = std::vector<int>({false, false, false, false, true, true, true, true});
 
   for (size_t i = 0; i < point_list.size() / 2; i = i + 2) {
-    auto points = this->make_device_points(
+    auto points = make_device_vector(
       {{point_list[i][0], point_list[i][1]}, {point_list[i + 1][0], point_list[i + 1][1]}});
     auto ret = pairwise_point_in_polygon(points.begin(),
                                          points.end(),
@@ -133,24 +125,24 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonTwoRings)
   using T = TypeParam;
   auto point_list =
     std::vector<std::vector<T>>{{0.0, 0.0}, {-0.4, 0.0}, {-0.6, 0.0}, {0.0, 0.4}, {0.0, -0.6}};
-  auto poly_offsets      = this->make_device_offsets({0, 1});
-  auto poly_ring_offsets = this->make_device_offsets({0, 5, 10});
-  auto poly_point        = this->make_device_points({{-1.0, -1.0},
-                                              {1.0, -1.0},
-                                              {1.0, 1.0},
-                                              {-1.0, 1.0},
-                                              {-1.0, -1.0},
-                                              {-0.5, -0.5},
-                                              {-0.5, 0.5},
-                                              {0.5, 0.5},
-                                              {0.5, -0.5},
-                                              {-0.5, -0.5}});
+  auto poly_offsets      = make_device_vector({0, 1});
+  auto poly_ring_offsets = make_device_vector({0, 5, 10});
+  auto poly_point = make_device_vector<vec_2d<T>>({{-1.0, -1.0},
+                                                   {1.0, -1.0},
+                                                   {1.0, 1.0},
+                                                   {-1.0, 1.0},
+                                                   {-1.0, -1.0},
+                                                   {-0.5, -0.5},
+                                                   {-0.5, 0.5},
+                                                   {0.5, 0.5},
+                                                   {0.5, -0.5},
+                                                   {-0.5, -0.5}});
 
   auto got      = rmm::device_vector<int32_t>(1);
   auto expected = std::vector<int>{0b0, 0b0, 0b1, 0b0, 0b1};
 
   for (size_t i = 0; i < point_list.size(); ++i) {
-    auto point = this->make_device_points({{point_list[i][0], point_list[i][1]}});
+    auto point = make_device_vector({{point_list[i][0], point_list[i][1]}});
     auto ret   = pairwise_point_in_polygon(point.begin(),
                                          point.end(),
                                          poly_offsets.begin(),
@@ -168,15 +160,15 @@ TYPED_TEST(PairwisePointInPolygonTest, OnePolygonTwoRings)
 
 TYPED_TEST(PairwisePointInPolygonTest, EdgesOfSquare)
 {
-  auto test_point   = this->make_device_points({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets = this->make_device_offsets({0, 1, 2, 3, 4});
-  auto poly_ring_offsets = this->make_device_offsets({0, 5, 10, 15, 20});
+  auto test_point = make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets = make_device_vector({0, 1, 2, 3, 4});
+  auto poly_ring_offsets = make_device_vector({0, 5, 10, 15, 20});
 
   // 0: rect on min x side
   // 1: rect on max x side
   // 2: rect on min y side
   // 3: rect on max y side
-  auto poly_point = this->make_device_points(
+  auto poly_point = make_device_vector<vec_2d<double>>(
     {{-1.0, -1.0}, {0.0, -1.0}, {0.0, 1.0},  {-1.0, 1.0},  {-1.0, -1.0}, {0.0, -1.0}, {1.0, -1.0},
      {1.0, 1.0},   {0.0, 1.0},  {0.0, -1.0}, {-1.0, -1.0}, {-1.0, 0.0},  {1.0, 0.0},  {1.0, -1.0},
      {-1.0, 1.0},  {-1.0, 0.0}, {-1.0, 1.0}, {1.0, 1.0},   {1.0, 0.0},   {-1.0, 0.0}});
@@ -200,15 +192,15 @@ TYPED_TEST(PairwisePointInPolygonTest, EdgesOfSquare)
 
 TYPED_TEST(PairwisePointInPolygonTest, CornersOfSquare)
 {
-  auto test_point   = this->make_device_points({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets = this->make_device_offsets({0, 1, 2, 3, 4});
-  auto poly_ring_offsets = this->make_device_offsets({0, 5, 10, 15, 20});
+  auto test_point   = make_device_vector<vec_2d<double>>({{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets = make_device_vector({0, 1, 2, 3, 4});
+  auto poly_ring_offsets = make_device_vector({0, 5, 10, 15, 20});
 
   // 0: min x min y corner
   // 1: min x max y corner
   // 2: max x min y corner
   // 3: max x max y corner
-  auto poly_point = this->make_device_points(
+  auto poly_point = make_device_vector<vec_2d<double>>(
     {{-1.0, -1.0}, {-1.0, 0.0}, {0.0, 0.0},  {0.0, -1.0}, {-1.0, -1.0}, {-1.0, 0.0}, {-1.0, 1.0},
      {0.0, 1.0},   {-1.0, 0.0}, {-1.0, 0.0}, {0.0, -1.0}, {0.0, 0.0},   {1.0, 0.0},  {1.0, -1.0},
      {0.0, -1.0},  {0.0, 0.0},  {0.0, 1.0},  {1.0, 1.0},  {1.0, 0.0},   {0.0, 0.0}});
@@ -271,7 +263,7 @@ TYPED_TEST(PairwisePointInPolygonTest, 32PolygonSupport)
   auto constexpr num_polys       = 32;
   auto constexpr num_poly_points = num_polys * 5;
 
-  auto test_point = this->make_device_points(
+  auto test_point = make_device_vector<vec_2d<T>>(
     {{0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0},
      {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0},
      {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0},
@@ -311,10 +303,10 @@ TEST_F(PairwisePointInPolygonErrorTest, InsufficientPoints)
 {
   using T = double;
 
-  auto test_point        = this->make_device_points({{0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets      = this->make_device_offsets({0, 1});
-  auto poly_ring_offsets = this->make_device_offsets({0, 3});
-  auto poly_point        = this->make_device_points({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}});
+  auto test_point        = make_device_vector<vec_2d<T>>({{0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets      = make_device_vector({0, 1});
+  auto poly_ring_offsets = make_device_vector({0, 3});
+  auto poly_point        = make_device_vector<vec_2d<T>>({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}});
   auto got               = rmm::device_vector<int32_t>(test_point.size());
 
   EXPECT_THROW(pairwise_point_in_polygon(test_point.begin(),
@@ -333,10 +325,10 @@ TEST_F(PairwisePointInPolygonErrorTest, InsufficientPolyOffsets)
 {
   using T = double;
 
-  auto test_point        = this->make_device_points({{0.0, 0.0}, {0.0, 0.0}});
-  auto poly_offsets      = this->make_device_offsets({0});
-  auto poly_ring_offsets = this->make_device_offsets({0, 4});
-  auto poly_point = this->make_device_points({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}});
+  auto test_point        = make_device_vector<vec_2d<T>>({{0.0, 0.0}, {0.0, 0.0}});
+  auto poly_offsets      = make_device_vector({0});
+  auto poly_ring_offsets = make_device_vector({0, 4});
+  auto poly_point = make_device_vector<vec_2d<T>>({{0.0, 1.0}, {1.0, 0.0}, {0.0, -1.0}, {0.0, 1.0}});
   auto got        = rmm::device_vector<int32_t>(test_point.size());
 
   EXPECT_THROW(pairwise_point_in_polygon(test_point.begin(),


### PR DESCRIPTION
use make_device_vector in pairwise_point_in_polygon_test

closes #825

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
