### PR TITLE
Update nightly wheel tests for cuproj

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-  wheel-tests:
+  wheel-tests-cuspatial:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.08
     with:
@@ -38,4 +38,13 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      script: ci/test_wheel.sh
+      script: ci/test_wheel_cuspatial.sh
+  wheel-tests-cuproj:
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.08
+    with:
+      build_type: nightly
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: ci/test_wheel_cuproj.sh


### PR DESCRIPTION
## Description
Follow up to #1217 to enable wheels testing for `cuproj` for nightly tests.

Should fix issue seen [here](https://github.com/rapidsai/cuspatial/actions/runs/5748659541/job/15581971500)

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
