### PR TITLE
Add `geoseries.distance`

### DIFF
--- a/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
+++ b/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
@@ -1,0 +1,166 @@
+import cudf
+
+from cuspatial._lib.distance import (
+    pairwise_linestring_distance,
+    pairwise_linestring_polygon_distance,
+    pairwise_point_distance,
+    pairwise_point_linestring_distance,
+    pairwise_point_polygon_distance,
+    pairwise_polygon_distance,
+)
+from cuspatial._lib.types import CollectionType
+from cuspatial.core._column.geometa import Feature_Enum
+from cuspatial.utils.column_utils import (
+    contains_only_linestrings,
+    contains_only_multipoints,
+    contains_only_points,
+    contains_only_polygons,
+)
+
+# Maps from type combinations to a tuple of (function, reverse,
+# point_collection_types) where if reverse is True, the arguments
+# need to be swapped and point_collection_types is a tuple of the
+# types of the point column type. For example, if the first argument
+# is a MultiPoint and the second is a Point, then the
+# point_collection_types is (CollectionType.MULTI, CollectionType.SINGLE)
+type_to_func = {
+    (Feature_Enum.POINT, Feature_Enum.POINT): (
+        pairwise_point_distance,
+        False,
+        (CollectionType.SINGLE, CollectionType.SINGLE),
+    ),
+    (Feature_Enum.POINT, Feature_Enum.MULTIPOINT): (
+        pairwise_point_distance,
+        False,
+        (CollectionType.SINGLE, CollectionType.MULTI),
+    ),
+    (Feature_Enum.POINT, Feature_Enum.LINESTRING): (
+        pairwise_point_linestring_distance,
+        False,
+        (CollectionType.SINGLE,),
+    ),
+    (Feature_Enum.POINT, Feature_Enum.POLYGON): (
+        pairwise_point_polygon_distance,
+        False,
+        (CollectionType.SINGLE,),
+    ),
+    (Feature_Enum.LINESTRING, Feature_Enum.POINT): (
+        pairwise_point_linestring_distance,
+        True,
+        (CollectionType.SINGLE,),
+    ),
+    (Feature_Enum.LINESTRING, Feature_Enum.MULTIPOINT): (
+        pairwise_point_linestring_distance,
+        True,
+        (CollectionType.MULTI,),
+    ),
+    (Feature_Enum.LINESTRING, Feature_Enum.LINESTRING): (
+        pairwise_linestring_distance,
+        False,
+        (),
+    ),
+    (Feature_Enum.LINESTRING, Feature_Enum.POLYGON): (
+        pairwise_linestring_polygon_distance,
+        False,
+        (),
+    ),
+    (Feature_Enum.POLYGON, Feature_Enum.POINT): (
+        pairwise_point_polygon_distance,
+        True,
+        (CollectionType.SINGLE,),
+    ),
+    (Feature_Enum.POLYGON, Feature_Enum.MULTIPOINT): (
+        pairwise_point_polygon_distance,
+        True,
+        (CollectionType.MULTI,),
+    ),
+    (Feature_Enum.POLYGON, Feature_Enum.LINESTRING): (
+        pairwise_linestring_polygon_distance,
+        True,
+        (),
+    ),
+    (Feature_Enum.POLYGON, Feature_Enum.POLYGON): (
+        pairwise_polygon_distance,
+        False,
+        (),
+    ),
+    (Feature_Enum.MULTIPOINT, Feature_Enum.POINT): (
+        pairwise_point_distance,
+        False,
+        (CollectionType.MULTI, CollectionType.SINGLE),
+    ),
+    (Feature_Enum.MULTIPOINT, Feature_Enum.MULTIPOINT): (
+        pairwise_point_distance,
+        False,
+        (CollectionType.MULTI, CollectionType.MULTI),
+    ),
+    (Feature_Enum.MULTIPOINT, Feature_Enum.LINESTRING): (
+        pairwise_point_linestring_distance,
+        False,
+        (CollectionType.MULTI,),
+    ),
+    (Feature_Enum.MULTIPOINT, Feature_Enum.POLYGON): (
+        pairwise_point_polygon_distance,
+        False,
+        (CollectionType.MULTI,),
+    ),
+}
+
+
+class DistanceDispatch:
+    """Dispatches distance operations between two GeoSeries
+    """
+    def __init__(self, lhs, rhs, align):
+        if align:
+            self._lhs, self._rhs = lhs.align(rhs)
+        else:
+            self._lhs, self._rhs = lhs, rhs
+
+        self._lhs_type = self._determine_series_type(self._lhs)
+        self._rhs_type = self._determine_series_type(self._rhs)
+
+    def _determine_series_type(self, s):
+        if contains_only_multipoints(s):
+            typ = Feature_Enum.MULTIPOINT
+        elif contains_only_points(s):
+            typ = Feature_Enum.POINT
+        elif contains_only_linestrings(s):
+            typ = Feature_Enum.LINESTRING
+        elif contains_only_polygons(s):
+            typ = Feature_Enum.POLYGON
+        else:
+            raise NotImplementedError(
+                "Geoseries with mixed geometry types are not supported"
+            )
+        return typ
+
+    def _column(self, s, typ):
+        if typ == Feature_Enum.POINT:
+            return s.points.column()
+        elif typ == Feature_Enum.MULTIPOINT:
+            return s.multipoints.column()
+        elif typ == Feature_Enum.LINESTRING:
+            return s.lines.column()
+        elif typ == Feature_Enum.POLYGON:
+            return s.polygons.column()
+
+    @property
+    def _lhs_column(self):
+        return self._column(self._lhs, self._lhs_type)
+
+    @property
+    def _rhs_column(self):
+        return self._column(self._rhs, self._rhs_type)
+
+    def __call__(self):
+        func, reverse, collection_types = type_to_func[
+            (self._lhs_type, self._rhs_type)
+        ]
+        if reverse:
+            return cudf.Series(
+                func(*collection_types, self._rhs_column, self._lhs_column)
+            )
+        else:
+            return cudf.Series(
+                func(*collection_types, self._lhs_column, self._rhs_column)
+            )

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1401,7 +1401,10 @@ class GeoSeries(cudf.Series):
     def distance(self, other, align=True):
         """Returns a `Series` containing the distance to aligned other.
 
-        The operation works on a 1-to-1 row-wise manner:
+        The operation works on a 1-to-1 row-wise manner. See
+        `geopandas.distance` documentation [1] for details.
+
+        [1]: https://geopandas.org/docs/reference/api/geopandas.GeoSeries.distance.html#geopandas.GeoSeries.distance # noqa E501
 
         Parameters
         ----------
@@ -1428,6 +1431,34 @@ class GeoSeries(cudf.Series):
         >>> point2 = GeoSeries([Point(1, 1)])
         >>> print(point.distance(point2))
         0    1.414214
+        dtype: float64
+
+        By default, geoseries are aligned before computing:
+
+        >>> from shapely.geometry import Point
+        >>> point = GeoSeries([Point(0, 0)])
+        >>> point2 = GeoSeries([Point(1, 1), Point(2, 2)])
+        >>> print(point.distance(point2))
+        0    1.414214
+        1         NaN
+        dtype: float64
+
+        This can be overridden by setting `align=False`:
+
+        >>> lines = GeoSeries([
+                LineString([(0, 0), (1, 1)]), LineString([(2, 2), (3, 3)])])
+        >>> polys = GeoSeries([
+                Polygon([(0, 0), (1, 1), (1, 0)]),
+                Polygon([(2, 2), (3, 3), (3, 2)])],
+                index=[1, 0])
+        >>> lines.distance(polys), align=False)
+        0    0.0
+        1    0.0
+        dtype: float64
+        >>> lines.distance(polys, align=True)
+        0    1.414214
+        1    1.414214
+        dtype: float64
         """
 
         if not align:

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1386,6 +1386,18 @@ class GeoSeries(cudf.Series):
         )
         return predicate(self, other)
 
+    def isna(self):
+        """Detect missing values."""
+
+        c = self._column._meta.input_types == Feature_Enum.NONE.value
+        return cudf.Series(c, index=self.index)
+
+    def notna(self):
+        """Detect non-missing values."""
+
+        c = self._column._meta.input_types != Feature_Enum.NONE.value
+        return cudf.Series(c, index=self.index)
+
     def distance(self, other, align=True):
         """Returns a `Series` containing the distance to aligned other.
 
@@ -1417,5 +1429,12 @@ class GeoSeries(cudf.Series):
         >>> print(point.distance(point2))
         0    1.414214
         """
+
+        if not align:
+            if len(self) != len(other):
+                raise ValueError(
+                    f"Lengths of inputs do not match. Left: {len(self)}, "
+                    f"Right: {len(other)}"
+                )
 
         return DistanceDispatch(self, other, align)()

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -27,6 +27,7 @@ from cudf.core.copy_types import GatherMap
 import cuspatial.io.pygeoarrow as pygeoarrow
 from cuspatial.core._column.geocolumn import ColumnType, GeoColumn
 from cuspatial.core._column.geometa import Feature_Enum, GeoMeta
+from cuspatial.core.binops.distance_dispatch import DistanceDispatch
 from cuspatial.core.binpreds.binpred_dispatch import (
     CONTAINS_DISPATCH,
     CONTAINS_PROPERLY_DISPATCH,
@@ -1417,4 +1418,4 @@ class GeoSeries(cudf.Series):
         0    1.414214
         """
 
-        pass
+        return DistanceDispatch(self, other, align)()

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1384,3 +1384,37 @@ class GeoSeries(cudf.Series):
             align=align
         )
         return predicate(self, other)
+
+    def distance(self, other, align=True):
+        """Returns a `Series` containing the distance to aligned other.
+
+        The operation works on a 1-to-1 row-wise manner:
+
+        Parameters
+        ----------
+        other
+            The GeoSeries (elementwise) or geometric object to find the
+            distance to.
+        align : bool, default True
+            If True, automatically aligns GeoSeries based on their indices.
+            If False, the order of the elements is preserved.
+
+        Returns
+        -------
+        Series (float)
+
+        Notes
+        -----
+        Unlike GeoPandas, this API only supports geoseries that contain only
+        single type geometries.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> point = GeoSeries([Point(0, 0)])
+        >>> point2 = GeoSeries([Point(1, 1)])
+        >>> print(point.distance(point2))
+        0    1.414214
+        """
+
+        pass

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1420,8 +1420,8 @@ class GeoSeries(cudf.Series):
 
         Notes
         -----
-        Unlike GeoPandas, this API only supports geoseries that contain only
-        single type geometries.
+        Unlike GeoPandas, this API currently only supports geoseries that
+        contain only single type geometries.
 
         Examples
         --------

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1403,9 +1403,7 @@ class GeoSeries(cudf.Series):
         """Returns a `Series` containing the distance to aligned other.
 
         The operation works on a 1-to-1 row-wise manner. See
-        `geopandas.distance` documentation [1] for details.
-
-        [1]: https://geopandas.org/docs/reference/api/geopandas.GeoSeries.distance.html#geopandas.GeoSeries.distance # noqa E501
+        `geopandas.GeoSeries.distance` documentation for details.
 
         Parameters
         ----------

--- a/python/cuspatial/cuspatial/tests/conftest.py
+++ b/python/cuspatial/cuspatial/tests/conftest.py
@@ -257,7 +257,7 @@ def polygon_generator():
 
 
 @pytest.fixture
-def multipolygon_generator():
+def multipolygon_generator(polygon_generator):
     """Generator for multi complex polygons.
     Usage: multipolygon_generator(n, max_per_multi)
     """

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
@@ -124,3 +124,27 @@ def test_geoseries_distance_indices_different_not_aligned():
     except Exception as e:
         with pytest.raises(e.__class__, match=e.__str__()):
             d0.distance(d1, align=False)
+
+
+@pytest.mark.parametrize("align", [True, False])
+@pytest.mark.parametrize(
+    "index",
+    [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+    ],
+)
+def test_geoseries_distance_to_shapely_object(
+    _binary_op_combinations, align, index
+):
+    g0, g1 = _binary_op_combinations
+    h0 = geopandas.GeoSeries([*g0(n=10)], index=index)
+    obj = [*g1(n=1)][0]
+
+    expected = h0.distance(obj, align=align)
+
+    d0 = cuspatial.GeoSeries(h0)
+
+    actual = d0.distance(obj, align=align)
+
+    assert_series_equal(actual, cudf.Series(expected))

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
@@ -52,8 +52,8 @@ def _binary_op_combinations(
         polygon_generator: {"distance_from_origin": 10, "radius": 10},
         multipolygon_generator: {
             "max_per_multi": 10,
-            "max_num_geometries": 10,
-            "max_num_interior_rings": 10,
+            "distance_from_origin": 10,
+            "radius": 10,
         },
     }
 
@@ -62,6 +62,11 @@ def _binary_op_combinations(
     p0, p1 = generator_parameters[g0], generator_parameters[g1]
     return (partial(g0, **p0), partial(g1, **p1))
 
+def test_geoseires_distance_empty():
+    expected = geopandas.GeoSeries([]).distance(geopandas.GeoSeries([]))
+    actual = cuspatial.GeoSeries([]).distance(cuspatial.GeoSeries([]))
+
+    assert_series_equal(actual, cudf.Series(expected))
 
 @pytest.mark.parametrize("n", [10, 1000])
 @pytest.mark.parametrize("align", [True, False])
@@ -78,3 +83,16 @@ def test_geoseries_distance_non_empty(_binary_op_combinations, n, align):
     actual = d0.distance(d1, align=align)
 
     assert_series_equal(actual, cudf.Series(expected))
+
+# def test_geoseries_distance_indices_different():
+#     h0 = geopandas.GeoSeries([Point(0, 0), Point(1, 1)], index=[0, 1])
+#     h1 = geopandas.GeoSeries([Point(0, 0)], index=[0])
+
+#     expected = h0.distance(h1)
+
+#     d0 = cuspatial.GeoSeries(h0)
+#     d1 = cuspatial.GeoSeries(h1)
+
+#     actual = d0.distance(d1)
+
+#     assert_series_equal(actual, cudf.Series(expected))

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_distance.py
@@ -1,0 +1,80 @@
+from functools import partial
+from itertools import product
+
+import geopandas
+import pytest
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
+
+import cudf
+from cudf.testing import assert_series_equal
+
+import cuspatial
+
+geometry_types = set(
+    [Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon]
+)
+
+
+@pytest.fixture(params=set(product(geometry_types, geometry_types)))
+def _binary_op_combinations(
+    request,
+    point_generator,
+    multipoint_generator,
+    linestring_generator,
+    multilinestring_generator,
+    polygon_generator,
+    multipolygon_generator,
+):
+    type_to_generator = {
+        Point: point_generator,
+        MultiPoint: multipoint_generator,
+        LineString: linestring_generator,
+        MultiLineString: multilinestring_generator,
+        Polygon: polygon_generator,
+        MultiPolygon: multipolygon_generator,
+    }
+
+    generator_parameters = {
+        point_generator: {},
+        multipoint_generator: {"max_num_geometries": 10},
+        linestring_generator: {"max_num_segments": 10},
+        multilinestring_generator: {
+            "max_num_geometries": 10,
+            "max_num_segments": 10,
+        },
+        polygon_generator: {"distance_from_origin": 10, "radius": 10},
+        multipolygon_generator: {
+            "max_per_multi": 10,
+            "max_num_geometries": 10,
+            "max_num_interior_rings": 10,
+        },
+    }
+
+    ty0, ty1 = request.param
+    g0, g1 = type_to_generator[ty0], type_to_generator[ty1]
+    p0, p1 = generator_parameters[g0], generator_parameters[g1]
+    return (partial(g0, **p0), partial(g1, **p1))
+
+
+@pytest.mark.parametrize("n", [10, 1000])
+@pytest.mark.parametrize("align", [True, False])
+def test_geoseries_distance_non_empty(_binary_op_combinations, n, align):
+    g0, g1 = _binary_op_combinations
+    h0 = geopandas.GeoSeries([*g0(n=n)])
+    h1 = geopandas.GeoSeries([*g1(n=n)], index=h0.index[::-1])
+
+    expected = h0.distance(h1, align=align)
+
+    d0 = cuspatial.GeoSeries(h0)
+    d1 = cuspatial.GeoSeries(h1)
+
+    actual = d0.distance(d1, align=align)
+
+    assert_series_equal(actual, cudf.Series(expected))

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -20,6 +20,7 @@ from shapely.geometry import (
 )
 
 import cudf
+from cudf.testing import assert_series_equal
 
 import cuspatial
 
@@ -757,3 +758,31 @@ def test_from_polygons_xy_example():
         [Polygon([(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (0, 0)])]
     )
     gpd.testing.assert_geoseries_equal(gpolygon.to_geopandas(), hpolygon)
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        gpd.GeoSeries(),
+        gpd.GeoSeries([Point(0, 0)]),
+        gpd.GeoSeries([None]),
+        gpd.GeoSeries([Point(0, 0), None, Point(1, 1)]),
+        gpd.GeoSeries([Point(0, 0), None, LineString([(1, 1), (2, 2)]), None]),
+    ],
+)
+def test_isna(s):
+    assert_series_equal(cudf.Series(s.isna()), cuspatial.GeoSeries(s).isna())
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        gpd.GeoSeries(),
+        gpd.GeoSeries([Point(0, 0)]),
+        gpd.GeoSeries([None]),
+        gpd.GeoSeries([Point(0, 0), None, Point(1, 1)]),
+        gpd.GeoSeries([Point(0, 0), None, LineString([(1, 1), (2, 2)]), None]),
+    ],
+)
+def test_notna(s):
+    assert_series_equal(cudf.Series(s.notna()), cuspatial.GeoSeries(s).notna())


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

closes #759
This PR adds `geoseries.distance`, computing distances between two geoseries.

Benchmarking distance API is a complicated task. Below I present the benchmark of a simplest case: distance between a pair of point geoseries. geopandas is also quite fast when computing simple point distances, througput peaks at 1e5 and gets surpassed by cuspatial for larger data sizes. Both geopandas and cuspatial sees performance drop when dealing with index alignments.

![image](https://github.com/rapidsai/cuspatial/assets/13521008/dc0772f4-2b35-41da-883c-39ba4e731f6a)


TODO:
- [x] Support distance to a single shapely object.
- [x] Benchmark against geopandas.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
