### PR TITLE
Fix broken hausdorff test

### DIFF
--- a/python/cuspatial/cuspatial/core/spatial/distance.py
+++ b/python/cuspatial/cuspatial/core/spatial/distance.py
@@ -80,7 +80,7 @@ def directed_hausdorff_distance(multipoints: GeoSeries):
 
     num_spaces = len(multipoints)
     if num_spaces == 0:
-        return DataFrame()
+        return DataFrame([])
 
     if not contains_only_multipoints(multipoints):
         raise ValueError("Input must be a series of multipoints.")

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_hausdorff_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_hausdorff_distance.py
@@ -14,7 +14,7 @@ def _test_hausdorff_from_list_of_spaces(spaces):
 def test_empty():
     actual = _test_hausdorff_from_list_of_spaces([])
 
-    expected = cudf.DataFrame([], columns=cudf.Index([]))
+    expected = cudf.DataFrame([])
 
     cudf.testing.assert_frame_equal(expected, actual)
 

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_hausdorff_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_hausdorff_distance.py
@@ -14,7 +14,7 @@ def _test_hausdorff_from_list_of_spaces(spaces):
 def test_empty():
     actual = _test_hausdorff_from_list_of_spaces([])
 
-    expected = cudf.DataFrame([])
+    expected = cudf.DataFrame([], columns=cudf.Index([]))
 
     cudf.testing.assert_frame_equal(expected, actual)
 


### PR DESCRIPTION
This PR revises the gold result of hausdorff empty input test to address
an upstream change in cudf.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
