### PR TITLE
Add streams to allocate_like call

### DIFF
--- a/cpp/src/distance/haversine.cu
+++ b/cpp/src/distance/haversine.cu
@@ -54,7 +54,7 @@ struct haversine_functor {
     if (a_lon.is_empty()) { return cudf::empty_like(a_lon); }
 
     auto mask_policy = cudf::mask_allocation_policy::NEVER;
-    auto result      = cudf::allocate_like(a_lon, a_lon.size(), mask_policy, mr);
+    auto result      = cudf::allocate_like(a_lon, a_lon.size(), mask_policy, stream, mr);
 
     auto lonlat_a = cuspatial::make_vec_2d_iterator(a_lon.begin<T>(), a_lat.begin<T>());
     auto lonlat_b = cuspatial::make_vec_2d_iterator(b_lon.begin<T>(), b_lat.begin<T>());

--- a/cpp/src/trajectory/derive_trajectories.cu
+++ b/cpp/src/trajectory/derive_trajectories.cu
@@ -47,10 +47,10 @@ struct derive_trajectories_dispatch {
   {
     auto cols = std::vector<std::unique_ptr<cudf::column>>{};
     cols.reserve(4);
-    cols.push_back(cudf::allocate_like(object_id, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(x, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(y, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(timestamp, cudf::mask_allocation_policy::NEVER, mr));
+    cols.push_back(cudf::allocate_like(object_id, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(x, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(y, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(timestamp, cudf::mask_allocation_policy::NEVER, stream, mr));
 
     auto points_begin     = thrust::make_zip_iterator(x.begin<T>(), y.begin<T>());
     auto points_out_begin = thrust::make_zip_iterator(cols[1]->mutable_view().begin<T>(),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

rapidsai/cudf#13629 added stream argument to all copying APIs. This fix makes sure cuspatial usage is compliant.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
