### PR TITLE
Adds workaround to CI workflow to upgrage pip

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,5 +109,7 @@ jobs:
     with:
       build_command: |
         sccache -z;
+        python -m pip install -U pip;
+        rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
         build-all -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON --verbose;
         sccache -s;


### PR DESCRIPTION
## Description
This PR adds a workaround to the `pr.yaml` GitHub workflow `devcontainer` job to upgrade `pip`.  This should allow devcontainer CI jobs that were previously failing due to the older pip version to complete successfully.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
