### PR TITLE
[HOTFIX] Add a loose pin for proj

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - numpydoc
 - nvcc_linux-64=11.8
 - pre-commit
-- proj
+- proj>=9.2,<10a0
 - pydata-sphinx-theme
 - pydeck
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -34,7 +34,7 @@ dependencies:
 - notebook
 - numpydoc
 - pre-commit
-- proj
+- proj>=9.2,<10a0
 - pydata-sphinx-theme
 - pydeck
 - pytest

--- a/conda/recipes/cuproj/conda_build_config.yaml
+++ b/conda/recipes/cuproj/conda_build_config.yaml
@@ -15,3 +15,6 @@ sysroot_version:
 
 cmake_version:
   - ">=3.26.4"
+
+proj_version:
+  - ">=9.2.0,<10a0"

--- a/conda/recipes/cuproj/meta.yaml
+++ b/conda/recipes/cuproj/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - rmm ={{ minor_version }}
     - scikit-build >=0.13.1
     - setuptools
-    - proj
+    - proj {{ proj_version }}
     - sqlite
   run:
     {% if cuda_major == "11" %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -114,7 +114,7 @@ dependencies:
           - gtest>=1.13.0
           - libcudf==23.8.*
           - librmm==23.8.*
-          - proj
+          - proj>=9.2,<10a0
           - sqlite
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description
The implicit tight pin on the latest proj forces a dependency on an older libtiff. Hopefully this loosens that up.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
