### PR TITLE
Update IO anchor to correct link in user guide

### DIFF
--- a/docs/source/user_guide/cuspatial_api_examples.ipynb
+++ b/docs/source/user_guide/cuspatial_api_examples.ipynb
@@ -77,7 +77,7 @@
     "## GPU accelerated memory layout\n",
     "\n",
     "cuSpatial uses `GeoArrow` buffers, a GPU-friendly data format for geometric data that is well  \n",
-    "suited for massively parallel programming. See [I/O](#io) on the fastest methods to get your  \n",
+    "suited for massively parallel programming. See [I/O]((#Input-/-Output) on the fastest methods to get your  \n",
     "data into cuSpatial. GeoArrow extends [PyArrow](\n",
     "https://arrow.apache.org/docs/python/index.html       ) bindings and introduces several new types suited  \n",
     "for geometry applications.  GeoArrow supports [ListArrays](\n",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The user guide has an incorrect anchor link for the Input/Output section, which threw breaking warnings in CI.  this should correct it.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
