### PR TITLE
[TEST] Build with libcudacxx 2.1.0.

### DIFF
--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - doxygen
     - gmock {{ gtest_version }}
     - gtest {{ gtest_version }}
-    #- libcudf ={{ minor_version }}
+    - libcudf ={{ minor_version }}
     #- librmm ={{ minor_version }}
     - sqlite
     - proj

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -52,6 +52,7 @@ requirements:
     #- librmm ={{ minor_version }}
     - sqlite
     - proj
+    - zlib
 
 outputs:
   - name: libcuspatial

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -48,8 +48,8 @@ requirements:
     - doxygen
     - gmock {{ gtest_version }}
     - gtest {{ gtest_version }}
-    - libcudf ={{ minor_version }}
-    - librmm ={{ minor_version }}
+    #- libcudf ={{ minor_version }}
+    #- librmm ={{ minor_version }}
     - sqlite
     - proj
 

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch libcudacxx-2.1.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
        ${CMAKE_BINARY_DIR}/CUSPATIAL_RAPIDS.cmake


### PR DESCRIPTION
This PR tests a rapids-cmake branch with libcudacxx updated to 2.1.0. **Do not merge this PR.** The changes will be merged upstream in rapids-cmake after all libraries pass CI.
