### PR TITLE
Bug fix in `pairwise_linestring_intersection`

### DIFF
--- a/cpp/tests/experimental/spatial/linestring_intersection_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_test.cu
@@ -457,6 +457,117 @@ TYPED_TEST(LinestringIntersectionTest, TwoPairMultiWithDuplicatePoints)
                      expected);
 }
 
+TYPED_TEST(LinestringIntersectionTest, ThreePairIdenticalInputsNoRing)
+{
+  using T = TypeParam;
+  using P = vec_2d<T>;
+
+  using index_t = typename linestring_intersection_result<T, std::size_t>::index_t;
+  using types_t = typename linestring_intersection_result<T, std::size_t>::types_t;
+
+  auto multilinestrings1 = make_multilinestring_array(
+    {0, 1, 2, 3},
+    {0, 2, 4, 6},
+    {P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}});
+
+  auto multilinestrings2 = make_multilinestring_array<T>({0, 1, 2, 3},
+                                                         {0, 4, 8, 12},
+                                                         {{0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0}});
+
+  auto expected = make_linestring_intersection_result<T, index_t, types_t>({0, 2, 4, 6},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 1, 2, 3, 4, 5},
+                                                                           {
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                           },
+                                                                           {},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 1, 0, 1, 0, 1},
+                                                                           this->stream(),
+                                                                           this->mr());
+
+  CUSPATIAL_RUN_TEST(this->template run_single_test<index_t>,
+                     multilinestrings1.range(),
+                     multilinestrings2.range(),
+                     expected);
+}
+
+TYPED_TEST(LinestringIntersectionTest, ThreePairIdenticalInputsHasRing)
+{
+  using T = TypeParam;
+  using P = vec_2d<T>;
+
+  using index_t = typename linestring_intersection_result<T, std::size_t>::index_t;
+  using types_t = typename linestring_intersection_result<T, std::size_t>::types_t;
+
+  auto multilinestrings1 = make_multilinestring_array(
+    {0, 1, 2, 3},
+    {0, 2, 4, 6},
+    {P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}});
+
+  auto multilinestrings2 = make_multilinestring_array<T>({0, 1, 2, 3},
+                                                         {0, 5, 10, 15},
+                                                         {{0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+                                                          {0, 0},
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+                                                          {0, 0},
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+                                                          {0, 0}});
+
+  auto expected = make_linestring_intersection_result<T, index_t, types_t>({0, 2, 4, 6},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 1, 2, 3, 4, 5},
+                                                                           {
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                             {0.0, 0.0},
+                                                                             {1.0, 1.0},
+                                                                           },
+                                                                           {},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 0, 0, 0, 0, 0},
+                                                                           {0, 1, 0, 1, 0, 1},
+                                                                           this->stream(),
+                                                                           this->mr());
+
+  CUSPATIAL_RUN_TEST(this->template run_single_test<index_t>,
+                     multilinestrings1.range(),
+                     multilinestrings2.range(),
+                     expected);
+}
+
 TYPED_TEST(LinestringIntersectionTest, ManyPairsIntegrated)
 {
   using T = TypeParam;

--- a/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
+++ b/cpp/tests/experimental/spatial/linestring_intersection_with_duplicates_test.cu
@@ -656,3 +656,54 @@ TYPED_TEST(LinestringIntersectionDuplicatesTest, TwoPairsMultitoMulti)
                      {},
                      {});
 }
+
+TYPED_TEST(LinestringIntersectionDuplicatesTest, ThreePairIdenticalInputsNoRings)
+{
+  using T = TypeParam;
+  using P = vec_2d<T>;
+
+  using index_t = std::size_t;
+
+  auto multilinestrings1 = make_multilinestring_array(
+    {0, 1, 2, 3},
+    {0, 2, 4, 6},
+    {P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}, P{0.0, 0.0}, P{1.0, 1.0}});
+
+  auto multilinestrings2 = make_multilinestring_array<T>({0, 1, 2, 3},
+                                                         {0, 4, 8, 12},
+                                                         {{0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0},
+                                                          {0, 0},
+                                                          {0, 1},
+                                                          {1, 1},
+                                                          {1, 0}});
+
+  CUSPATIAL_RUN_TEST(
+    this->template run_single<index_t>,
+    multilinestrings1.range(),
+    multilinestrings2.range(),
+    // Point offsets
+    {0, 3, 6, 9},
+    // Expected Points
+    {P{0, 0}, P{1, 1}, P{1, 1}, P{0, 0}, P{1, 1}, P{1, 1}, P{0, 0}, P{1, 1}, P{1, 1}},
+    // Segment offsets
+    {0, 0, 0, 0},
+    // Expected segments
+    {},
+    // Point look-back ids
+    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 1, 2, 0, 1, 2, 0, 1, 2},
+    // segment look-back ids
+    {},
+    {},
+    {},
+    {});
+}

--- a/python/cuspatial/cuspatial/tests/binops/test_intersections.py
+++ b/python/cuspatial/cuspatial/tests/binops/test_intersections.py
@@ -156,3 +156,81 @@ def test_one_pair_multilinestring():
     )
 
     run_test(s1, s2, expect_offset, expect_geom, expect_ids)
+
+
+def test_three_pairs_identical_has_ring():
+    lhs = gpd.GeoSeries(
+        [
+            LineString([(0, 0), (1, 1)]),
+            LineString([(0, 0), (1, 1)]),
+            LineString([(0, 0), (1, 1)]),
+        ]
+    )
+    rhs = gpd.GeoSeries(
+        [
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]),
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]),
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]),
+        ]
+    )
+
+    expect_offset = pd.Series([0, 2, 4, 6])
+    expect_geom = gpd.GeoSeries(
+        [
+            Point(0, 0),
+            Point(1, 1),
+            Point(0, 0),
+            Point(1, 1),
+            Point(0, 0),
+            Point(1, 1),
+        ]
+    )
+    expect_ids = pd.DataFrame(
+        {
+            "lhs_linestring_id": [[0, 0], [0, 0], [0, 0]],
+            "lhs_segment_id": [[0, 0], [0, 0], [0, 0]],
+            "rhs_linestring_id": [[0, 0], [0, 0], [0, 0]],
+            "rhs_segment_id": [[0, 1], [0, 1], [0, 1]],
+        }
+    )
+
+    run_test(lhs, rhs, expect_offset, expect_geom, expect_ids)
+
+
+def test_three_pairs_identical_no_ring():
+    lhs = gpd.GeoSeries(
+        [
+            LineString([(0, 0), (1, 1)]),
+            LineString([(0, 0), (1, 1)]),
+            LineString([(0, 0), (1, 1)]),
+        ]
+    )
+    rhs = gpd.GeoSeries(
+        [
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0)]),
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0)]),
+            LineString([(0, 0), (0, 1), (1, 1), (1, 0)]),
+        ]
+    )
+
+    expect_offset = pd.Series([0, 2, 4, 6])
+    expect_geom = gpd.GeoSeries(
+        [
+            Point(0, 0),
+            Point(1, 1),
+            Point(0, 0),
+            Point(1, 1),
+            Point(0, 0),
+            Point(1, 1),
+        ]
+    )
+    expect_ids = pd.DataFrame(
+        {
+            "lhs_linestring_id": [[0, 0], [0, 0], [0, 0]],
+            "lhs_segment_id": [[0, 0], [0, 0], [0, 0]],
+            "rhs_linestring_id": [[0, 0], [0, 0], [0, 0]],
+            "rhs_segment_id": [[0, 1], [0, 1], [0, 1]],
+        }
+    )
+
+    run_test(lhs, rhs, expect_offset, expect_geom, expect_ids)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR fixes a bug in `pairwise_linestring_intersection`, where `point_flags` is incorrectly used to remove points in points array due to leftover results from find_duplicate_points.

Previously, the code incorrectly  assumed that `point_flags` will always be written to prior to `merge_point_on_segment` kernel, however, this may not be true if the result segment array is empty, and the kernel launch could be evaded, leading to that the second `remove_if` operates on the "leftover" from the previous `point_flag` ramnant.

This fix is to only run segment cleanup kernels if there is at least one segment result in the output. This not only fixes #1067 , but also serve as an optimization to avoid unnecessary kernel launching.

It should be pointed out that the result from python isn't exactly 1-1 matching with geopandas, as geopandas returns
```python
0    MULTIPOINT (1.00000 1.00000, 0.00000 0.00000)
1    MULTIPOINT (1.00000 1.00000, 0.00000 0.00000)
2    MULTIPOINT (1.00000 1.00000, 0.00000 0.00000)
```
While cuspatial returns the result in 6 point rows with geometry offsets.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
