### PR TITLE
Binary Predicate Test Dispatch

### DIFF
--- a/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
@@ -59,11 +59,11 @@ def geotype_tuple(request):
 @pytest.fixture(
     params=[
         "contains_properly",
+        "geom_equals",
+        "intersects",
         "covers",
         "crosses",
         "disjoint",
-        "geom_equals",
-        "intersects",
         "overlaps",
         "touches",
         "within",

--- a/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+import pytest
+from shapely.geometry import LineString, MultiPoint, Point, Polygon
+
+import cuspatial
+
+"""Test Dispatch"""
+
+"""Testing all combinations of possible geometry types and
+binary predicates is a complex task. This file contains the
+basic fixtures for all geometry types that are required to
+cover different possible test outcomes. This file also contains
+the dispatching system that uses each fixture to generate
+a test for each possible combination of geometry types and
+binary predicates.
+"""
+
+"""The following fixtures are used to generate tests for
+each possible combination of geometry types and binary
+predicates. Each fixture returns a tuple of the form
+(geotype, geotype, predicate, expected_result). The
+geotype fixtures are used to generate the first two
+elements of the tuple. The predicate fixture is used to
+generate the third element of the tuple. The expected_result
+fixture is used to generate the fourth element of the tuple.
+"""
+
+"""The collection of all possible geometry types"""
+
+
+@pytest.fixture(
+    params=[
+        (Point, Point),
+        (Point, MultiPoint),
+        (Point, LineString),
+        (Point, Polygon),
+        (MultiPoint, Point),
+        (MultiPoint, MultiPoint),
+        (MultiPoint, LineString),
+        (MultiPoint, Polygon),
+        (LineString, Point),
+        (LineString, MultiPoint),
+        (LineString, LineString),
+        (LineString, Polygon),
+        (Polygon, Point),
+        (Polygon, MultiPoint),
+        (Polygon, LineString),
+        (Polygon, Polygon),
+    ]
+)
+def geotype_tuple(request):
+    return request.param
+
+
+"""The collection of all possible binary predicates"""
+
+
+@pytest.fixture(
+    params=[
+        "contains_properly",
+        "covers",
+        "crosses",
+        "disjoint",
+        "geom_equals",
+        "intersects",
+        "overlaps",
+        "touches",
+        "within",
+    ]
+)
+def predicate(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        "single_equal",
+        "single_disjoint",
+        "triple_center_equal",
+        "triple_center_disjoint",
+        "border_overlap",
+        "interior_overlap",
+    ]
+)
+def test_type(request):
+    return request.param
+
+
+points_dispatch = {
+    "feature1": Point(0.0, 0.0),
+    "feature2": Point(1.0, 1.0),
+    "feature1_bo": Point(1.0, 1.0),
+    "feature2_bo": Point(0.0, 0.0),
+    "feature1_io": Point(1.0, 1.0),
+    "feature2_io": Point(2.0, 2.0),
+}
+
+multipoints_dispatch = {
+    "feature1": MultiPoint([(0.0, 0.0), (1.0, 1.0)]),
+    "feature2": MultiPoint([(2.0, 2.0), (3.0, 3.0)]),
+    "feature1_bo": MultiPoint([(0.0, 0.0), (1.0, 1.0)]),
+    "feature2_bo": MultiPoint([(1.0, 1.0), (2.0, 2.0)]),
+    "feature1_io": MultiPoint([(1.0, 1.0), (1.0, 1.0), (2.0, 2.0)]),
+    "feature2_io": MultiPoint([(3.0, 3.0), (1.0, 1.0), (4.0, 4.0)]),
+}
+
+linestrings_dispatch = {
+    "feature1": LineString([(0.0, 0.0), (1.0, 1.0)]),
+    "feature2": LineString([(2.0, 2.0), (3.0, 3.0)]),
+    "feature1_bo": LineString([(0.0, 0.0), (1.0, 1.0)]),
+    "feature2_bo": LineString([(1.1, 1.1), (2.0, 1.0)]),
+    "feature1_io": LineString(
+        [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]
+    ),
+    "feature2_io": LineString(
+        [(4.0, 4.0), (1.0, 1.0), (2.0, 2.0), (4.0, 4.0)]
+    ),
+}
+
+polygons_dispatch = {
+    "feature1": Polygon([(0.0, 0.0), (1.0, 1.0), (1.0, 0.0)]),
+    "feature2": Polygon([(2.0, 2.0), (3.0, 3.0), (3.0, 2.0)]),
+    "feature1_bo": Polygon([(0.0, 0.0), (1.0, 1.0), (1.0, 0.0)]),
+    "feature2_bo": Polygon([(2.0, 2.0), (1.0, 1.0), (1.0, 0.0)]),
+    "feature1_io": Polygon(
+        [(4.0, 4.0), (4.0, -4.0), (-4.0, -4.0), (-4.0, 4.0)]
+    ),
+    "feature2_io": Polygon(
+        [(1.0, 1.0), (1.0, -1.0), (-1.0, -1.0), (-1.0, 1.0)]
+    ),
+}
+
+feature_dispatch = {
+    Point: points_dispatch,
+    MultiPoint: multipoints_dispatch,
+    LineString: linestrings_dispatch,
+    Polygon: polygons_dispatch,
+}
+
+
+def get_feature(feature_type, feature_name):
+    return feature_dispatch[feature_type][feature_name]
+
+
+def single_equal(type0, type1):
+    return (
+        cuspatial.GeoSeries([get_feature(type0, "feature1")]),
+        cuspatial.GeoSeries([get_feature(type1, "feature2")]),
+    )
+
+
+def single_disjoint(type0, type1):
+    return (
+        cuspatial.GeoSeries([get_feature(type0, "feature1")]),
+        cuspatial.GeoSeries([get_feature(type1, "feature2")]),
+    )
+
+
+def triple_center_equal(type0, type1):
+    return (
+        cuspatial.GeoSeries(
+            [
+                get_feature(type0, "feature1"),
+                get_feature(type0, "feature2"),
+                get_feature(type0, "feature1"),
+            ]
+        ),
+        cuspatial.GeoSeries(
+            [
+                get_feature(type1, "feature2"),
+                get_feature(type1, "feature2"),
+                get_feature(type1, "feature2"),
+            ]
+        ),
+    )
+
+
+def triple_center_disjoint(type0, type1):
+    return (
+        cuspatial.GeoSeries(
+            [
+                get_feature(type0, "feature1"),
+                get_feature(type0, "feature2"),
+                get_feature(type0, "feature1"),
+            ]
+        ),
+        cuspatial.GeoSeries(
+            [
+                get_feature(type1, "feature1"),
+                get_feature(type1, "feature1"),
+                get_feature(type1, "feature1"),
+            ]
+        ),
+    )
+
+
+def border_overlap(type0, type1):
+    return (
+        cuspatial.GeoSeries([get_feature(type0, "feature1_bo")]),
+        cuspatial.GeoSeries([get_feature(type1, "feature2_bo")]),
+    )
+
+
+def interior_overlap(type0, type1):
+    return (
+        cuspatial.GeoSeries([get_feature(type0, "feature1_io")]),
+        cuspatial.GeoSeries([get_feature(type1, "feature2_io")]),
+    )
+
+
+# Build a nested dictionary for the dispatch system
+predicate_dispatch = {
+    "single_equal": single_equal,
+    "single_disjoint": single_disjoint,
+    "triple_center_equal": triple_center_equal,
+    "triple_center_disjoint": triple_center_disjoint,
+    "border_overlap": border_overlap,
+    "interior_overlap": interior_overlap,
+}
+
+
+def feature_test_dispatch(type0, type1, test_type):
+    dispatch_function = predicate_dispatch[test_type]
+    return dispatch_function(type0, type1)

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_test_dispatch.py
@@ -23,7 +23,8 @@ def skip_on_exception(func):
     return wrapper
 
 
-def test_fixtures(geotype_tuple, predicate, test_type):  # noqa: F811
+@skip_on_exception
+def test_fixtures(predicate, geotype_tuple, test_type):  # noqa: F811
     """Test that the fixture data is correct."""
     (lhs, rhs) = feature_test_dispatch(
         geotype_tuple[0], geotype_tuple[1], test_type
@@ -47,4 +48,5 @@ def test_fixtures(geotype_tuple, predicate, test_type):  # noqa: F811
         print(f"test_type: {test_type}")
         print(f"expected: {expected}")
         print(f"got: {got}")
-        pytest.fail(f"Assertion failed: {e}")
+        raise AssertionError(e)
+        # pytest.fail(f"Assertion failed: {e}")

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_test_dispatch.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+from functools import wraps
+
+import pandas as pd
+import pytest
+from binpred_test_dispatch import (  # noqa: F401
+    feature_test_dispatch,
+    geotype_tuple,
+    predicate,
+    test_type,
+)
+
+
+def skip_on_exception(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            pytest.skip(f"Skipping due to an exception: {e}")
+
+    return wrapper
+
+
+def test_fixtures(geotype_tuple, predicate, test_type):  # noqa: F811
+    """Test that the fixture data is correct."""
+    (lhs, rhs) = feature_test_dispatch(
+        geotype_tuple[0], geotype_tuple[1], test_type
+    )
+    gpdlhs = lhs.to_geopandas()
+    gpdrhs = rhs.to_geopandas()
+    pred_fn = getattr(lhs, predicate)
+    got = pred_fn(rhs)
+    if predicate == "contains_properly":
+        predicate = "contains"
+    gpd_pred_fn = getattr(gpdlhs, predicate)
+    expected = gpd_pred_fn(gpdrhs)
+    try:
+        pd.testing.assert_series_equal(expected, got.to_pandas())
+    except AssertionError as e:
+        print("Binary Predicate Test failed")
+        print("----------------------------")
+        print(f"lhs: {lhs}")
+        print(f"rhs: {rhs}")
+        print(f"predicate: {predicate}")
+        print(f"test_type: {test_type}")
+        print(f"expected: {expected}")
+        print(f"got: {got}")
+        pytest.fail(f"Assertion failed: {e}")


### PR DESCRIPTION
## Description
Currently `contains_properly`, `intersection`, and `equals` based predicates are all tested in their own files and lack explicit corner cases and boundary conditions for certain tests. They also do not test unimplemented cases at all.

This PR creates `binpred_test_dispatch.py` and `test_binpred_test_dispatch.py`. These files are used to exhaustively test the space of binary predicates and dispatched feature pairs. This will allow easy implementation of the remaining binary predicates in a test-driven fashion. Finally, failing tests are automatically skipped for now, until the entire suite has been finished. At that point the skip functionality will be removed and fails will be treated as such.

Each test of `feature1.predicate(feature2)` is also dispatched internally to a group of custom values for each feature type. These specified values will be used in the follow up PR for https://github.com/rapidsai/cuspatial/issues/1036, enabling truly exhaustive testing of all possible combinations of features and feature coordinate arrangements.

When this test dispatcher and types in #1036 are finished, the pre-existing tests should be able to be deleted.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
