### PR TITLE
Use `conda mambabuild` not `mamba mambabuild`

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,7 +11,7 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
     conda/recipes/libcuspatial
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,7 +15,7 @@ rapids-logger "Begin py build cuSpatial"
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cuspatial
@@ -24,7 +24,7 @@ rapids-logger "Begin py build cuProj"
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cuproj


### PR DESCRIPTION
With the release of conda 23.7.3, `mamba mambabuild` stopped working. With boa installed, `conda mambabuild` uses the mamba solver, so just use that instead.

See also https://github.com/rapidsai/cudf/issues/14068.
