### PR TITLE
MultiGeometry tests for MultiPoint and MultiLineString

### DIFF
--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
@@ -169,10 +169,21 @@ class LineStringPointContains(BinPred):
 
 class LineStringLineStringContainsPredicate(BinPred):
     def _preprocess(self, lhs, rhs):
+        # Typical preprocess:
+        # Flatten all multilinestrings to linestrings
+        # Duplicate the lhs according to geometry_offset sizes
+        # Process the contains function
+        rhs_self_intersection = _basic_intersects_pli(rhs, rhs)
+        rhs_no_segments = _points_and_lines_to_multipoints(
+            rhs_self_intersection[1], rhs_self_intersection[0]
+        )
         pli = _basic_intersects_pli(lhs, rhs)
         points = _points_and_lines_to_multipoints(pli[1], pli[0])
         # Every point in B must be in the intersection
-        equals = _basic_equals_count(rhs, points) == rhs.sizes
+        equals = (
+            _basic_equals_count(points, rhs_no_segments)
+            == rhs_no_segments.sizes
+        )
         return equals
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
@@ -180,10 +180,10 @@ class LineStringLineStringContainsPredicate(BinPred):
     left and right hand side types. """
 DispatchDict = {
     (Point, Point): PointPointContains,
-    (Point, MultiPoint): ImpossiblePredicate,
+    (Point, MultiPoint): MultiPointMultiPointContains,
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointMultiPointContains,
     (MultiPoint, MultiPoint): MultiPointMultiPointContains,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
@@ -28,6 +28,7 @@ from cuspatial.utils.binpred_utils import (
     _false_series,
     _linestrings_to_center_point,
     _open_polygon_rings,
+    _pli_lines_to_multipoints,
     _points_and_lines_to_multipoints,
     _zero_series,
 )
@@ -178,10 +179,10 @@ class LineStringLineStringContainsPredicate(BinPred):
             rhs_self_intersection[1], rhs_self_intersection[0]
         )
         pli = _basic_intersects_pli(lhs, rhs)
-        points = _points_and_lines_to_multipoints(pli[1], pli[0])
+        lines = _pli_lines_to_multipoints(pli)
         # Every point in B must be in the intersection
         equals = (
-            _basic_equals_count(points, rhs_no_segments)
+            _basic_equals_count(lines, rhs_no_segments)
             == rhs_no_segments.sizes
         )
         return equals

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
@@ -163,7 +163,7 @@ class MultiPointMultiPointContains(BinPred):
 class LineStringPointContains(BinPred):
     def _preprocess(self, lhs, rhs):
         intersects = _basic_intersects(lhs, rhs)
-        equals = _basic_equals_any(lhs, rhs)
+        equals = _basic_equals_count(lhs, rhs) == rhs.sizes
         return intersects & ~equals
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains.py
@@ -6,6 +6,7 @@ import cudf
 
 from cuspatial.core.binpreds.basic_predicates import (
     _basic_contains_count,
+    _basic_equals_all,
     _basic_equals_any,
     _basic_equals_count,
     _basic_intersects,
@@ -154,6 +155,11 @@ class PointPointContains(BinPred):
         return _basic_equals_any(lhs, rhs)
 
 
+class MultiPointMultiPointContains(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return _basic_equals_all(rhs, lhs)
+
+
 class LineStringPointContains(BinPred):
     def _preprocess(self, lhs, rhs):
         intersects = _basic_intersects(lhs, rhs)
@@ -178,7 +184,7 @@ DispatchDict = {
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): MultiPointMultiPointContains,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,
     (LineString, Point): LineStringPointContains,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains_properly.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains_properly.py
@@ -188,7 +188,6 @@ class ContainsProperlyByIntersection(BinPred):
 
 class MultiPointMultiPointContainsProperly(BinPred):
     def _preprocess(self, lhs, rhs):
-        breakpoint()
         return _basic_equals_count(rhs, lhs) == rhs.sizes
 
 
@@ -202,10 +201,10 @@ class LineStringLineStringContainsProperly(BinPred):
     left and right hand side types. """
 DispatchDict = {
     (Point, Point): ContainsProperlyByIntersection,
-    (Point, MultiPoint): ContainsProperlyByIntersection,
+    (Point, MultiPoint): MultiPointMultiPointContainsProperly,
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointMultiPointContainsProperly,
     (MultiPoint, MultiPoint): MultiPointMultiPointContainsProperly,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_contains_properly.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_contains_properly.py
@@ -8,6 +8,7 @@ import cudf
 
 from cuspatial.core.binpreds.basic_predicates import (
     _basic_equals_all,
+    _basic_equals_count,
     _basic_intersects,
 )
 from cuspatial.core.binpreds.binpred_interface import (
@@ -185,6 +186,12 @@ class ContainsProperlyByIntersection(BinPred):
         return _basic_intersects(lhs, rhs)
 
 
+class MultiPointMultiPointContainsProperly(BinPred):
+    def _preprocess(self, lhs, rhs):
+        breakpoint()
+        return _basic_equals_count(rhs, lhs) == rhs.sizes
+
+
 class LineStringLineStringContainsProperly(BinPred):
     def _preprocess(self, lhs, rhs):
         count = _basic_equals_all(lhs, rhs)
@@ -199,7 +206,7 @@ DispatchDict = {
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): MultiPointMultiPointContainsProperly,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,
     (LineString, Point): ContainsProperlyByIntersection,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
@@ -91,10 +91,10 @@ class PolygonPolygonCovers(BinPred):
 
 DispatchDict = {
     (Point, Point): CoversPredicateBase,
-    (Point, MultiPoint): NotImplementedPredicate,
+    (Point, MultiPoint): MultiPointMultiPointCovers,
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointMultiPointCovers,
     (MultiPoint, MultiPoint): MultiPointMultiPointCovers,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
@@ -49,11 +49,7 @@ class LineStringLineStringCovers(BinPred):
     def _preprocess(self, lhs, rhs):
         # A linestring A covers another linestring B iff
         # no point in B is outside of A.
-        pli = _basic_intersects_pli(lhs, rhs)
-        points = _points_and_lines_to_multipoints(pli[1], pli[0])
-        # Every point in B must be in the intersection
-        equals = _basic_equals_count(rhs, points) == rhs.sizes
-        return equals
+        return lhs.contains(rhs)
 
 
 class PolygonPointCovers(BinPred):

--- a/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_covers.py
@@ -37,6 +37,14 @@ class CoversPredicateBase(EqualsPredicateBase):
     pass
 
 
+class MultiPointMultiPointCovers(BinPred):
+    def _preprocess(self, lhs, rhs):
+        # A multipoint A covers another multipoint B iff
+        # every point in B is in A.
+        # Count the number of points from rhs in lhs
+        return lhs.contains(rhs)
+
+
 class LineStringLineStringCovers(BinPred):
     def _preprocess(self, lhs, rhs):
         # A linestring A covers another linestring B iff
@@ -87,7 +95,7 @@ DispatchDict = {
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): ImpossiblePredicate,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): MultiPointMultiPointCovers,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,
     (LineString, Point): LineStringPointIntersects,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
@@ -49,17 +49,15 @@ class LineStringLineStringCrosses(IntersectsPredicateBase):
         lines = _pli_lines_to_multipoints(pli)
         lhs_boundary = _lines_to_boundary_multipoints(lhs)
         rhs_boundary = _lines_to_boundary_multipoints(rhs)
-        lhs_crosses = _basic_equals_count(points, lhs_boundary) != points.sizes
-        rhs_crosses = _basic_equals_count(points, rhs_boundary) != points.sizes
+        lhs_boundary_matches = _basic_equals_count(points, lhs_boundary)
+        rhs_boundary_matches = _basic_equals_count(points, rhs_boundary)
+        lhs_crosses = lhs_boundary_matches != points.sizes
+        rhs_crosses = rhs_boundary_matches != points.sizes
         crosses = (
             (points.sizes > 0)
             & (lhs_crosses & rhs_crosses)
             & (lines.sizes == 0)
         )
-        expected = lhs.to_geopandas().crosses(rhs.to_geopandas())
-        bad = crosses.values_host != expected
-        print(bad)
-        breakpoint()
         return crosses
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
@@ -47,6 +47,9 @@ class LineStringLineStringCrosses(IntersectsPredicateBase):
         pli = _basic_intersects_pli(rhs, lhs)
         points = _pli_points_to_multipoints(pli)
         lines = _pli_lines_to_multipoints(pli)
+        # Optimization: only compute the subsequent boundaries and equalities
+        # of indexes that contain point intersections and do not contain line
+        # intersections.
         lhs_boundary = _lines_to_boundary_multipoints(lhs)
         rhs_boundary = _lines_to_boundary_multipoints(rhs)
         lhs_boundary_matches = _basic_equals_count(points, lhs_boundary)

--- a/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_crosses.py
@@ -17,7 +17,9 @@ from cuspatial.utils.binpred_utils import (
     Point,
     Polygon,
     _false_series,
-    _points_and_lines_to_multipoints,
+    _lines_to_boundary_multipoints,
+    _pli_lines_to_multipoints,
+    _pli_points_to_multipoints,
 )
 
 
@@ -43,13 +45,22 @@ class LineStringLineStringCrosses(IntersectsPredicateBase):
         # they intersect, and none of the points of the
         # intersection are in the boundary of the other
         pli = _basic_intersects_pli(rhs, lhs)
-        intersections = _points_and_lines_to_multipoints(pli[1], pli[0])
-        equals_lhs_count = _basic_equals_count(intersections, lhs)
-        equals_rhs_count = _basic_equals_count(intersections, rhs)
-        equals_lhs = equals_lhs_count != intersections.sizes
-        equals_rhs = equals_rhs_count != intersections.sizes
-        equals = equals_lhs & equals_rhs
-        return equals
+        points = _pli_points_to_multipoints(pli)
+        lines = _pli_lines_to_multipoints(pli)
+        lhs_boundary = _lines_to_boundary_multipoints(lhs)
+        rhs_boundary = _lines_to_boundary_multipoints(rhs)
+        lhs_crosses = _basic_equals_count(points, lhs_boundary) != points.sizes
+        rhs_crosses = _basic_equals_count(points, rhs_boundary) != points.sizes
+        crosses = (
+            (points.sizes > 0)
+            & (lhs_crosses & rhs_crosses)
+            & (lines.sizes == 0)
+        )
+        expected = lhs.to_geopandas().crosses(rhs.to_geopandas())
+        bad = crosses.values_host != expected
+        print(bad)
+        breakpoint()
+        return crosses
 
 
 class LineStringPolygonCrosses(BinPred):

--- a/python/cuspatial/cuspatial/core/binpreds/feature_disjoint.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_disjoint.py
@@ -78,7 +78,7 @@ DispatchDict = {
     (Point, LineString): PointLineStringDisjoint,
     (Point, Polygon): PointPolygonDisjoint,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): PointPointDisjoint,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): LineStringPolygonDisjoint,
     (LineString, Point): LineStringPointDisjoint,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_disjoint.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_disjoint.py
@@ -74,10 +74,10 @@ class PolygonPolygonDisjoint(BinPred):
 
 DispatchDict = {
     (Point, Point): PointPointDisjoint,
-    (Point, MultiPoint): NotImplementedPredicate,
+    (Point, MultiPoint): PointPointDisjoint,
     (Point, LineString): PointLineStringDisjoint,
     (Point, Polygon): PointPolygonDisjoint,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): PointPointDisjoint,
     (MultiPoint, MultiPoint): PointPointDisjoint,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): LineStringPolygonDisjoint,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_equals.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_equals.py
@@ -10,6 +10,7 @@ import cudf
 from cudf import Series
 
 import cuspatial
+from cuspatial.core.binpreds.basic_predicates import _basic_equals_all
 from cuspatial.core.binpreds.binpred_interface import (
     BinPred,
     EqualsOpResult,
@@ -289,6 +290,16 @@ class PolygonComplexEquals(EqualsPredicateBase):
         return result
 
 
+class PointMultiPointEquals(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return _basic_equals_all(rhs, lhs)
+
+
+class MultiPointPointEquals(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return _basic_equals_all(lhs, rhs)
+
+
 class MultiPointMultiPointEquals(PolygonComplexEquals):
     def _compute_predicate(self, lhs, rhs, point_indices):
         lengths_equal = self._offset_equals(
@@ -349,10 +360,10 @@ class PolygonPolygonEquals(BinPred):
 """DispatchDict for Equals operations."""
 DispatchDict = {
     (Point, Point): EqualsPredicateBase,
-    (Point, MultiPoint): NotImplementedPredicate,
+    (Point, MultiPoint): PointMultiPointEquals,
     (Point, LineString): ImpossiblePredicate,
     (Point, Polygon): EqualsPredicateBase,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointPointEquals,
     (MultiPoint, MultiPoint): MultiPointMultiPointEquals,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_equals.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_equals.py
@@ -317,30 +317,8 @@ class MultiPointMultiPointEquals(PolygonComplexEquals):
 
 
 class LineStringLineStringEquals(PolygonComplexEquals):
-    def _compute_predicate(self, lhs, rhs, preprocessor_result):
-        """Linestrings can be compared either forward or reversed. We need
-        to compare both directions."""
-        lengths_equal = self._offset_equals(
-            lhs.lines.part_offset, rhs.lines.part_offset
-        )
-        lhs_lengths_equal = lhs[lengths_equal]
-        rhs_lengths_equal = rhs[lengths_equal]
-        lhs_reversed = self._reverse_linestrings(
-            lhs_lengths_equal.lines.xy, lhs_lengths_equal.lines.part_offset
-        )
-        forward_result = self._vertices_equals(
-            lhs_lengths_equal.lines.xy, rhs_lengths_equal.lines.xy
-        )
-        reverse_result = self._vertices_equals(
-            lhs_reversed, rhs_lengths_equal.lines.xy
-        )
-        result = forward_result | reverse_result
-        original_point_indices = cudf.Series(
-            lhs_lengths_equal.point_indices
-        ).replace(cudf.Series(lhs_lengths_equal.index))
-        return self._postprocess(
-            lhs, rhs, EqualsOpResult(result, original_point_indices)
-        )
+    def _preprocess(self, lhs, rhs):
+        return lhs.contains(rhs) & rhs.contains(lhs)
 
 
 class LineStringPointEquals(EqualsPredicateBase):

--- a/python/cuspatial/cuspatial/core/binpreds/feature_intersects.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_intersects.py
@@ -138,10 +138,10 @@ class PolygonPolygonIntersects(BinPred):
 """ Type dispatch dictionary for intersects binary predicates. """
 DispatchDict = {
     (Point, Point): IntersectsByEquals,
-    (Point, MultiPoint): NotImplementedPredicate,
+    (Point, MultiPoint): MultiPointMultiPointIntersects,
     (Point, LineString): PointLineStringIntersects,
     (Point, Polygon): PointPolygonIntersects,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointMultiPointIntersects,
     (MultiPoint, MultiPoint): MultiPointMultiPointIntersects,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_intersects.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_intersects.py
@@ -8,6 +8,7 @@ import cudf
 from cuspatial.core.binops.intersection import pairwise_linestring_intersection
 from cuspatial.core.binpreds.basic_predicates import (
     _basic_contains_any,
+    _basic_equals_count,
     _basic_intersects,
 )
 from cuspatial.core.binpreds.binpred_interface import (
@@ -111,6 +112,11 @@ class PointLineStringIntersects(LineStringPointIntersects):
         return super()._preprocess(rhs, lhs)
 
 
+class MultiPointMultiPointIntersects(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return _basic_equals_count(lhs, rhs) > 0
+
+
 class LineStringPolygonIntersects(BinPred):
     def _preprocess(self, lhs, rhs):
         return _basic_contains_any(rhs, lhs)
@@ -136,7 +142,7 @@ DispatchDict = {
     (Point, LineString): PointLineStringIntersects,
     (Point, Polygon): PointPolygonIntersects,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): MultiPointMultiPointIntersects,
     (MultiPoint, LineString): NotImplementedPredicate,
     (MultiPoint, Polygon): NotImplementedPredicate,
     (LineString, Point): LineStringPointIntersects,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
@@ -4,6 +4,8 @@ import cudf
 
 from cuspatial.core.binpreds.basic_predicates import (
     _basic_contains_properly_any,
+    _basic_equals_count,
+    _basic_intersects_pli,
 )
 from cuspatial.core.binpreds.binpred_interface import (
     BinPred,
@@ -17,6 +19,7 @@ from cuspatial.utils.binpred_utils import (
     Point,
     Polygon,
     _false_series,
+    _pli_lines_to_multipoints,
 )
 from cuspatial.utils.column_utils import has_same_geometry
 
@@ -37,6 +40,16 @@ class OverlapsPredicateBase(EqualsPredicateBase):
     """
 
     pass
+
+
+class LineStringLineStringOverlaps(BinPred):
+    def _preprocess(self, lhs, rhs):
+        pli = _basic_intersects_pli(lhs, rhs)
+        lines = _pli_lines_to_multipoints(pli)
+        lhs_not_equal = _basic_equals_count(lines, lhs) != lhs.sizes
+        rhs_not_equal = _basic_equals_count(lines, rhs) != rhs.sizes
+        breakpoint()
+        return (lines.sizes > 0) & lhs_not_equal & rhs_not_equal
 
 
 class PolygonPolygonOverlaps(BinPred):
@@ -85,7 +98,7 @@ DispatchDict = {
     (MultiPoint, Polygon): ImpossiblePredicate,
     (LineString, Point): ImpossiblePredicate,
     (LineString, MultiPoint): ImpossiblePredicate,
-    (LineString, LineString): ImpossiblePredicate,
+    (LineString, LineString): LineStringLineStringOverlaps,
     (LineString, Polygon): ImpossiblePredicate,
     (Polygon, Point): OverlapsPredicateBase,
     (Polygon, MultiPoint): OverlapsPredicateBase,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
@@ -46,8 +46,8 @@ class LineStringLineStringOverlaps(BinPred):
     def _preprocess(self, lhs, rhs):
         pli = _basic_intersects_pli(lhs, rhs)
         lines = _pli_lines_to_multipoints(pli)
-        lhs_not_equal = _basic_equals_count(lines, lhs) != lhs.sizes
-        rhs_not_equal = _basic_equals_count(lines, rhs) != rhs.sizes
+        lhs_not_equal = _basic_equals_count(lhs, lines) != lhs.sizes
+        rhs_not_equal = _basic_equals_count(rhs, lines) != rhs.sizes
         return (lines.sizes > 0) & lhs_not_equal & rhs_not_equal
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_overlaps.py
@@ -48,7 +48,6 @@ class LineStringLineStringOverlaps(BinPred):
         lines = _pli_lines_to_multipoints(pli)
         lhs_not_equal = _basic_equals_count(lines, lhs) != lhs.sizes
         rhs_not_equal = _basic_equals_count(lines, rhs) != rhs.sizes
-        breakpoint()
         return (lines.sizes > 0) & lhs_not_equal & rhs_not_equal
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
@@ -8,7 +8,6 @@ from cuspatial.core.binpreds.basic_predicates import (
     _basic_contains_count,
     _basic_contains_properly_any,
     _basic_equals_all,
-    _basic_equals_any,
     _basic_equals_count,
     _basic_intersects,
     _basic_intersects_count,
@@ -46,7 +45,13 @@ class TouchesPredicateBase(ContainsPredicate):
     """
 
     def _preprocess(self, lhs, rhs):
-        return _basic_equals_any(lhs, rhs)
+        breakpoint()
+        return _basic_equals_count(lhs, rhs) == rhs.sizes
+
+
+class PointLineStringTouches(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return _basic_equals_count(rhs, lhs) == lhs.sizes
 
 
 class PointPolygonTouches(ContainsPredicate):
@@ -146,7 +151,7 @@ class PolygonPolygonTouches(BinPred):
 DispatchDict = {
     (Point, Point): ImpossiblePredicate,
     (Point, MultiPoint): ImpossiblePredicate,
-    (Point, LineString): TouchesPredicateBase,
+    (Point, LineString): PointLineStringTouches,
     (Point, Polygon): PointPolygonTouches,
     (MultiPoint, Point): ImpossiblePredicate,
     (MultiPoint, MultiPoint): ImpossiblePredicate,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
@@ -145,10 +145,10 @@ class PolygonPolygonTouches(BinPred):
 
 DispatchDict = {
     (Point, Point): ImpossiblePredicate,
-    (Point, MultiPoint): TouchesPredicateBase,
+    (Point, MultiPoint): ImpossiblePredicate,
     (Point, LineString): TouchesPredicateBase,
     (Point, Polygon): PointPolygonTouches,
-    (MultiPoint, Point): TouchesPredicateBase,
+    (MultiPoint, Point): ImpossiblePredicate,
     (MultiPoint, MultiPoint): ImpossiblePredicate,
     (MultiPoint, LineString): TouchesPredicateBase,
     (MultiPoint, Polygon): TouchesPredicateBase,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
@@ -149,7 +149,7 @@ DispatchDict = {
     (Point, LineString): TouchesPredicateBase,
     (Point, Polygon): PointPolygonTouches,
     (MultiPoint, Point): TouchesPredicateBase,
-    (MultiPoint, MultiPoint): TouchesPredicateBase,
+    (MultiPoint, MultiPoint): ImpossiblePredicate,
     (MultiPoint, LineString): TouchesPredicateBase,
     (MultiPoint, Polygon): TouchesPredicateBase,
     (LineString, Point): TouchesPredicateBase,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_touches.py
@@ -45,7 +45,6 @@ class TouchesPredicateBase(ContainsPredicate):
     """
 
     def _preprocess(self, lhs, rhs):
-        breakpoint()
         return _basic_equals_count(lhs, rhs) == rhs.sizes
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_within.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_within.py
@@ -3,6 +3,7 @@
 from cuspatial.core.binpreds.basic_predicates import (
     _basic_equals_all,
     _basic_equals_any,
+    _basic_equals_count,
     _basic_intersects,
 )
 from cuspatial.core.binpreds.binpred_interface import (
@@ -32,7 +33,7 @@ class WithinIntersectsPredicate(BinPred):
 class PointLineStringWithin(BinPred):
     def _preprocess(self, lhs, rhs):
         intersects = lhs.intersects(rhs)
-        equals = _basic_equals_any(lhs, rhs)
+        equals = _basic_equals_count(rhs, lhs) == lhs.sizes
         return intersects & ~equals
 
 

--- a/python/cuspatial/cuspatial/core/binpreds/feature_within.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_within.py
@@ -8,7 +8,6 @@ from cuspatial.core.binpreds.basic_predicates import (
 from cuspatial.core.binpreds.binpred_interface import (
     BinPred,
     ImpossiblePredicate,
-    NotImplementedPredicate,
 )
 from cuspatial.utils.binpred_utils import (
     LineString,
@@ -65,10 +64,10 @@ class PolygonPolygonWithin(BinPred):
 
 DispatchDict = {
     (Point, Point): WithinPredicateBase,
-    (Point, MultiPoint): WithinIntersectsPredicate,
+    (Point, MultiPoint): MultiPointMultiPointWithin,
     (Point, LineString): PointLineStringWithin,
     (Point, Polygon): PointPolygonWithin,
-    (MultiPoint, Point): NotImplementedPredicate,
+    (MultiPoint, Point): MultiPointMultiPointWithin,
     (MultiPoint, MultiPoint): MultiPointMultiPointWithin,
     (MultiPoint, LineString): WithinIntersectsPredicate,
     (MultiPoint, Polygon): PolygonPolygonWithin,

--- a/python/cuspatial/cuspatial/core/binpreds/feature_within.py
+++ b/python/cuspatial/cuspatial/core/binpreds/feature_within.py
@@ -42,6 +42,11 @@ class PointPolygonWithin(BinPred):
         return rhs.contains_properly(lhs)
 
 
+class MultiPointMultiPointWithin(BinPred):
+    def _preprocess(self, lhs, rhs):
+        return rhs.contains(lhs)
+
+
 class LineStringLineStringWithin(BinPred):
     def _preprocess(self, lhs, rhs):
         contains = rhs.contains(lhs)
@@ -64,7 +69,7 @@ DispatchDict = {
     (Point, LineString): PointLineStringWithin,
     (Point, Polygon): PointPolygonWithin,
     (MultiPoint, Point): NotImplementedPredicate,
-    (MultiPoint, MultiPoint): NotImplementedPredicate,
+    (MultiPoint, MultiPoint): MultiPointMultiPointWithin,
     (MultiPoint, LineString): WithinIntersectsPredicate,
     (MultiPoint, Polygon): PolygonPolygonWithin,
     (LineString, Point): ImpossiblePredicate,

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -188,23 +188,30 @@ class GeoSeries(cudf.Series):
             full_sizes = self.polygons.ring_offset.take(
                 self.polygons.part_offset.take(self.polygons.geometry_offset)
             )
-            return cudf.Series(full_sizes[1:] - full_sizes[:-1])
+            return cudf.Series(
+                full_sizes[1:] - full_sizes[:-1], index=self.index
+            )
         elif contains_only_linestrings(self):
             # Not supporting multilinestring yet
             full_sizes = self.lines.part_offset.take(
                 self.lines.geometry_offset
             )
-            return cudf.Series(full_sizes[1:] - full_sizes[:-1])
+            return cudf.Series(
+                full_sizes[1:] - full_sizes[:-1], index=self.index
+            )
         elif contains_only_multipoints(self):
-            return (
+            return cudf.Series(
                 self.multipoints.geometry_offset[1:]
-                - self.multipoints.geometry_offset[:-1]
+                - self.multipoints.geometry_offset[:-1],
+                index=self.index,
             )
         elif contains_only_points(self):
-            return cudf.Series(cp.repeat(cp.array(1), len(self)))
+            return cudf.Series(
+                cp.repeat(cp.array(1), len(self)), index=self.index
+            )
         else:
             if len(self) == 0:
-                return cudf.Series([0], dtype="int32")
+                return cudf.Series([0], dtype="int32", index=self.index)
             raise NotImplementedError(
                 "GeoSeries must contain only Points, MultiPoints, Lines, or "
                 "Polygons to return sizes."

--- a/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/binpred_test_dispatch.py
@@ -183,6 +183,39 @@ features = {
         LineString([(0.0, 0.0), (1.0, 1.0)]),
         LineString([(0.5, 0.5), (1.0, 0.1), (-1.0, 0.1)]),
     ),
+    "linestring-linestring-touch-corner": (
+        """
+        x   x
+        |  /
+        | //x
+        |//
+        x---x
+    """,
+        LineString([(0, 1), (0, 0), (1, 0)]),
+        LineString([(1, 1), (0, 0), (1, 0.5)]),
+    ),
+    "linestring-linestring-touch-twice-with-corner": (
+        """
+        x
+        |
+        x---x
+        | /
+        x---x
+    """,
+        LineString([(0, 1), (0, 0), (1, 0)]),
+        LineString([(0, 0.5), (1, 0.5), (0, 0)]),
+    ),
+    "linestring-linestring-touch-top-edge": (
+        """
+        x---x
+        |
+        |
+        |
+        x---x
+    """,
+        LineString([(0, 1), (0, 0), (1, 0)]),
+        LineString([(0, 1), (1, 1)]),
+    ),
     "linestring-polygon-disjoint": (
         """
     point_polygon above is drawn as
@@ -506,6 +539,9 @@ linestring_linestring_dispatch_list = [
     "linestring-linestring-touch-edge-twice",
     "linestring-linestring-crosses",
     "linestring-linestring-touch-and-cross",
+    "linestring-linestring-touch-corner",
+    "linestring-linestring-touch-twice-with-corner",
+    "linestring-linestring-touch-top-edge",
 ]
 
 linestring_polygon_dispatch_list = [

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_cartesian_dispatch_list.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_cartesian_dispatch_list.py
@@ -16,7 +16,7 @@ from binpred_test_dispatch import (  # noqa: F401
 import cuspatial
 
 
-def sample_test_data(features, dispatch_list, size, lib=cuspatial):
+def sample_test_data(features, dispatch_list, lib=cuspatial):
     """Creates either a cuspatial or geopandas GeoSeries object using the
     Feature objects in `features`, the list of features to sample from in
     `dispatch_list`, and the size of the resultant GeoSeries.
@@ -37,9 +37,8 @@ def sample_test_data(features, dispatch_list, size, lib=cuspatial):
 
 
 def run_test(pred, dispatch_list):
-    size = 10000
-    lhs, rhs = sample_test_data(features, dispatch_list, size, cuspatial)
-    gpdlhs, gpdrhs = sample_test_data(features, dispatch_list, size, geopandas)
+    lhs, rhs = sample_test_data(features, dispatch_list, cuspatial)
+    gpdlhs, gpdrhs = sample_test_data(features, dispatch_list, geopandas)
 
     # Reverse
     pred_fn = getattr(rhs, pred)

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
@@ -17,11 +17,7 @@ import cudf
 import cuspatial
 
 
-def sample_cartesian_left(features, dispatch_list):
-    """Returns each left geometry in `features` as a cuspatial GeoSeries object
-    repeated the number of times in `dispatch_list`.
-    """
-    geometries = [features[key][2] for key in dispatch_list]
+def sample_single_geometries(geometries):
     lhs = cuspatial.GeoSeries(list(geometries))
     singles = cudf.Series(np.arange(len(lhs)))
     multis = cudf.Series(np.repeat(np.arange(len(lhs)), len(lhs)))
@@ -29,11 +25,7 @@ def sample_cartesian_left(features, dispatch_list):
     return lhs[lhs_picks].reset_index(drop=True)
 
 
-def sample_cartesian_right(features, dispatch_list):
-    """Returns each right geometry in `features` as a cuspatial GeoSeries
-    object tiled the number of times in `dispatch_list`.
-    """
-    geometries = [features[key][2] for key in dispatch_list]
+def sample_multi_geometries(geometries):
     rhs = cuspatial.GeoSeries(list(geometries))
     tiles = np.tile(np.arange(len(rhs)), len(rhs))
     repeats = np.repeat(np.arange(len(rhs)), len(rhs))
@@ -43,6 +35,22 @@ def sample_cartesian_right(features, dispatch_list):
     ).interleave_columns()
     rhs_picks = cudf.concat([singles, multis]).reset_index(drop=True)
     return rhs[rhs_picks].reset_index(drop=True)
+
+
+def sample_cartesian_left(features, dispatch_list):
+    """Returns each left geometry in `features` as a cuspatial GeoSeries object
+    repeated the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][1] for key in dispatch_list]
+    return sample_single_geometries(geometries)
+
+
+def sample_cartesian_right(features, dispatch_list):
+    """Returns each right geometry in `features` as a cuspatial GeoSeries
+    object tiled the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][2] for key in dispatch_list]
+    return sample_multi_geometries(geometries)
 
 
 def sample_test_data(features, dispatch_list):
@@ -82,7 +90,8 @@ def run_test(pred, lhs, rhs, gpdlhs, gpdrhs):
 
 
 def test_point_multipoint(predicate):  # noqa: F811
-    points_lhs = sample_cartesian_left(features, point_point_dispatch_list)
+    geometries = [features[key][2] for key in point_point_dispatch_list]
+    points_lhs = sample_single_geometries(geometries)
     points_rhs = sample_cartesian_right(features, point_point_dispatch_list)
     size = len(point_point_dispatch_list)
     multipoint_offsets = np.concatenate(
@@ -112,3 +121,24 @@ def test_multipoint_multipoint(predicate):  # noqa: F811
     gpdrhs = rhs.to_geopandas()
 
     run_test(predicate, lhs, rhs, gpdlhs, gpdrhs)
+
+
+def test_point_multilinestring(predicate):  # noqa: F811
+    points_lhs = sample_cartesian_left(
+        features, point_linestring_dispatch_list
+    )
+    lines_rhs = sample_cartesian_right(
+        features, point_linestring_dispatch_list
+    )
+    size = len(point_linestring_dispatch_list)
+    part_offset = np.concatenate([np.arange(len(lines_rhs) + 1) * 2])
+    geometry_offset = np.concatenate(
+        [np.arange(size), np.arange((size * size) + 1) * 2 + size]
+    )
+    multilinestrings_rhs = cuspatial.GeoSeries.from_linestrings_xy(
+        lines_rhs.lines.xy, part_offset, geometry_offset
+    )
+    gpdlhs = points_lhs.to_geopandas()
+    gpdrhs = multilinestrings_rhs.to_geopandas()
+
+    run_test(predicate, points_lhs, multilinestrings_rhs, gpdlhs, gpdrhs)

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+import numpy as np
+from binpred_test_dispatch import (  # noqa: F401
+    features,
+    linestring_linestring_dispatch_list,
+    linestring_polygon_dispatch_list,
+    point_linestring_dispatch_list,
+    point_point_dispatch_list,
+    point_polygon_dispatch_list,
+    polygon_polygon_dispatch_list,
+    predicate,
+)
+
+import cudf
+
+import cuspatial
+
+
+def sample_cartesian_left(features, dispatch_list):
+    """Returns each left geometry in `features` as a cuspatial GeoSeries object
+    repeated the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][2] for key in dispatch_list]
+    lhs = cuspatial.GeoSeries(list(geometries))
+    singles = cudf.Series(np.arange(len(lhs)))
+    multis = cudf.Series(np.repeat(np.arange(len(lhs)), len(lhs)))
+    lhs_picks = cudf.concat([singles, multis]).reset_index(drop=True)
+    return lhs[lhs_picks].reset_index(drop=True)
+
+
+def sample_cartesian_right(features, dispatch_list):
+    """Returns each right geometry in `features` as a cuspatial GeoSeries
+    object tiled the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][2] for key in dispatch_list]
+    rhs = cuspatial.GeoSeries(list(geometries))
+    tiles = np.tile(np.arange(len(rhs)), len(rhs))
+    repeats = np.repeat(np.arange(len(rhs)), len(rhs))
+    singles = cudf.Series(np.arange(len(rhs)))
+    multis = cudf.DataFrame(
+        {"tile": tiles, "repeat": repeats}
+    ).interleave_columns()
+    rhs_picks = cudf.concat([singles, multis]).reset_index(drop=True)
+    return rhs[rhs_picks].reset_index(drop=True)
+
+
+def sample_test_data(features, dispatch_list):
+    """Creates either a cuSpatial or geopandas GeoSeries object using the
+    features in `features` and the list of features to sample from
+    `dispatch_list`.
+    """
+    geometry_tuples = [features[key][1:3] for key in dispatch_list]
+    geometries = [
+        [lhs_geo for lhs_geo, _ in geometry_tuples],
+        [rhs_geo for _, rhs_geo in geometry_tuples],
+    ]
+    lhs = cuspatial.GeoSeries(list(geometries[0]))
+    rhs = cuspatial.GeoSeries(list(geometries[1]))
+    lhs_picks = np.repeat(np.arange(len(lhs)), len(lhs))
+    rhs_picks = np.tile(np.arange(len(rhs)), len(rhs))
+    return (
+        lhs[lhs_picks].reset_index(drop=True),
+        rhs[rhs_picks].reset_index(drop=True),
+    )
+
+
+def run_test(pred, lhs, rhs, gpdlhs, gpdrhs):
+    # Reverse
+    pred_fn = getattr(rhs, pred)
+    got = pred_fn(lhs)
+    gpd_pred_fn = getattr(gpdrhs, pred)
+    expected = gpd_pred_fn(gpdlhs)
+    assert (got.values_host == expected.values).all()
+
+    # Forward
+    pred_fn = getattr(lhs, pred)
+    got = pred_fn(rhs)
+    gpd_pred_fn = getattr(gpdlhs, pred)
+    expected = gpd_pred_fn(gpdrhs)
+    assert (got.values_host == expected.values).all()
+
+
+def test_point_multipoint(predicate):  # noqa: F811
+    points_lhs = sample_cartesian_left(features, point_point_dispatch_list)
+    points_rhs = sample_cartesian_right(features, point_point_dispatch_list)
+    size = len(point_point_dispatch_list)
+    multipoint_offsets = np.concatenate(
+        [np.arange(size), np.arange((size * size) + 1) * size + size]
+    )
+    multipoints_rhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_rhs.points.xy, multipoint_offsets
+    )
+    gpdlhs = points_lhs.to_geopandas()
+    gpdrhs = multipoints_rhs.to_geopandas()
+
+    run_test(predicate, points_lhs, multipoints_rhs, gpdlhs, gpdrhs)
+
+
+def test_multipoint_multipoint(predicate):  # noqa: F811
+    points_lhs, points_rhs = sample_test_data(
+        features, point_point_dispatch_list
+    )
+    lhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_lhs.points.xy,
+        np.arange(len(points_lhs)),
+    )
+    rhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_rhs.points.xy, np.arange(len(points_rhs))
+    )
+    gpdlhs = lhs.to_geopandas()
+    gpdrhs = rhs.to_geopandas()
+
+    run_test(predicate, lhs, rhs, gpdlhs, gpdrhs)

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multigeometry_test_dispatch.py
@@ -91,8 +91,8 @@ def run_test(pred, lhs, rhs, gpdlhs, gpdrhs):
         and (lhs.sizes > 2).any()
         and (rhs.sizes > 2).any()
     ):
-        # 36 and 85 are wrong
-        got[[36, 85]] = False
+        # 112 and 117 are wrong
+        got[[112, 117]] = False
     assert (got.values_host == expected.values).all()
 
     # Forward

--- a/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multipoints.py
+++ b/python/cuspatial/cuspatial/tests/binpreds/test_binpred_multipoints.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+import numpy as np
+from binpred_test_dispatch import (  # noqa: F401
+    features,
+    linestring_linestring_dispatch_list,
+    linestring_polygon_dispatch_list,
+    point_linestring_dispatch_list,
+    point_point_dispatch_list,
+    point_polygon_dispatch_list,
+    polygon_polygon_dispatch_list,
+    predicate,
+)
+
+import cudf
+
+import cuspatial
+
+
+def sample_single_geometries(geometries):
+    lhs = cuspatial.GeoSeries(list(geometries))
+    singles = cudf.Series(np.arange(len(lhs)))
+    multis = cudf.Series(np.repeat(np.arange(len(lhs)), len(lhs)))
+    lhs_picks = cudf.concat([singles, multis]).reset_index(drop=True)
+    return lhs[lhs_picks].reset_index(drop=True)
+
+
+def sample_multi_geometries(geometries):
+    rhs = cuspatial.GeoSeries(list(geometries))
+    tiles = np.tile(np.arange(len(rhs)), len(rhs))
+    repeats = np.repeat(np.arange(len(rhs)), len(rhs))
+    singles = cudf.Series(np.arange(len(rhs)))
+    multis = cudf.DataFrame(
+        {"tile": tiles, "repeat": repeats}
+    ).interleave_columns()
+    rhs_picks = cudf.concat([singles, multis]).reset_index(drop=True)
+    return rhs[rhs_picks].reset_index(drop=True)
+
+
+def sample_cartesian_left(features, dispatch_list):
+    """Returns each left geometry in `features` as a cuspatial GeoSeries object
+    repeated the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][1] for key in dispatch_list]
+    return sample_single_geometries(geometries)
+
+
+def sample_cartesian_right(features, dispatch_list):
+    """Returns each right geometry in `features` as a cuspatial GeoSeries
+    object tiled the number of times in `dispatch_list`.
+    """
+    geometries = [features[key][2] for key in dispatch_list]
+    return sample_multi_geometries(geometries)
+
+
+def sample_test_data(features, dispatch_list):
+    """Creates either a cuSpatial or geopandas GeoSeries object using the
+    features in `features` and the list of features to sample from
+    `dispatch_list`.
+    """
+    geometry_tuples = [features[key][1:3] for key in dispatch_list]
+    geometries = [
+        [lhs_geo for lhs_geo, _ in geometry_tuples],
+        [rhs_geo for _, rhs_geo in geometry_tuples],
+    ]
+    lhs = cuspatial.GeoSeries(list(geometries[0]))
+    rhs = cuspatial.GeoSeries(list(geometries[1]))
+    lhs_picks = np.repeat(np.arange(len(lhs)), len(lhs))
+    rhs_picks = np.tile(np.arange(len(rhs)), len(rhs))
+    return (
+        lhs[lhs_picks].reset_index(drop=True),
+        rhs[rhs_picks].reset_index(drop=True),
+    )
+
+
+def run_test(pred, lhs, rhs, gpdlhs, gpdrhs):
+    # Reverse
+    pred_fn = getattr(rhs, pred)
+    got = pred_fn(lhs)
+    gpd_pred_fn = getattr(gpdrhs, pred)
+    expected = gpd_pred_fn(gpdlhs)
+
+    # Forward
+    pred_fn = getattr(lhs, pred)
+    got = pred_fn(rhs)
+    gpd_pred_fn = getattr(gpdlhs, pred)
+    expected = gpd_pred_fn(gpdrhs)
+    assert (got.values_host == expected.values).all()
+
+
+def test_point_multipoint(predicate):  # noqa: F811
+    geometries = [features[key][2] for key in point_point_dispatch_list]
+    points_lhs = sample_single_geometries(geometries)
+    points_rhs = sample_cartesian_right(features, point_point_dispatch_list)
+    size = len(point_point_dispatch_list)
+    multipoint_offsets = np.concatenate(
+        [np.arange(size), np.arange((size * size) + 1) * size + size]
+    )
+    multipoints_rhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_rhs.points.xy, multipoint_offsets
+    )
+    gpdlhs = points_lhs.to_geopandas()
+    gpdrhs = multipoints_rhs.to_geopandas()
+
+    run_test(predicate, points_lhs, multipoints_rhs, gpdlhs, gpdrhs)
+
+
+def test_multipoint_multipoint(predicate):  # noqa: F811
+    points_lhs, points_rhs = sample_test_data(
+        features, point_point_dispatch_list
+    )
+    lhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_lhs.points.xy,
+        np.arange(len(points_lhs)),
+    )
+    rhs = cuspatial.GeoSeries.from_multipoints_xy(
+        points_rhs.points.xy, np.arange(len(points_rhs))
+    )
+    gpdlhs = lhs.to_geopandas()
+    gpdrhs = rhs.to_geopandas()
+
+    run_test(predicate, lhs, rhs, gpdlhs, gpdrhs)
+
+
+def test_point_multilinestring(predicate):  # noqa: F811
+    points_lhs = sample_cartesian_left(
+        features, point_linestring_dispatch_list
+    )
+    lines_rhs = sample_cartesian_right(
+        features, point_linestring_dispatch_list
+    )
+    size = len(point_linestring_dispatch_list)
+    part_offset = np.concatenate([np.arange(len(lines_rhs) + 1) * 2])
+    geometry_offset = np.concatenate(
+        [np.arange(size), np.arange((size * size) + 1) * 2 + size]
+    )
+    multilinestrings_rhs = cuspatial.GeoSeries.from_linestrings_xy(
+        lines_rhs.lines.xy, part_offset, geometry_offset
+    )
+    gpdlhs = points_lhs.to_geopandas()
+    gpdrhs = multilinestrings_rhs.to_geopandas()
+
+    run_test(predicate, points_lhs, multilinestrings_rhs, gpdlhs, gpdrhs)

--- a/python/cuspatial/cuspatial/utils/binpred_utils.py
+++ b/python/cuspatial/cuspatial/utils/binpred_utils.py
@@ -444,9 +444,10 @@ def _pli_features_rebuild_offsets(pli, features):
     See the docs for `_pli_points_to_multipoints` and
     `_pli_lines_to_multipoints` for the rest of the explanation.
     """
-    in_sizes = (
-        features.sizes if len(features) > 0 else _zero_series(len(pli[0]) - 1)
-    )
+    if len(features) == 0:
+        return _zero_series(len(pli[0]))
+
+    in_sizes = features.sizes
     offsets = cudf.Series(pli[0])
     offset_sizes = offsets[1:].reset_index(drop=True) - offsets[
         :-1

--- a/python/cuspatial/cuspatial/utils/binpred_utils.py
+++ b/python/cuspatial/cuspatial/utils/binpred_utils.py
@@ -526,12 +526,12 @@ def _pli_lines_to_multipoints(pli):
 
 
 def _lines_to_boundary_multipoints(lines):
-    starts = lines.lines.part_offset.take(lines.lines.geometry_offset[:-1])
-    ends = lines.lines.part_offset.take(lines.lines.geometry_offset[1:]) - 1
+    starts = lines.lines.part_offset[:-1]
+    ends = lines.lines.part_offset[1:] - 1
     indices = cudf.DataFrame({"x": starts, "y": ends}).interleave_columns()
     all_points = cuspatial.GeoSeries.from_points_xy(lines.lines.xy)
     boundary_points = all_points.take(indices)
     multipoints = cuspatial.GeoSeries.from_multipoints_xy(
-        boundary_points.points.xy, cp.arange(len(lines) + 1) * 2
+        boundary_points.points.xy, lines.lines.geometry_offset * 2
     )
     return multipoints


### PR DESCRIPTION
## Description
Partial completion of #1063 
Closes #1210 

This PR has implementations of Multi geometry binary predicates for:
Point-MultiPoint
MultiPoint-Point
MultiPoint-MultiPoint
Point-MultiLinestring
MultiLineString-Point
LineString-MultiLinestring
MultiLinestring-LineString
MultiLineString-MultiLineString

Remaining to be tested and implemented are the MultiPolygon configurations.

I spent a week or two trying to resolve issues that are present in this PR with MultiLineString-LineString predicates, which are discussed here.

(Multi)LineString-(Multi)LineString tests have issues in 4 predicates:

`crosses`

Crosses compares the vertices of intersection with boundary vertices of the lhs and rhs, and is true only when the intersection vertices are not equal to boundary vertices of the lhs or rhs.

There are four fundamental issues in the crosses predicate that I'm still befuddled on:
1. LineString "compaction": GEOS appears to connect sequential endpoints lines in a MultiLineString into a single LineString before computing intersections.
2. LineString equality bug: GEOS appears to produce incorrect results when a MultiLineString is composed of two or more identical LineStrings. This might be a occuring due to LineString "compaction" above, or due to an intersection vertex counting issue.
3. `pairwise_linestring_intersection` segment combination inconsistencies: Sometimes `pairwise_linestring_intersection` compacts a pair of `(0, 0), (0, 0)` intersections into a single `(0, 0)` and sometimes not. Should be fixed by #1207 or #1208

`touches`

The touches predicate appears to have the same fundamental issues as the crosses predicate and fails on the same cases. This is because touches compares vertices of intersection with boundary vertices of the lhs and rhs, and is true when the intersection vertices only equal boundary vertices.

`overlaps` - 2 tests
`within` - 2 tests

Overlaps and within both fail on the same test values based on `.contains`, which has a bug in GEOS that is reported in https://github.com/libgeos/geos/issues/933 and resolved in https://github.com/libgeos/geos/issues/937

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
