### PR TITLE
Remove CUSPATIAL_BUILD_WHEELS and standardize Python builds

### DIFF
--- a/ci/build_wheel_cuspatial.sh
+++ b/ci/build_wheel_cuspatial.sh
@@ -3,6 +3,4 @@
 
 set -euo pipefail
 
-export SKBUILD_CONFIGURE_OPTIONS="-DCUSPATIAL_BUILD_WHEELS=ON"
-
 ci/build_wheel.sh cuspatial python/cuspatial

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -52,7 +52,7 @@ if(NOT cuspatial_FOUND)
   include(cmake/Modules/WheelHelpers.cmake)
   # TODO: This install is currently overzealous. We should only install the libraries that are
   # downloaded by CPM during the build, not libraries that were found on the system.  However, in
-  # practice right this would only be a problem is if libcudf was not found but some of the
+  # practice this would only be a problem if libcudf was not found but some of the
   # dependencies were, and we have no real use cases where that happens.
   install_aliased_imported_targets(
     TARGETS cuspatial arrow_shared nvcomp::nvcomp nvcomp::nvcomp_gdeflate nvcomp::nvcomp_bitcomp

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -32,13 +32,6 @@ project(
 option(FIND_CUSPATIAL_CPP "Search for existing cuspatial C++ installations before defaulting to local files"
        OFF)
 
-# When building the Python package, always defer to pyarrow to tell us where to find libarrow. This
-# works whether libarrow is installed by pyarrow itself (i.e. as part of a wheel) or as part of a
-# separate libarrow package (i.e. in conda) because pyarrow always knows where it is. libcudf must
-# be built against an ABI-compatible arrow library for the package to load at runtime, so searching
-# this way is always correct.
-set(USE_LIBARROW_FROM_PYARROW ON)
-
 # If the user requested it we attempt to find cuspatial.
 if(FIND_CUSPATIAL_CPP)
   find_package(cuspatial ${cuspatial_version} REQUIRED)

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -32,11 +32,16 @@ project(
 option(FIND_CUSPATIAL_CPP "Search for existing cuspatial C++ installations before defaulting to local files"
        OFF)
 
-option(CUSPATIAL_BUILD_WHEELS "Whether this build is generating a Python wheel." OFF)
+# When building the Python package, always defer to pyarrow to tell us where to find libarrow. This
+# works whether libarrow is installed by pyarrow itself (i.e. as part of a wheel) or as part of a
+# separate libarrow package (i.e. in conda) because pyarrow always knows where it is. libcudf must
+# be built against an ABI-compatible arrow library for the package to load at runtime, so searching
+# this way is always correct.
+set(USE_LIBARROW_FROM_PYARROW ON)
 
 # If the user requested it we attempt to find cuspatial.
 if(FIND_CUSPATIAL_CPP)
-  find_package(cuspatial ${cuspatial_version})
+  find_package(cuspatial ${cuspatial_version} REQUIRED)
 else()
   set(cuspatial_FOUND OFF)
 endif()
@@ -44,40 +49,22 @@ endif()
 if(NOT cuspatial_FOUND)
   set(BUILD_TESTS OFF)
   set(BUILD_BENCHMARKS OFF)
-  set(_exclude_from_all "")
-  if(CUSPATIAL_BUILD_WHEELS)
+  set(CUDA_STATIC_RUNTIME ON)
+  set(CUSPATIAL_USE_CUDF_STATIC ON)
+  set(CUSPATIAL_EXCLUDE_CUDF_FROM_ALL ON)
 
-    # Statically link cudart if building wheels
-    set(CUDA_STATIC_RUNTIME ON)
-    set(CUSPATIAL_USE_CUDF_STATIC ON)
-    set(CUSPATIAL_EXCLUDE_CUDF_FROM_ALL ON)
-
-    # Always build wheels against the pyarrow libarrow.
-    set(USE_LIBARROW_FROM_PYARROW ON)
-
-    # Need to set this so all the nvcomp targets are global, not only nvcomp::nvcomp
-    # https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_TARGETS_GLOBAL.html#variable:CMAKE_FIND_PACKAGE_TARGETS_GLOBAL
-    set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
-
-    # Don't install the cuSpatial C++ targets into wheels
-    set(_exclude_from_all EXCLUDE_FROM_ALL)
-  endif()
-
-  add_subdirectory(../../cpp cuspatial-cpp ${_exclude_from_all})
+  add_subdirectory(../../cpp cuspatial-cpp EXCLUDE_FROM_ALL)
 
   set(cython_lib_dir cuspatial)
-
-  if(CUSPATIAL_BUILD_WHEELS)
-    include(cmake/Modules/WheelHelpers.cmake)
-    get_target_property(_nvcomp_link_libs nvcomp::nvcomp INTERFACE_LINK_LIBRARIES)
-    # Ensure all the shared objects we need at runtime are in the wheel
-    add_target_libs_to_wheel(LIB_DIR ${cython_lib_dir} TARGETS arrow_shared nvcomp::nvcomp ${_nvcomp_link_libs})
-  endif()
-
-  # Since there are multiple subpackages of cuspatial._lib that require access to libcuspatial, we place the
-  # library in the cuspatial directory as a single source of truth and modify the other rpaths
-  # appropriately.
-  install(TARGETS cuspatial DESTINATION ${cython_lib_dir})
+  include(cmake/Modules/WheelHelpers.cmake)
+  # TODO: This install is currently overzealous. We should only install the libraries that are
+  # downloaded by CPM during the build, not libraries that were found on the system.  However, in
+  # practice right this would only be a problem is if libcudf was not found but some of the
+  # dependencies were, and we have no real use cases where that happens.
+  install_aliased_imported_targets(
+    TARGETS cuspatial arrow_shared nvcomp::nvcomp nvcomp::nvcomp_gdeflate nvcomp::nvcomp_bitcomp
+    DESTINATION ${cython_lib_dir}
+  )
 endif()
 
 include(rapids-cython)

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -34,7 +34,7 @@ option(FIND_CUSPATIAL_CPP "Search for existing cuspatial C++ installations befor
 
 # If the user requested it we attempt to find cuspatial.
 if(FIND_CUSPATIAL_CPP)
-  find_package(cuspatial ${cuspatial_version} REQUIRED)
+  find_package(cuspatial ${cuspatial_version})
 else()
   set(cuspatial_FOUND OFF)
 endif()

--- a/python/cuspatial/cmake/Modules/WheelHelpers.cmake
+++ b/python/cuspatial/cmake/Modules/WheelHelpers.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -14,15 +14,15 @@
 include_guard(GLOBAL)
 
 # Making libraries available inside wheels by installing the associated targets.
-function(add_target_libs_to_wheel)
-  list(APPEND CMAKE_MESSAGE_CONTEXT "add_target_libs_to_wheel")
+function(install_aliased_imported_targets)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "install_aliased_imported_targets")
 
   set(options "")
-  set(one_value "LIB_DIR")
+  set(one_value "DESTINATION")
   set(multi_value "TARGETS")
   cmake_parse_arguments(_ "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  message(VERBOSE "Installing targets '${__TARGETS}' into lib_dir '${__LIB_DIR}'")
+  message(VERBOSE "Installing targets '${__TARGETS}' into lib_dir '${__DESTINATION}'")
 
   foreach(target IN LISTS __TARGETS)
 
@@ -38,34 +38,22 @@ function(add_target_libs_to_wheel)
 
     get_target_property(is_imported ${target} IMPORTED)
     if(NOT is_imported)
-      # If the target isn't imported, install it into the the wheel
-      install(TARGETS ${target} DESTINATION ${__LIB_DIR})
-      message(VERBOSE "install(TARGETS ${target} DESTINATION ${__LIB_DIR})")
+      # If the target isn't imported, install it into the wheel
+      install(TARGETS ${target} DESTINATION ${__DESTINATION})
+      message(VERBOSE "install(TARGETS ${target} DESTINATION ${__DESTINATION})")
     else()
       # If the target is imported, make sure it's global
-      get_target_property(already_global ${target} IMPORTED_GLOBAL)
-      if(NOT already_global)
-        set_target_properties(${target} PROPERTIES IMPORTED_GLOBAL TRUE)
+      get_target_property(type ${target} TYPE)
+      if(${type} STREQUAL "UNKNOWN_LIBRARY")
+        install(FILES $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})
+        message(VERBOSE "install(FILES $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})")
+      else()
+        install(IMPORTED_RUNTIME_ARTIFACTS ${target} DESTINATION ${__DESTINATION})
+        message(
+          VERBOSE
+          "install(IMPORTED_RUNTIME_ARTIFACTS $<TARGET_FILE:${target}> DESTINATION ${__DESTINATION})"
+        )
       endif()
-
-      # Find the imported target's library so we can copy it into the wheel
-      set(lib_loc)
-      foreach(prop IN ITEMS IMPORTED_LOCATION IMPORTED_LOCATION_RELEASE IMPORTED_LOCATION_DEBUG)
-        get_target_property(lib_loc ${target} ${prop})
-        if(lib_loc)
-          message(VERBOSE "Found ${prop} for ${target}: ${lib_loc}")
-          break()
-        endif()
-        message(VERBOSE "${target} has no value for property ${prop}")
-      endforeach()
-
-      if(NOT lib_loc)
-        message(FATAL_ERROR "Found no libs to install for target ${target}")
-      endif()
-
-      # Copy the imported library into the wheel
-      install(FILES ${lib_loc} DESTINATION ${__LIB_DIR})
-      message(VERBOSE "install(FILES ${lib_loc} DESTINATION ${__LIB_DIR})")
     endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Some minor simplification in advance of the scikit-build-core migration to better align wheel and non-wheel Python builds. Additionally, this PR simplifies handling of the nvcomp targets and their installation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
