### PR TITLE
Bump Gtest version following Rapids-cmake change

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,8 +16,8 @@ dependencies:
 - doxygen
 - gcc_linux-64=11.*
 - geopandas>=0.11.0
-- gmock>=1.13.0.*
-- gtest>=1.13.0.*
+- gmock>=1.13.0
+- gtest>=1.13.0
 - ipython
 - ipywidgets
 - libcudf==23.6.*

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,8 +16,8 @@ dependencies:
 - doxygen
 - gcc_linux-64=11.*
 - geopandas>=0.11.0
-- gmock=1.10.0
-- gtest=1.10.0
+- gmock>=1.13.0.*
+- gtest>=1.13.0.*
 - ipython
 - ipywidgets
 - libcudf==23.6.*

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.23.1,!=3.25.0"
 
 gtest_version:
-  - "1.10.0"
+  - "1.13.0"
 
 sysroot_version:
   - "2.17"

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cmake_version:
   - ">=3.23.1,!=3.25.0"
 
 gtest_version:
-  - "1.13.0"
+  - ">=1.13.0"
 
 sysroot_version:
   - "2.17"

--- a/cpp/include/cuspatial_test/test_util.cuh
+++ b/cpp/include/cuspatial_test/test_util.cuh
@@ -19,14 +19,15 @@
 #include <cuspatial/geometry/vec_2d.hpp>
 #include <cuspatial/traits.hpp>
 
-#include <iomanip>
 #include <rmm/device_uvector.hpp>
 
-#include <string_view>
 #include <thrust/for_each.h>
 #include <thrust/host_vector.h>
+#include <thrust/optional.h>
 
 #include <cstdio>
+#include <iomanip>
+#include <string_view>
 
 namespace cuspatial {
 

--- a/cpp/tests/operators/linestrings_test.cu
+++ b/cpp/tests/operators/linestrings_test.cu
@@ -30,6 +30,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <optional>
 
 using namespace cuspatial;
@@ -38,6 +39,21 @@ using namespace cuspatial::test;
 
 template <typename T>
 using optional_vec2d = thrust::optional<vec_2d<T>>;
+
+namespace cuspatial {
+
+// Required by gtest test suite to compile
+// Need to be defined within cuspatial namespace for ADL.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, thrust::optional<vec_2d<T>> const& opt)
+{
+  if (opt.has_value())
+    return os << opt.value();
+  else
+    return os << "null";
+}
+
+}  // namespace cuspatial
 
 template <typename T>
 struct SegmentIntersectionTest : public BaseFixture {};

--- a/cpp/tests/trajectory/derive_trajectories_test.cu
+++ b/cpp/tests/trajectory/derive_trajectories_test.cu
@@ -35,6 +35,26 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <iostream>
+
+namespace std {
+
+// Required by gtest EXPECT_EQ test suite to compile.
+// Since `time_point` is an alias on
+// std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>,
+// according to ADL rules for templates, only the inner most enclosing namespaces,
+// and associated namespaces of the template arguments are added to search. In this
+// case, only `std` namespace is searched.
+//
+// [1]: https://en.cppreference.com/w/cpp/language/adl
+std::ostream& operator<<(std::ostream& os, cuspatial::test::time_point const& tp)
+{
+  // Output the time point in the desired format
+  os << tp.time_since_epoch().count() << "ms";
+  return os;
+}
+
+}  // namespace std
 
 template <typename T>
 struct DeriveTrajectoriesTest : public ::testing::Test {};

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,8 +54,8 @@ dependencies:
           - &cmake_ver cmake>=3.23.1,!=3.25.0
           - c-compiler
           - cxx-compiler
-          - gmock=1.10.0
-          - gtest=1.10.0
+          - gmock>=1.13.0.*
+          - gtest>=1.13.0.*
           - libcudf==23.6.*
           - librmm==23.6.*
           - ninja

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,8 +54,8 @@ dependencies:
           - &cmake_ver cmake>=3.23.1,!=3.25.0
           - c-compiler
           - cxx-compiler
-          - gmock>=1.13.0.*
-          - gtest>=1.13.0.*
+          - gmock>=1.13.0
+          - gtest>=1.13.0
           - libcudf==23.6.*
           - librmm==23.6.*
           - ninja


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Following Rapids-cmake bump to gtest 1.13.0 https://github.com/rapidsai/rapids-cmake/issues/400, this PR implements some custom out stream operator for more constrained ADL rules that 1.11+ uses.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
