### PR TITLE
Update to clang 16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         hooks:
               - id: cython-lint
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v15.0.7
+        rev: v16.0.6
         hooks:
               - id: clang-format
                 types_or: [c, c++, cuda]

--- a/cpp/scripts/run-clang-format.py
+++ b/cpp/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import argparse
 import tempfile
 
 
-EXPECTED_VERSION = "15.0.7"
+EXPECTED_VERSION = "16.0.6"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to the cuspatial repo
 DEFAULT_DIRS = ["cpp/include",


### PR DESCRIPTION
## Description
This PR updates cuspatial to use clang 16.0.6. This aligns with the major version 16 being used elsewhere in RAPIDS, with a bugfix version that avoids clang-format issues around `*` multiplication operators.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
