### PR TITLE
Update recipes to GTest version >=1.13.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,8 +16,8 @@ dependencies:
 - doxygen
 - gcc_linux-64=11.*
 - geopandas>=0.11.0
-- gmock=1.10.0
-- gtest=1.10.0
+- gmock>=1.13.0
+- gtest>=1.13.0
 - ipython
 - ipywidgets
 - libcudf==23.6.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,8 +54,8 @@ dependencies:
           - &cmake_ver cmake>=3.23.1,!=3.25.0
           - c-compiler
           - cxx-compiler
-          - gmock=1.10.0
-          - gtest=1.10.0
+          - gmock>=1.13.0
+          - gtest>=1.13.0
           - libcudf==23.6.*
           - librmm==23.6.*
           - ninja


### PR DESCRIPTION
This PR updates GTest pinnings to >=1.13.0. This aligns with recent changes in rapids-cmake: https://github.com/rapidsai/rapids-cmake/pull/401.
