### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/cpp/cuproj/CMakeLists.txt
+++ b/cpp/cuproj/CMakeLists.txt
@@ -175,13 +175,8 @@ endif()
 
 if(CUPROJ_BUILD_BENCHMARKS)
     # Find or install GoogleBench
-    CPMFindPackage(NAME benchmark
-        VERSION         1.5.3
-        GIT_REPOSITORY  https://github.com/google/benchmark.git
-        GIT_TAG         v1.5.3
-        GIT_SHALLOW     TRUE
-        OPTIONS         "BENCHMARK_ENABLE_TESTING OFF"
-                        "BENCHMARK_ENABLE_INSTALL OFF")
+    include(${rapids-cmake-dir}/cpm/gbench.cmake)
+    rapids_cpm_gbench()
 
     # Find or install NVBench Temporarily force downloading of fmt because current versions of nvbench
     # do not support the latest version of fmt, which is automatically pulled into our conda


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.