### PR TITLE
Fix a small typo in pairwise_linestring_distance

### DIFF
--- a/cpp/include/cuspatial/distance.cuh
+++ b/cpp/include/cuspatial/distance.cuh
@@ -235,9 +235,9 @@ OutputIt pairwise_point_polygon_distance(MultiPointRange multipoints,
  * [LinkLRAI]: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
  * "LegacyRandomAccessIterator"
  */
-template <class MultiLinestringRange1, class MultiLinstringRange2, class OutputIt>
+template <class MultiLinestringRange1, class MultiLinestringRange2, class OutputIt>
 OutputIt pairwise_linestring_distance(MultiLinestringRange1 multilinestrings1,
-                                      MultiLinstringRange2 multilinestrings2,
+                                      MultiLinestringRange2 multilinestrings2,
                                       OutputIt distances_first,
                                       rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. --> <!-- Reference any issues closed by this PR with "closes #1234". --> <!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR fixes a small typo in pairwise_linestring_distance

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md). 
- [x] New or existing tests cover these changes. 
- [x] The documentation is up to date with these changes.

