### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,6 +14,7 @@ dependencies:
 - cudf==23.10.*
 - cuml==23.10.*
 - cupy>=12.0.0
+- curl
 - cxx-compiler
 - cython>=3.0.0
 - doxygen

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -17,6 +17,7 @@ dependencies:
 - cudf==23.10.*
 - cuml==23.10.*
 - cupy>=12.0.0
+- curl
 - cxx-compiler
 - cython>=3.0.0
 - doxygen

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -313,6 +313,9 @@ dependencies:
       - output_types: [requirements, pyproject]
         packages:
           - pyproj>=3.6.0,<3.7a0
+      - output_types: [conda]
+        packages:
+          - curl
   py_version:
     specific:
       - output_types: conda


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.