### PR TITLE
Use rapids-cmake to supply Google Benchmark library.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -221,13 +221,8 @@ endif()
 
 if(CUSPATIAL_BUILD_BENCHMARKS)
     # Find or install GoogleBench
-    CPMFindPackage(NAME benchmark
-        VERSION         1.5.3
-        GIT_REPOSITORY  https://github.com/google/benchmark.git
-        GIT_TAG         v1.5.3
-        GIT_SHALLOW     TRUE
-        OPTIONS         "BENCHMARK_ENABLE_TESTING OFF"
-                        "BENCHMARK_ENABLE_INSTALL OFF")
+    include(${rapids-cmake-dir}/cpm/gbench.cmake)
+    rapids_cpm_gbench()
 
     # Find or install NVBench Temporarily force downloading of fmt because current versions of nvbench
     # do not support the latest version of fmt, which is automatically pulled into our conda


### PR DESCRIPTION
## Description
This PR updates cuspatial to use rapids-cmake to supply its Google Benchmark (gbench, also called `benchmark`) dependency.

Currently I am unable to build cuspatial in a rapids-compose environment with cudf because cuspatial and cudf expect different versions of `benchmark` (rapids-cmake and cudf use 1.8.0, while cuspatial is pinned at 1.5.3).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
