### PR TITLE
Fix `cudf::column` constructor args

### DIFF
--- a/cpp/src/indexing/point_quadtree.cu
+++ b/cpp/src/indexing/point_quadtree.cu
@@ -90,20 +90,31 @@ struct dispatch_construct_quadtree {
 
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, size, tree.key.release()));
+      cudf::data_type{cudf::type_id::UINT32}, size, tree.key.release(), rmm::device_buffer{}, 0));
     cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, size, tree.level.release()));
-    cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::BOOL8}, size, tree.internal_node_flag.release()));
-    cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, size, tree.length.release()));
-    cols.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, size, tree.offset.release()));
+      cudf::data_type{cudf::type_id::UINT8}, size, tree.level.release(), rmm::device_buffer{}, 0));
+    cols.push_back(std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::BOOL8},
+                                                  size,
+                                                  tree.internal_node_flag.release(),
+                                                  rmm::device_buffer{},
+                                                  0));
+    cols.push_back(std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                  size,
+                                                  tree.length.release(),
+                                                  rmm::device_buffer{},
+                                                  0));
+    cols.push_back(std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                  size,
+                                                  tree.offset.release(),
+                                                  rmm::device_buffer{},
+                                                  0));
 
-    return std::make_pair(
-      std::make_unique<cudf::column>(
-        cudf::data_type{cudf::type_id::UINT32}, x.size(), point_indices.release()),
-      std::make_unique<cudf::table>(std::move(cols)));
+    return std::make_pair(std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                         x.size(),
+                                                         point_indices.release(),
+                                                         rmm::device_buffer{},
+                                                         0),
+                          std::make_unique<cudf::table>(std::move(cols)));
   }
 };
 

--- a/cpp/src/intersection/linestring_intersection.cu
+++ b/cpp/src/intersection/linestring_intersection.cu
@@ -85,7 +85,9 @@ struct pairwise_linestring_intersection_launch {
 
     auto points_xy = std::make_unique<cudf::column>(cudf::data_type(cudf::type_to_id<T>()),
                                                     2 * num_points,
-                                                    intersection_results.points_coords->release());
+                                                    intersection_results.points_coords->release(),
+                                                    rmm::device_buffer{},
+                                                    0);
 
     auto points =
       cudf::make_lists_column(num_points, std::move(points_offsets), std::move(points_xy), 0, {});
@@ -100,7 +102,9 @@ struct pairwise_linestring_intersection_launch {
     auto segments_xy =
       std::make_unique<cudf::column>(cudf::data_type(cudf::type_to_id<T>()),
                                      num_segment_coords,
-                                     intersection_results.segments_coords->release());
+                                     intersection_results.segments_coords->release(),
+                                     rmm::device_buffer{},
+                                     0);
 
     auto segments =
       cudf::make_lists_column(num_segments,
@@ -118,15 +122,24 @@ struct pairwise_linestring_intersection_launch {
                               mr);
 
     return linestring_intersection_column_result{
-      std::make_unique<cudf::column>(std::move(*intersection_results.geometry_collection_offset)),
-      std::make_unique<cudf::column>(std::move(*intersection_results.types_buffer)),
-      std::make_unique<cudf::column>(std::move(*intersection_results.offset_buffer)),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.geometry_collection_offset.release()),
+        rmm::device_buffer{},
+        0),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.types_buffer.release()), rmm::device_buffer{}, 0),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.offset_buffer.release()), rmm::device_buffer{}, 0),
       std::move(points),
       std::move(segments),
-      std::make_unique<cudf::column>(std::move(*intersection_results.lhs_linestring_id)),
-      std::make_unique<cudf::column>(std::move(*intersection_results.lhs_segment_id)),
-      std::make_unique<cudf::column>(std::move(*intersection_results.rhs_linestring_id)),
-      std::make_unique<cudf::column>(std::move(*intersection_results.rhs_segment_id))};
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.lhs_linestring_id.release()), rmm::device_buffer{}, 0),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.lhs_segment_id.release()), rmm::device_buffer{}, 0),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.rhs_linestring_id.release()), rmm::device_buffer{}, 0),
+      std::make_unique<cudf::column>(
+        std::move(*intersection_results.rhs_segment_id.release()), rmm::device_buffer{}, 0)};
   }
 
   template <typename T, typename... Args>

--- a/cpp/src/join/quadtree_bbox_filtering.cu
+++ b/cpp/src/join/quadtree_bbox_filtering.cu
@@ -72,8 +72,8 @@ struct dispatch_quadtree_bounding_box_join {
       mr);
 
     std::vector<std::unique_ptr<cudf::column>> cols{};
-    cols.push_back(std::make_unique<cudf::column>(std::move(bbox_offset)));
-    cols.push_back(std::make_unique<cudf::column>(std::move(quad_offset)));
+    cols.push_back(std::make_unique<cudf::column>(std::move(bbox_offset), rmm::device_buffer{}, 0));
+    cols.push_back(std::make_unique<cudf::column>(std::move(quad_offset), rmm::device_buffer{}, 0));
 
     return std::make_unique<cudf::table>(std::move(cols));
   }

--- a/cpp/src/join/quadtree_point_in_polygon.cu
+++ b/cpp/src/join/quadtree_point_in_polygon.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "rmm/device_buffer.hpp"
 #include <cuspatial/iterator_factory.cuh>
 #include <cuspatial/range/multipoint_range.cuh>
 #include <cuspatial/range/multipolygon_range.cuh>
@@ -89,10 +90,16 @@ struct compute_quadtree_point_in_polygon {
     // Allocate output columns for the number of pairs that intersected
     auto num_intersections = poly_idx.size();
 
-    auto poly_idx_col = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, num_intersections, poly_idx.release());
-    auto point_idx_col = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, num_intersections, point_idx.release());
+    auto poly_idx_col  = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                       num_intersections,
+                                                       poly_idx.release(),
+                                                       rmm::device_buffer{},
+                                                       0);
+    auto point_idx_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                        num_intersections,
+                                                        point_idx.release(),
+                                                        rmm::device_buffer{},
+                                                        0);
 
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.reserve(2);

--- a/cpp/src/join/quadtree_point_to_nearest_linestring.cu
+++ b/cpp/src/join/quadtree_point_to_nearest_linestring.cu
@@ -88,12 +88,18 @@ struct compute_quadtree_point_to_nearest_linestring {
 
     auto num_distances = distances.size();
 
-    auto point_idx_col = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, num_distances, point_idxs.release());
-    auto linestring_idx_col = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT32}, num_distances, linestring_idxs.release());
-    auto distance_col =
-      std::make_unique<cudf::column>(point_x.type(), num_distances, distances.release());
+    auto point_idx_col      = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                        num_distances,
+                                                        point_idxs.release(),
+                                                        rmm::device_buffer{},
+                                                        0);
+    auto linestring_idx_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT32},
+                                                             num_distances,
+                                                             linestring_idxs.release(),
+                                                             rmm::device_buffer{},
+                                                             0);
+    auto distance_col       = std::make_unique<cudf::column>(
+      point_x.type(), num_distances, distances.release(), rmm::device_buffer{}, 0);
 
     std::vector<std::unique_ptr<cudf::column>> cols{};
     cols.reserve(3);

--- a/cpp/src/trajectory/derive_trajectories.cu
+++ b/cpp/src/trajectory/derive_trajectories.cu
@@ -70,8 +70,11 @@ struct derive_trajectories_dispatch {
 
     auto num_trajectories = offsets->size();
 
-    auto offsets_column = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::INT32}, num_trajectories, offsets->release());
+    auto offsets_column = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                         num_trajectories,
+                                                         offsets->release(),
+                                                         rmm::device_buffer{},
+                                                         0);
 
     return {std::move(result_table), std::move(offsets_column)};
   }

--- a/cpp/tests/trajectory/test_derive_trajectories.cpp
+++ b/cpp/tests/trajectory/test_derive_trajectories.cpp
@@ -35,28 +35,43 @@ TEST_F(DeriveTrajectoriesErrorTest, SizeMismatch)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
 
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
     auto ts =
-      cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size / 2, rmm::cuda_stream_default));
+      cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size / 2, rmm::cuda_stream_default),
+                   rmm::device_buffer{},
+                   0);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
@@ -67,29 +82,44 @@ TEST_F(DeriveTrajectoriesErrorTest, TypeError)
   auto const size = 1000;
 
   {
-    auto id =
-      cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));  // not integer
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);  // not integer
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts =
-      cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));  // not timestamp
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);  // not timestamp
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
     // x-y type mismatch
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<double>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<double>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
@@ -100,15 +130,20 @@ TEST_F(DeriveTrajectoriesErrorTest, Nulls)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
 
     auto nulls = rmm::device_uvector<int>(1000, rmm::cuda_stream_default);
     cudaMemsetAsync(nulls.data(), 0xcccc, nulls.size(), rmm::cuda_stream_default.value());
     auto nulls_buffer = nulls.release();
-    id.set_null_mask(nulls_buffer);
+    id.set_null_mask(nulls_buffer, 8000);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }

--- a/cpp/tests/trajectory/test_derive_trajectories.cpp
+++ b/cpp/tests/trajectory/test_derive_trajectories.cpp
@@ -143,7 +143,7 @@ TEST_F(DeriveTrajectoriesErrorTest, Nulls)
     auto nulls = rmm::device_uvector<int>(1000, rmm::cuda_stream_default);
     cudaMemsetAsync(nulls.data(), 0xcccc, nulls.size(), rmm::cuda_stream_default.value());
     auto nulls_buffer = nulls.release();
-    id.set_null_mask(nulls_buffer, 8000);
+    id.set_null_mask(nulls_buffer, 4000);
     EXPECT_THROW(cuspatial::derive_trajectories(id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }

--- a/cpp/tests/trajectory/test_trajectory_bounding_boxes.cu
+++ b/cpp/tests/trajectory/test_trajectory_bounding_boxes.cu
@@ -26,17 +26,24 @@ TEST_F(TrajectoryBoundingBoxesErrorTest, SizeMismatch)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
 
     EXPECT_THROW(cuspatial::trajectory_bounding_boxes(1, id, xs, ys, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
     EXPECT_THROW(cuspatial::trajectory_bounding_boxes(1, id, xs, ys, this->mr()),
                  cuspatial::logic_error);
   }
@@ -47,19 +54,26 @@ TEST_F(TrajectoryBoundingBoxesErrorTest, TypeError)
   auto const size = 1000;
 
   {
-    auto id =
-      cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));  // not integer
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);  // not integer
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
     EXPECT_THROW(cuspatial::trajectory_bounding_boxes(1, id, xs, ys, this->mr()),
                  cuspatial::logic_error);
   }
 
   {
     // x-y type mismatch
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<double>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<double>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
     EXPECT_THROW(cuspatial::trajectory_bounding_boxes(1, id, xs, ys, this->mr()),
                  cuspatial::logic_error);
   }
@@ -70,14 +84,18 @@ TEST_F(TrajectoryBoundingBoxesErrorTest, Nulls)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
 
     auto nulls = rmm::device_uvector<int>(1000, rmm::cuda_stream_default);
     cudaMemsetAsync(nulls.data(), 0xcccc, nulls.size(), rmm::cuda_stream_default.value());
     auto nulls_buffer = nulls.release();
-    id.set_null_mask(nulls_buffer);
+    id.set_null_mask(nulls_buffer, 4000);
     EXPECT_THROW(cuspatial::trajectory_bounding_boxes(1, id, xs, ys, this->mr()),
                  cuspatial::logic_error);
   }

--- a/cpp/tests/trajectory/test_trajectory_distances_and_speeds.cu
+++ b/cpp/tests/trajectory/test_trajectory_distances_and_speeds.cu
@@ -139,7 +139,7 @@ TEST_F(TrajectoryDistanceSpeedErrorTest, Nulls)
     auto nulls = rmm::device_uvector<int>(1000, rmm::cuda_stream_default);
     cudaMemsetAsync(nulls.data(), 0xcccc, nulls.size(), rmm::cuda_stream_default.value());
     auto nulls_buffer = nulls.release();
-    id.set_null_mask(nulls_buffer, 8000);
+    id.set_null_mask(nulls_buffer, 4000);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }

--- a/cpp/tests/trajectory/test_trajectory_distances_and_speeds.cu
+++ b/cpp/tests/trajectory/test_trajectory_distances_and_speeds.cu
@@ -30,27 +30,43 @@ TEST_F(TrajectoryDistanceSpeedErrorTest, SizeMismatch)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size / 2, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
     auto ts =
-      cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size / 2, rmm::cuda_stream_default));
+      cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size / 2, rmm::cuda_stream_default),
+                   rmm::device_buffer{},
+                   0);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
@@ -61,29 +77,44 @@ TEST_F(TrajectoryDistanceSpeedErrorTest, TypeError)
   auto const size = 1000;
 
   {
-    auto id =
-      cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));  // not integer
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);  // not integer
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
-    auto id = cudf::column(rmm::device_uvector<int>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts =
-      cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));  // not timestamp
+    auto id = cudf::column(
+      rmm::device_uvector<int>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);  // not timestamp
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
   {
     // x-y type mismatch
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<double>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<double>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }
@@ -94,15 +125,21 @@ TEST_F(TrajectoryDistanceSpeedErrorTest, Nulls)
   auto const size = 1000;
 
   {
-    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default));
-    auto xs = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ys = cudf::column(rmm::device_uvector<float>(size, rmm::cuda_stream_default));
-    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default));
+    auto id = cudf::column(rmm::device_uvector<cudf::size_type>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
+    auto xs = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ys = cudf::column(
+      rmm::device_uvector<float>(size, rmm::cuda_stream_default), rmm::device_buffer{}, 0);
+    auto ts = cudf::column(rmm::device_uvector<cudf::timestamp_ms>(size, rmm::cuda_stream_default),
+                           rmm::device_buffer{},
+                           0);
 
     auto nulls = rmm::device_uvector<int>(1000, rmm::cuda_stream_default);
     cudaMemsetAsync(nulls.data(), 0xcccc, nulls.size(), rmm::cuda_stream_default.value());
     auto nulls_buffer = nulls.release();
-    id.set_null_mask(nulls_buffer);
+    id.set_null_mask(nulls_buffer, 8000);
     EXPECT_THROW(cuspatial::trajectory_distances_and_speeds(1, id, xs, ys, ts, this->mr()),
                  cuspatial::logic_error);
   }

--- a/docs/source/user_guide/cuspatial_api_examples.ipynb
+++ b/docs/source/user_guide/cuspatial_api_examples.ipynb
@@ -77,7 +77,7 @@
     "## GPU accelerated memory layout\n",
     "\n",
     "cuSpatial uses `GeoArrow` buffers, a GPU-friendly data format for geometric data that is well  \n",
-    "suited for massively parallel programming. See [I/O](#io) on the fastest methods to get your  \n",
+    "suited for massively parallel programming. See [I/O]((#Input-/-Output) on the fastest methods to get your  \n",
     "data into cuSpatial. GeoArrow extends [PyArrow](\n",
     "https://arrow.apache.org/docs/python/index.html       ) bindings and introduces several new types suited  \n",
     "for geometry applications.  GeoArrow supports [ListArrays](\n",


### PR DESCRIPTION
## Description
Update `cudf::column` constructor args to match the changes in https://github.com/rapidsai/cudf/pull/13341.

Also corrects a minor issue in the docs, closes #1154.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
