### PR TITLE
Add Mixed Geometry Column

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -118,6 +118,7 @@ endif()
 
 add_library(cuspatial
     src/column/geometry_column_view.cpp
+    src/column/mixed_geometry_column_view.cpp
     src/indexing/construction/point_quadtree.cu
     src/join/quadtree_point_in_polygon.cu
     src/join/quadtree_point_to_nearest_linestring.cu

--- a/cpp/include/cuspatial/column/geometry_column_view.hpp
+++ b/cpp/include/cuspatial/column/geometry_column_view.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cuspatial/range/range.cuh>
 #include <cuspatial/types.hpp>
 
 #include <cudf/lists/lists_column_view.hpp>

--- a/cpp/include/cuspatial/column/mixed_geometry_column_view.hpp
+++ b/cpp/include/cuspatial/column/mixed_geometry_column_view.hpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuspatial/column/geometry_column_view.hpp>
+
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+namespace cuspatial {
+
+/**
+ * @ingroup cuspatial_types
+ * @brief A non-owning, immutable view to mixed type geometry view
+ *
+ * This column view implements a specialization of [arrow dense union layout][1], with
+ * exactly 6 child column representing 6 types of geometry column used in cuspatial.
+ *
+ * @note A union layout does not hold null fields on the top level. This means `types_buffer`
+ * and `offsets_buffer` must be non-nullable. This also implies that union column cannot hold
+ * a "typeless null": each row must contain a null one of its children. We compensate for this
+ * missing capability by allowing the type of a typeless null row to be set as union_type::NULL.
+ * The corresponding offset of that row is undefined.
+ *
+ * @throw cuspatial::logic_error if `types_buffer` data type is not INT8.
+ * @throw cuspatial::logic_error if `offsets_buffer` data type is not INT32.
+ * @throw cuspatial::logic_error if `points_column` is not a `SINGLE` `POINT` geometry column.
+ * @throw cuspatial::logic_error if `linestrings_column` is not a `SINGLE` `LINESTRING` geometry
+ * column.
+ * @throw cuspatial::logic_error if `polygons_column` is not a `SINGLE` `POLYGON` geometry column.
+ * @throw cuspatial::logic_error if `multipoints_column` is not a `MULTI` `POINT` geometry column.
+ * @throw cuspatial::logic_error if `multilinestrings_column` is not a `MULTI` `LINESTRING` geometry
+ * column.
+ * @throw cuspatial::logic_error if `multipolygons_column` is not a `MULTI` `POLYGON` geometry
+ * column.
+ *
+ * [1] https://arrow.apache.org/docs/format/Columnar.html#dense-union
+ */
+class mixed_geometry_column_view {
+ public:
+  mixed_geometry_column_view(cudf::column_view const& types_buffer,
+                             cudf::column_view const& offsets_buffer,
+                             geometry_column_view const& points_column,
+                             geometry_column_view const& linestrings_column,
+                             geometry_column_view const& polygons_column,
+                             geometry_column_view const& multipoints_column,
+                             geometry_column_view const& multilinestrings_column,
+                             geometry_column_view const& multipolygons_column);
+
+  mixed_geometry_column_view(mixed_geometry_column_view&&)      = default;
+  mixed_geometry_column_view(const mixed_geometry_column_view&) = default;
+  ~mixed_geometry_column_view()                                 = default;
+
+  mixed_geometry_column_view& operator=(mixed_geometry_column_view const&) = default;
+  mixed_geometry_column_view& operator=(mixed_geometry_column_view&&)      = default;
+
+ private:
+  cudf::column_view types_buffer;
+  cudf::column_view offsets_buffer;
+
+  geometry_column_view points_column;
+  geometry_column_view linestrings_column;
+  geometry_column_view polygons_column;
+  geometry_column_view multipoints_column;
+  geometry_column_view multilinestrings_column;
+  geometry_column_view multipolygons_column;
+};
+
+}  // namespace cuspatial

--- a/cpp/include/cuspatial/types.hpp
+++ b/cpp/include/cuspatial/types.hpp
@@ -30,4 +30,19 @@ enum class geometry_type_id : uint8_t { POINT, LINESTRING, POLYGON };
  */
 enum class collection_type_id : uint8_t { SINGLE, MULTI };
 
+using mixed_geometry_type_t = int8_t;
+
+/**
+ * @brief The underlying type id used in `cuspatial::mixed_geometry_column_view`
+ */
+enum class mixed_geometry_column_type_id : mixed_geometry_type_t {
+  INVALID = -1,
+  POINT,
+  LINESTRING,
+  POLYGON,
+  MULTIPOINT,
+  MULTILINESTRING,
+  MULTIPOLYGON
+};
+
 }  // namespace cuspatial

--- a/cpp/include/cuspatial_test/base_fixture.hpp
+++ b/cpp/include/cuspatial_test/base_fixture.hpp
@@ -17,7 +17,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
-#include <gtest/gtest.h>
+#include <cudf_test/cudf_gtest.hpp>
 
 namespace cuspatial {
 namespace test {

--- a/cpp/include/cuspatial_test/column_factories.hpp
+++ b/cpp/include/cuspatial_test/column_factories.hpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <cuspatial/types.hpp>
 
 #include <cudf/column/column_factories.hpp>

--- a/cpp/include/cuspatial_test/geometry_fixtures.hpp
+++ b/cpp/include/cuspatial_test/geometry_fixtures.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuspatial_test/base_fixture.hpp>
+#include <cuspatial_test/column_factories.hpp>
+
+#include <cuspatial/column/geometry_column_view.hpp>
+#include <cuspatial/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cudf/utilities/default_stream.hpp>
+
+namespace cuspatial {
+namespace test {
+
+/**
+ * @brief Test Fixture that initializes several commonly used geometry columns.
+ *
+ * @tparam T Type of the coordinates
+ */
+template <typename T>
+class CommonGeometryColumnFixture : public BaseFixture {
+ protected:
+  // TODO: explore SetUpTestSuite to perform per-test-suite initialization, saving expenses.
+  // However, this requires making `stream()` method a static member.
+  void SetUp()
+  {
+    collection_type_id _;
+
+    std::tie(_, empty_point_column)           = make_point_column<T>({}, stream());
+    std::tie(_, empty_linestring_column)      = make_linestring_column<T>({0}, {}, stream());
+    std::tie(_, empty_polygon_column)         = make_polygon_column<T>({0}, {0}, {}, stream());
+    std::tie(_, empty_multipoint_column)      = make_point_column<T>({0}, {}, stream());
+    std::tie(_, empty_multilinestring_column) = make_linestring_column<T>({0}, {0}, {}, stream());
+    std::tie(_, empty_multipolygon_column)    = make_polygon_column<T>({0}, {0}, {0}, {}, stream());
+  }
+
+  geometry_column_view empty_point()
+  {
+    return geometry_column_view(
+      empty_point_column->view(), collection_type_id::SINGLE, geometry_type_id::POINT);
+  }
+
+  geometry_column_view empty_multipoint()
+  {
+    return geometry_column_view(
+      empty_multipoint_column->view(), collection_type_id::MULTI, geometry_type_id::POINT);
+  }
+
+  geometry_column_view empty_linestring()
+  {
+    return geometry_column_view(
+      empty_linestring_column->view(), collection_type_id::SINGLE, geometry_type_id::LINESTRING);
+  }
+
+  geometry_column_view empty_multilinestring()
+  {
+    return geometry_column_view(empty_multilinestring_column->view(),
+                                collection_type_id::MULTI,
+                                geometry_type_id::LINESTRING);
+  }
+
+  geometry_column_view empty_polygon()
+  {
+    return geometry_column_view(
+      empty_polygon_column->view(), collection_type_id::SINGLE, geometry_type_id::POLYGON);
+  }
+
+  geometry_column_view empty_multipolygon()
+  {
+    return geometry_column_view(
+      empty_multipolygon_column->view(), collection_type_id::MULTI, geometry_type_id::POLYGON);
+  }
+
+  std::unique_ptr<cudf::column> empty_point_column;
+  std::unique_ptr<cudf::column> empty_linestring_column;
+  std::unique_ptr<cudf::column> empty_polygon_column;
+  std::unique_ptr<cudf::column> empty_multipoint_column;
+  std::unique_ptr<cudf::column> empty_multilinestring_column;
+  std::unique_ptr<cudf::column> empty_multipolygon_column;
+};
+
+}  // namespace test
+}  // namespace cuspatial

--- a/cpp/src/column/mixed_geometry_column_view.cpp
+++ b/cpp/src/column/mixed_geometry_column_view.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuspatial/column/mixed_geometry_column_view.hpp>
+#include <cuspatial/error.hpp>
+#include <cuspatial/types.hpp>
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/types.hpp>
+
+namespace cuspatial {
+
+mixed_geometry_column_view::mixed_geometry_column_view(
+  cudf::column_view const& types_buffer,
+  cudf::column_view const& offsets_buffer,
+  geometry_column_view const& points_column,
+  geometry_column_view const& linestrings_column,
+  geometry_column_view const& polygons_column,
+  geometry_column_view const& multipoints_column,
+  geometry_column_view const& multilinestrings_column,
+  geometry_column_view const& multipolygons_column)
+  : types_buffer(types_buffer),
+    offsets_buffer(offsets_buffer),
+    points_column(points_column),
+    linestrings_column(linestrings_column),
+    polygons_column(polygons_column),
+    multipoints_column(multipoints_column),
+    multilinestrings_column(multilinestrings_column),
+    multipolygons_column(multipolygons_column)
+{
+  CUSPATIAL_EXPECTS(
+    types_buffer.type() == cudf::data_type{cudf::type_to_id<mixed_geometry_type_t>()},
+    "types_buffer must have INT8 data type.");
+  CUSPATIAL_EXPECTS(offsets_buffer.type() == cudf::data_type{cudf::type_to_id<cudf::size_type>()},
+                    "offsets_buffer must use cudf's size type.");
+
+  CUSPATIAL_EXPECTS(points_column.collection_type() == collection_type_id::SINGLE &&
+                      points_column.geometry_type() == geometry_type_id::POINT,
+                    "points_column must be a single point column.");
+  CUSPATIAL_EXPECTS(linestrings_column.collection_type() == collection_type_id::SINGLE &&
+                      linestrings_column.geometry_type() == geometry_type_id::LINESTRING,
+                    "linestrings_column must be a single linestring column.");
+  CUSPATIAL_EXPECTS(polygons_column.collection_type() == collection_type_id::SINGLE &&
+                      polygons_column.geometry_type() == geometry_type_id::POLYGON,
+                    "polygons_column must be a single polygon column.");
+  CUSPATIAL_EXPECTS(multipoints_column.collection_type() == collection_type_id::MULTI &&
+                      multipoints_column.geometry_type() == geometry_type_id::POINT,
+                    "multipoints_column must be a multipoint column.");
+  CUSPATIAL_EXPECTS(multilinestrings_column.collection_type() == collection_type_id::MULTI &&
+                      multilinestrings_column.geometry_type() == geometry_type_id::LINESTRING,
+                    "multilinestrings_column must be a multilinestring column.");
+  CUSPATIAL_EXPECTS(multipolygons_column.collection_type() == collection_type_id::MULTI &&
+                      multipolygons_column.geometry_type() == geometry_type_id::POLYGON,
+                    "multipolygons_column must be a multipolygon column.");
+}
+
+}  // namespace cuspatial

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -50,6 +50,10 @@ endfunction(ConfigureTest)
 
 # Column-based API
 
+# column
+ConfigureTest(MIXED_GEOMETRY_COLUMN_VIEW_TEST
+    column/mixed_geometry_column_view_test.cpp)
+
 # index
 ConfigureTest(POINT_QUADTREE_TEST
     index/point_quadtree_test.cpp)

--- a/cpp/tests/column/mixed_geometry_column_view_test.cpp
+++ b/cpp/tests/column/mixed_geometry_column_view_test.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuspatial/error.hpp>
+#include <cuspatial_test/column_factories.hpp>
+#include <cuspatial_test/geometry_fixtures.hpp>
+
+#include <cuspatial/column/mixed_geometry_column_view.hpp>
+#include <cuspatial/types.hpp>
+
+#include <cudf_test/column_wrapper.hpp>
+
+using namespace cuspatial;
+using namespace cuspatial::test;
+
+template <typename T>
+struct mixed_geometry_column_test : CommonGeometryColumnFixture<T> {};
+
+TYPED_TEST_CASE(mixed_geometry_column_test, FloatingPointTypes);
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorLegalEmptyColumn)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<cudf::size_type>{};
+
+  auto mixed_geometry_column = mixed_geometry_column_view(types_buffer,
+                                                          offsets_buffer,
+                                                          this->empty_point(),
+                                                          this->empty_linestring(),
+                                                          this->empty_polygon(),
+                                                          this->empty_multipoint(),
+                                                          this->empty_multilinestring(),
+                                                          this->empty_multipolygon());
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongTypesBufferTypes)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<int32_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<cudf::size_type>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongOffsetsBufferTypes)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongPointColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_linestring(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongLinestringColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_polygon(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongPolygonColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_point(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongMultipointColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipolygon(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongMultilinestringColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multipolygon(),
+                                          this->empty_multipolygon()),
+               cuspatial::logic_error);
+}
+
+TYPED_TEST(mixed_geometry_column_test, ConstructorIllegalWrongMultipolygonColumnType)
+{
+  auto types_buffer   = cudf::test::fixed_width_column_wrapper<mixed_geometry_type_t>{};
+  auto offsets_buffer = cudf::test::fixed_width_column_wrapper<int64_t>{};
+
+  EXPECT_THROW(mixed_geometry_column_view(types_buffer,
+                                          offsets_buffer,
+                                          this->empty_point(),
+                                          this->empty_linestring(),
+                                          this->empty_polygon(),
+                                          this->empty_multipoint(),
+                                          this->empty_multilinestring(),
+                                          this->empty_multipoint()),
+               cuspatial::logic_error);
+}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This is an initial introduction of mixed geometry column.

A mixed geometry column is a specialization of arrow's dense union layout column. It doesn't allow arbitrary types defined for the column but is always strongly typed for all 6 commonly used geometry types in cuspatial: points, linestrings, polygons, multipoints, multilinestrings, multipolygons.

Type codes is also fixed to what's defined in `cuspatial/types.hpp`. The actual value of these can be retrieved by casting the enum type to `mixed_geometry_type_t`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
