### PR TITLE
Pin `proj` to `9.3.0` in `cuproj`

### DIFF
--- a/conda/recipes/cuproj/conda_build_config.yaml
+++ b/conda/recipes/cuproj/conda_build_config.yaml
@@ -15,3 +15,7 @@ sysroot_version:
 
 cmake_version:
   - ">=3.26.4"
+
+# Workaround until proj 9.3.1 migration completes
+proj:
+  - "9.3.0"


### PR DESCRIPTION
## Description

Currently `pyproj` is still pinned to `proj` 9.3.0 (for [example]( https://github.com/conda-forge/pyproj-feedstock/blob/1cd88219a34c40265a8f70384476ce6c90e1ac45/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml#L19-L20 )). However `proj` recently released `9.3.1` ( https://github.com/conda-forge/proj.4-feedstock/pull/140 ), which `cuproj` is pulling in at the moment. Since `proj` [pins to the patch version in its `run_exports`]( https://github.com/conda-forge/proj.4-feedstock/blob/332baf3b6a739377f5e5cf65d9e9297d02a6ddf3/recipe/meta.yaml#L15-L18 ), building against `9.3.1` means `cuproj` would need exactly `9.3.1` at runtime. This makes it incompatible with everything else, which is still pinned to `proj` `9.3.0`. Embedded screenshot below to highlight this

<details>

<img width="1840" alt="Screenshot 2023-12-06 at 3 30 00 PM" src="https://github.com/rapidsai/cuspatial/assets/3019665/89084383-789a-43d8-99b5-402b8f217ec4">

</details>

So for now just manually pin `proj` to `9.3.0` to build `cuproj` with a consistent `proj` version to resolve conflicts

This issue should clear up once to `proj` `9.3.1` migration ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5226 ) completes. Then we can bump this or drop it as we see fit then

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
