### PR TITLE
Handle sparse `GeoSeries` better and add `expand_values` to convert sparse to dense.

### DIFF
--- a/python/cuspatial/cuspatial/core/binops/intersection.py
+++ b/python/cuspatial/cuspatial/core/binops/intersection.py
@@ -69,6 +69,9 @@ def pairwise_linestring_intersection(
         not contains_only_linestrings(s) for s in [linestrings1, linestrings2]
     ):
         raise ValueError("Input GeoSeries must contain only linestrings.")
+    if len(linestrings1._column.lines) != len(linestrings2._column.lines):
+        linestrings1 = linestrings1.expand_values()
+        linestrings2 = linestrings2.expand_values()
 
     geoms, look_back_ids = c_pairwise_linestring_intersection(
         linestrings1._column.lines._column, linestrings2._column.lines._column

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -109,7 +109,7 @@ class GeoSeries(cudf.Series):
 
     @property
     def feature_types(self):
-        return self._column._meta.input_types
+        return self._column._meta.input_types.reset_index(drop=True)
 
     @property
     def type(self):
@@ -996,6 +996,54 @@ class GeoSeries(cudf.Series):
         else:
             self.index = cudf_series.index
             return None
+
+    def expand_values(self):
+        """Converts a potentially sparse view of a GeoSeries into a
+        dense view. Makes a copy if self is already dense."""
+        dense_points = cudf.Series([])
+        dense_mpoints = cudf.Series([])
+        dense_lines = cudf.Series([])
+        dense_polygons = cudf.Series([])
+        if len(self._column.points) > 0:
+            dense_points = self._column.points[
+                self._column._meta.union_offsets[
+                    self._column._meta.input_types == Feature_Enum.POINT.value
+                ]
+            ]
+        if len(self._column.mpoints) > 0:
+            dense_mpoints = self._column.mpoints[
+                self._column._meta.union_offsets[
+                    self._column._meta.input_types
+                    == Feature_Enum.MULTIPOINT.value
+                ]
+            ]
+        if len(self._column.lines) > 0:
+            dense_lines = self._column.lines[
+                self._column._meta.union_offsets[
+                    self._column._meta.input_types
+                    == Feature_Enum.LINESTRING.value
+                ]
+            ]
+        if len(self._column.polygons) > 0:
+            dense_polygons = self._column.polygons[
+                self._column._meta.union_offsets[
+                    self._column._meta.input_types
+                    == Feature_Enum.POLYGON.value
+                ]
+            ]
+        column = GeoColumn(
+            (
+                dense_points,
+                dense_mpoints,
+                dense_lines,
+                dense_polygons,
+            ),
+            {
+                "input_types": self._column._meta.input_types,
+                "union_offsets": self._column._meta.union_offsets,
+            },
+        )
+        return GeoSeries(column)
 
     def contains(self, other, align=False, allpairs=False, mode="full"):
         """Returns a `Series` of `dtype('bool')` with value `True` for each

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -757,3 +757,169 @@ def test_from_polygons_xy_example():
         [Polygon([(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0)])]
     )
     gpd.testing.assert_geoseries_equal(gpolygon.to_geopandas(), hpolygon)
+
+
+def test_expand_values_points():
+    point_base = cuspatial.GeoSeries([Point(0, 0), Point(1, 1)])
+    point_base._column._meta.input_types = cudf.Series([0, 0, 0])
+    point_base._column._meta.union_offsets = cudf.Series([0, 1, 0])
+    point_base._index = cudf.Series([0, 1, 2])
+    point_expanded = point_base.expand_values()
+    assert len(point_expanded._column.points) == 3
+
+
+def test_expand_values_multipoints():
+    multipoint_base = cuspatial.GeoSeries(
+        [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3)])]
+    )
+    multipoint_base._column._meta.input_types = cudf.Series([1, 1, 1, 1, 1, 1])
+    multipoint_base._column._meta.union_offsets = cudf.Series(
+        [0, 1, 0, 1, 0, 1]
+    )
+    multipoint_base._index = cudf.Series([0, 1, 2, 3, 4, 5])
+    multipoint_expanded = multipoint_base.expand_values()
+    assert len(multipoint_expanded._column.mpoints) == 6
+
+
+def test_expand_values_linestrings():
+    linestring_base = cuspatial.GeoSeries(
+        [
+            LineString([(0, 0), (1, 1), (2, 2)]),
+            LineString([(3, 3), (4, 4), (5, 5)]),
+        ]
+    )
+    linestring_base._column._meta.input_types = cudf.Series(
+        [2, 2, 2, 2, 2, 2, 2, 2, 2]
+    )
+    linestring_base._column._meta.union_offsets = cudf.Series(
+        [0, 1, 0, 1, 0, 1, 0, 1, 0]
+    )
+    linestring_base._index = cudf.Series([0, 1, 2, 3, 4, 5, 6, 7, 8])
+    linestring_expanded = linestring_base.expand_values()
+    assert len(linestring_expanded._column.lines) == 9
+
+
+def test_expand_values_polygons():
+    polygon_base = cuspatial.GeoSeries(
+        [
+            Polygon([(0, 0), (1, 1), (2, 2), (0, 0)]),
+            Polygon([(3, 3), (4, 4), (5, 5), (3, 3)]),
+        ]
+    )
+    polygon_base._column._meta.input_types = cudf.Series(
+        [3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+    )
+    polygon_base._column._meta.union_offsets = cudf.Series(
+        [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    )
+    polygon_base._index = cudf.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    polygon_expanded = polygon_base.expand_values()
+    assert len(polygon_expanded._column.polygons) == 10
+
+
+def test_expand_values_mixed():
+    """This test demonstrates expand_values on a GeoSeries with mixed geometry
+    types as well as repeats."""
+    mixed_base = cuspatial.GeoSeries(
+        [
+            Polygon([(94, 94), (92, 92), (93, 93), (94, 94)]),
+            Point(0, 0),
+            LineString([(95, 95), (96, 96), (97, 97)]),
+            MultiPoint([(1, 1), (2, 2)]),
+            LineString([(3, 3), (4, 4), (5, 5)]),
+            MultiPoint([(98, 98), (99, 99)]),
+            Polygon([(6, 6), (7, 7), (8, 8), (6, 6)]),
+            Point(100, 100),
+        ]
+    )
+    mixed_base._column._meta.input_types = cudf.Series(
+        [3, 0, 2, 1, 2, 1, 3, 0, 3, 0, 2, 1, 2, 1, 3, 0],
+    )
+    mixed_base._column._meta.union_offsets = cudf.Series(
+        [1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1],
+    )
+    mixed_base._index = cudf.RangeIndex(16)
+    mixed_expanded = mixed_base.expand_values()
+    assert len(mixed_expanded._column.points) == 4
+    assert len(mixed_expanded._column.mpoints) == 4
+    assert len(mixed_expanded._column.lines) == 4
+    assert len(mixed_expanded._column.polygons) == 4
+    pd.testing.assert_series_equal(
+        mixed_expanded.to_geopandas(),
+        gpd.GeoSeries(
+            [
+                Polygon([(94, 94), (92, 92), (93, 93), (94, 94)]),
+                Point(0, 0),
+                LineString([(95, 95), (96, 96), (97, 97)]),
+                MultiPoint([(1, 1), (2, 2)]),
+                LineString([(3, 3), (4, 4), (5, 5)]),
+                MultiPoint([(98, 98), (99, 99)]),
+                Polygon([(6, 6), (7, 7), (8, 8), (6, 6)]),
+                Point(100, 100),
+                Polygon([(94, 94), (92, 92), (93, 93), (94, 94)]),
+                Point(0, 0),
+                LineString([(95, 95), (96, 96), (97, 97)]),
+                MultiPoint([(1, 1), (2, 2)]),
+                LineString([(3, 3), (4, 4), (5, 5)]),
+                MultiPoint([(98, 98), (99, 99)]),
+                Polygon([(6, 6), (7, 7), (8, 8), (6, 6)]),
+                Point(100, 100),
+            ]
+        ),
+    )
+
+
+def test_expand_values_multi():
+    mixed_base = cuspatial.GeoSeries(
+        [
+            MultiPolygon(
+                [
+                    Polygon([(0, 0), (1, 1), (2, 2), (0, 0)]),
+                    Polygon([(3, 3), (4, 4), (5, 5), (3, 3)]),
+                ]
+            ),
+            MultiLineString(
+                [
+                    LineString([(6, 6), (6, 6), (7, 7)]),
+                    LineString([(8, 8), (9, 9), (10, 10)]),
+                ]
+            ),
+        ]
+    )
+    mixed_base._column._meta.input_types = cudf.Series([3, 2, 3, 2])
+    mixed_base._column._meta.union_offsets = cudf.Series([0, 0, 0, 0])
+    mixed_base._index = cudf.RangeIndex(4)
+    mixed_expanded = mixed_base.expand_values()
+    assert len(mixed_expanded._column.polygons) == 2
+    assert len(mixed_expanded._column.lines) == 2
+    pd.testing.assert_series_equal(
+        mixed_expanded.to_geopandas(),
+        gpd.GeoSeries(
+            [
+                MultiPolygon(
+                    [
+                        Polygon([(0, 0), (1, 1), (2, 2), (0, 0)]),
+                        Polygon([(3, 3), (4, 4), (5, 5), (3, 3)]),
+                    ]
+                ),
+                MultiLineString(
+                    [
+                        LineString([(6, 6), (6, 6), (7, 7)]),
+                        LineString([(8, 8), (9, 9), (10, 10)]),
+                    ]
+                ),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 0), (1, 1), (2, 2), (0, 0)]),
+                        Polygon([(3, 3), (4, 4), (5, 5), (3, 3)]),
+                    ]
+                ),
+                MultiLineString(
+                    [
+                        LineString([(6, 6), (6, 6), (7, 7)]),
+                        LineString([(8, 8), (9, 9), (10, 10)]),
+                    ]
+                ),
+            ]
+        ),
+    )


### PR DESCRIPTION
Fixes #1142 

## Description

When a `GeoSeries` is sliced, or through careful construction methods, a sparse GeoSeries can be created:

```
series = cuspatial.GeoSeries([Point(0, 0)])
sparse_series = series[[0, 0]]
sparse_series
```
```
0    POINT (0.00000 0.00000)
0    POINT (0.00000 0.00000)
dtype: geometry
```

The above series has the appearance of containing two `Points`, but actually contains a single `Point` which is indexed twice. `pairwise_linestring_intersection` depends on a pairwise comparison of dense `LineStrings`. This PR adds `GeoSeries.expand_values()` which fills out a sparse `GeoSeries` prior to calling `pairwise_linestring_intersection`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
