### PR TITLE
Add `curl` for notebook testing

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,6 +14,7 @@ dependencies:
 - cudf==23.10.*
 - cuml==23.10.*
 - cupy>=12.0.0
+- curl
 - cxx-compiler
 - cython>=3.0.0
 - doxygen

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - cudf==23.10.*
 - cuml==23.10.*
 - cupy>=12.0.0
+- curl
 - cxx-compiler
 - cython>=3.0.0
 - doxygen

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -313,6 +313,9 @@ dependencies:
       - output_types: [requirements, pyproject]
         packages:
           - pyproj>=3.6.0,<3.7a0
+      - output_types: [conda]
+        packages:
+          - curl
   py_version:
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description
Adds `curl` as a notebook dependency which is used in two notebooks: `notebooks/nyc_taxi_years_correlation.ipynb` & `notebooks/ZipCodes_Stops_PiP_cuSpatial.ipynb` (https://github.com/search?q=repo%3Arapidsai%2Fcuspatial+curl&type=code).

This is similar to https://github.com/rapidsai/cugraph/pull/3918 and will fix errors in the notebooks tests in `rapidsai/docker`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
