### PR TITLE
Add author credit to zipcode counting notebook, fix cudf string processing argument

### DIFF
--- a/notebooks/ZipCodes_Stops_PiP_cuSpatial.ipynb
+++ b/notebooks/ZipCodes_Stops_PiP_cuSpatial.ipynb
@@ -1,14 +1,18 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "458fe838-b143-4d31-9ddd-8efd0217f4a7",
    "metadata": {},
    "source": [
-    "# Stop Sign Counting By Zipcode in California"
+    "# Stop Sign Counting By Zipcode in California\n",
+    "\n",
+    "Author: Everett Spackman, Michael Wang, Thomson Comer, Ben Jarmak"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6931011f-0d83-45ce-b254-4b5424b82624",
    "metadata": {},
@@ -59,6 +63,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "497810f3-acf0-4472-a187-322413c9db11",
    "metadata": {},
@@ -108,6 +113,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "044c84d9-2f82-4de5-a4c5-b7b9e5ef6b93",
    "metadata": {},
@@ -144,6 +150,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "50b8d8bc-378f-4faa-b60c-e8f0ff507b2a",
    "metadata": {},
@@ -170,6 +177,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6fdaedfc-2d7f-4d73-a9b8-e3a8131bea2f",
    "metadata": {},
@@ -221,7 +229,7 @@
     "    # split polygons into rings\n",
     "    wkts, num_rings = traverse(wkts, \"\\),\\s?\\(\", regex=True)\n",
     "    # split coordinates into lists\n",
-    "    wkts, num_coords = traverse(wkts, \",\", regex=True)\n",
+    "    wkts, num_coords = traverse(wkts, \",\")\n",
     "    # split into x-y coordinates\n",
     "    wkts = wkts.str.split(\" \")\n",
     "    wkts = wkts.explode().astype(cp.dtype(dtype))\n",
@@ -400,6 +408,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "eda8fb4c-39ec-44e2-9163-cbbdd91eeb1d",
    "metadata": {},
@@ -468,6 +477,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ab387f5a-cf7e-49d4-b3c8-c5b4b059cd4d",
    "metadata": {},
@@ -476,6 +486,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6446d81b-006a-4a0b-995b-a001c9b7766f",
    "metadata": {},
@@ -604,6 +615,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4b61f534-faa4-4465-b47b-fb717169f30e",
    "metadata": {},
@@ -668,6 +680,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d1f2af42-affb-4e9e-ac24-b5583641a366",
    "metadata": {},
@@ -734,6 +747,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e05fc526-c935-417f-9f53-0f13a0c6d02a",
    "metadata": {},


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR fixes the usage of a small cudf string processing method. `regex` should be set to false for `.str.split` without
regex delimiter. In addition, adds credit to authors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
