### PR TITLE
Enable sccache hits from local builds

### DIFF
--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -31,6 +31,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=cuspatial-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=cuspatial-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
     - {{ compiler('cuda') }}
 

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -29,6 +29,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=libcuspatial-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=libcuspatial-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
 
 requirements:
   build:


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.