### PR TITLE
Remove proj and sqlite from libcuspatial recipe.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - numpydoc
 - nvcc_linux-64=11.8
 - pre-commit
-- proj
+- proj==9.3.0
 - pydata-sphinx-theme!=0.14.2
 - pydeck
 - pytest

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -35,7 +35,7 @@ dependencies:
 - notebook
 - numpydoc
 - pre-commit
-- proj
+- proj==9.3.0
 - pydata-sphinx-theme!=0.14.2
 - pydeck
 - pytest

--- a/conda/recipes/cuproj/conda_build_config.yaml
+++ b/conda/recipes/cuproj/conda_build_config.yaml
@@ -16,6 +16,6 @@ sysroot_version:
 cmake_version:
   - ">=3.26.4"
 
-# Workaround until proj 9.3.1 migration completes
+# Match with dependencies.yaml, and keep in sync with the conda-forge pinning
 proj:
   - "9.3.0"

--- a/conda/recipes/libcuspatial/meta.yaml
+++ b/conda/recipes/libcuspatial/meta.yaml
@@ -50,8 +50,6 @@ requirements:
     - gtest {{ gtest_version }}
     - libcudf ={{ minor_version }}
     - librmm ={{ minor_version }}
-    - sqlite
-    - proj
 
 outputs:
   - name: libcuspatial
@@ -79,8 +77,6 @@ outputs:
         {% endif %}
         - libcudf ={{ minor_version }}
         - librmm ={{ minor_version }}
-        - sqlite
-        - proj
     test:
       commands:
         - test -f $PREFIX/lib/libcuspatial.so

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -115,9 +115,6 @@ include (cmake/thirdparty/get_ranger.cmake)
 ###################################################################################################
 # - library targets -------------------------------------------------------------------------------
 
-# cuProj
-add_subdirectory(cuproj)
-
 add_library(cuspatial
     src/bounding_boxes/linestring_bounding_boxes.cu
     src/bounding_boxes/polygon_bounding_boxes.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -115,6 +115,9 @@ include (cmake/thirdparty/get_ranger.cmake)
 ###################################################################################################
 # - library targets -------------------------------------------------------------------------------
 
+# cuProj
+add_subdirectory(cuproj)
+
 add_library(cuspatial
     src/bounding_boxes/linestring_bounding_boxes.cu
     src/bounding_boxes/polygon_bounding_boxes.cu

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -167,7 +167,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - proj
+          # Match with conda_build_config.yaml, and keep in sync with the conda-forge pinning
+          - proj==9.3.0
           - sqlite
   build_python:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,7 +6,9 @@ files:
       cuda: ["11.8", "12.0"]
       arch: [x86_64]
     includes:
-      - build_cpp
+      - build_cpp_common
+      - build_cpp_cuspatial
+      - build_cpp_cuproj
       - build_python
       - cudatoolkit
       - develop
@@ -57,7 +59,8 @@ files:
     includes:
       - depends_on_rmm
       - depends_on_cudf
-      - build_cpp
+      - build_cpp_common
+      - build_cpp_cuspatial
       - build_python
       - build_wheels
   py_run_cuspatial:
@@ -84,6 +87,7 @@ files:
       table: build-system
     includes:
       - depends_on_rmm
+      - build_cpp_common
       - build_cpp_cuproj
       - build_python_cuproj
       - build_wheels
@@ -111,7 +115,7 @@ channels:
   - conda-forge
   - nvidia
 dependencies:
-  build_cpp:
+  build_cpp_common:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
@@ -123,10 +127,7 @@ dependencies:
           - cxx-compiler
           - gmock>=1.13.0
           - gtest>=1.13.0
-          - libcudf==24.2.*
           - librmm==24.2.*
-          - proj
-          - sqlite
     specific:
       - output_types: conda
         matrices:
@@ -157,51 +158,17 @@ dependencies:
             packages:
               - cuda-version=12.0
               - cuda-nvcc
+  build_cpp_cuspatial:
+    common:
+      - output_types: conda
+        packages:
+          - libcudf==24.2.*
   build_cpp_cuproj:
     common:
-      - output_types: [conda, requirements, pyproject]
-        packages:
-          - ninja
-          - cmake>=3.26.4
       - output_types: conda
         packages:
-          - c-compiler
-          - cxx-compiler
-          - gmock>=1.13.0
-          - gtest>=1.13.0
-          - librmm==24.2.*
           - proj
           - sqlite
-    specific:
-      - output_types: conda
-        matrices:
-          - matrix:
-              arch: x86_64
-            packages:
-              - *gcc_amd64
-              - *sysroot_amd64
-          - matrix:
-              arch: aarch64
-            packages:
-              - *gcc_aarch64
-              - *sysroot_aarch64
-      - output_types: conda
-        matrices:
-          - matrix:
-              arch: x86_64
-              cuda: "11.8"
-            packages:
-              - nvcc_linux-64=11.8
-          - matrix:
-              arch: aarch64
-              cuda: "11.8"
-            packages:
-              - nvcc_linux-aarch64=11.8
-          - matrix:
-              cuda: "12.0"
-            packages:
-              - cuda-version=12.0
-              - cuda-nvcc
   build_python:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description
This cleans up some packaging. We no longer need `proj` or `sqlite` in libcuspatial.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
