### PR TITLE
Add variance to the number of geometries/components in multipoint/multilinestring/multipolygon generator

### DIFF
--- a/cpp/benchmarks/distance/pairwise_point_polygon_distance.cu
+++ b/cpp/benchmarks/distance/pairwise_point_polygon_distance.cu
@@ -49,7 +49,7 @@ void pairwise_point_polygon_distance_benchmark(nvbench::state& state, nvbench::t
   auto mpoly_generator_param = multipolygon_generator_parameter<T>{
     num_pairs, num_polygons_per_multipolygon, num_holes_per_polygon, num_edges_per_ring};
 
-  auto mpoint_generator_param = multipoint_generator_parameter<T>{
+  auto mpoint_generator_param = multipoint_generator_parameter_idendity<T>{
     num_pairs, num_points_per_multipoint, vec_2d<T>{-1, -1}, vec_2d<T>{0, 0}};
 
   auto multipolygons = generate_multipolygon_array<T>(mpoly_generator_param, stream);
@@ -74,10 +74,11 @@ void pairwise_point_polygon_distance_benchmark(nvbench::state& state, nvbench::t
   state.add_global_memory_reads<T>(
     mpoly_generator_param.num_coords() + mpoint_generator_param.num_points(),
     "CoordinatesReadSize");
-  state.add_global_memory_reads<std::size_t>(
-    (mpoly_generator_param.num_rings() + 1) + (mpoly_generator_param.num_polygons() + 1) +
-      (mpoly_generator_param.num_multipolygons + 1) + (mpoint_generator_param.num_multipoints + 1),
-    "OffsetsDataSize");
+  state.add_global_memory_reads<std::size_t>((mpoly_generator_param.num_rings() + 1) +
+                                               (mpoly_generator_param.num_polygons() + 1) +
+                                               (mpoly_generator_param.num_multipolygons + 1) +
+                                               (mpoint_generator_param.num_multipoints() + 1),
+                                             "OffsetsDataSize");
 
   state.add_global_memory_writes<T>(num_pairs);
 

--- a/cpp/include/cuspatial/iterator_factory.cuh
+++ b/cpp/include/cuspatial/iterator_factory.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cuspatial/detail/functors.cuh>
 #include <cuspatial/error.hpp>
 #include <cuspatial/geometry/box.hpp>
 #include <cuspatial/geometry/vec_2d.hpp>
@@ -422,6 +423,13 @@ auto make_geometry_id_iterator(GeometryIter geometry_offsets_begin,
     first_part_offsets_begin,
     thrust::next(first_part_offsets_begin,
                  std::distance(geometry_offsets_begin, geometry_offsets_end)));
+}
+
+template <typename OffsetIter>
+auto make_element_count_iterator_from_offset(OffsetIter offset_begin)
+{
+  auto zipped = thrust::make_zip_iterator(offset_begin, thrust::next(offset_begin));
+  return thrust::make_transform_iterator(zipped, detail::offset_pair_to_count_functor{});
 }
 
 /**

--- a/cpp/include/cuspatial_test/random.cuh
+++ b/cpp/include/cuspatial_test/random.cuh
@@ -62,7 +62,7 @@ using integral_to_realType =
                      std::conditional_t<sizeof(T) * 8 <= 23, float, double>>;
 
 /**
- * @brief Generates a normal distribution between zero and upper_bound.
+ * @brief Generates a normal distribution between lower_bound and upper_bound.
  */
 template <typename T>
 auto make_normal_dist(T lower_bound, T upper_bound)

--- a/cpp/tests/utility_test/test_geometry_generators.cu
+++ b/cpp/tests/utility_test/test_geometry_generators.cu
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "thrust/detail/advance.inl"
 #include <cuspatial_test/base_fixture.hpp>
 #include <cuspatial_test/geometry_generator.cuh>
 #include <cuspatial_test/vector_equality.hpp>
 
 #include <cuspatial/geometry/vec_2d.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <gtest/gtest-param-test.h>
 #include <type_traits>
+
+#include <fstream>
 
 using namespace cuspatial;
 using namespace cuspatial::test;
@@ -319,4 +323,51 @@ INSTANTIATE_TEST_SUITE_P(
                      ::testing::Values<std::size_t>(1, 30),   // num_polygons_per_multipolygon
                      ::testing::Values<std::size_t>(0, 100),  // num_holes_per_polygon
                      ::testing::Values<std::size_t>(3, 100)   // num_sides_per_ring
+                     ));
+
+struct MultiPointFactoryStatsValidator : public BaseFixtureWithParam<std::size_t, std::size_t> {
+  void run(multipoint_generator_parameter_normal<float> params)
+  {
+    auto got = generate_multipoint_array(params, stream());
+
+    auto [got_geometry_offsets, got_coordinates] = got.release();
+
+    auto num_geometry_counts_it =
+      make_element_count_iterator_from_offset(got_geometry_offsets.begin());
+
+    auto h = cuspatial::test::to_host<std::size_t>(got_geometry_offsets);
+
+    std::ofstream ofs("/home/coder/output.txt", std::ios::out);
+    for (std::size_t i = 0; i < h.size() - 1; ++i) {
+      ofs << h[i + 1] - h[i] << ", ";
+    }
+    ofs.close();
+
+    EXPECT_TRUE(thrust::all_of(rmm::exec_policy(stream()),
+                               num_geometry_counts_it,
+                               thrust::next(num_geometry_counts_it, params.num_multipoints()),
+                               [] __device__(auto count) { return count >= 1; }));
+    EXPECT_EQ(got_geometry_offsets.size(), params.num_multipoints() + 1);
+  }
+};
+
+TEST_P(MultiPointFactoryStatsValidator, CountsVerification)
+{
+  // Structured binding unsupported by Gtest
+  std::size_t num_multipoints            = std::get<0>(GetParam());
+  std::size_t num_points_per_multipoints = std::get<1>(GetParam());
+
+  auto params = multipoint_generator_parameter_normal<float>{num_multipoints,
+                                                             num_points_per_multipoints,
+                                                             vec_2d<float>{0.0, 0.0},
+                                                             vec_2d<float>{1.0, 1.0},
+                                                             5.0};
+  CUSPATIAL_RUN_TEST(this->run, params);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  MultiPointFactoryStatsValidators,
+  MultiPointFactoryStatsValidator,
+  ::testing::Combine(::testing::Values<std::size_t>(1, 1000),  // num_multipoints
+                     ::testing::Values<std::size_t>(1, 30)     // num_points_per_multipoints
                      ));


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR closes #1161 

This PR adds normal distribution to the number of points, linestrings and polygons in the geometry generators. The generator API hasn't change, the parameters structs are now strongly typed with two different types: `multipoint_generator_parameter_idendity` and `multipoint_generator_parameter_normal`. They compose with the current `multipoint_generator_parameter` struct, which is now a detail struct that holds the basic parameters of a generator.

In the `*_idendity` generator case, the generator behave as it is today - every pair has exactly the same number of geometry per pair.

In the `*_normal` generator case, each of the count parameter is treated as the mean of the distribution and sampled with a normal distribution, an additional `stddev` parameter is provided to control the variance.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
