### PR TITLE
Use Cython 3 for cuproj.

### DIFF
--- a/conda/recipes/cuproj/meta.yaml
+++ b/conda/recipes/cuproj/meta.yaml
@@ -53,7 +53,7 @@ requirements:
   host:
     - cuda-version ={{ cuda_version }}
     - cmake {{ cmake_version }}
-    - cython >=0.29,<0.30
+    - cython >=3.0.0
     - python
     - rmm ={{ minor_version }}
     - scikit-build >=0.13.1


### PR DESCRIPTION
## Description
This updates cuproj's conda recipe to use `cython >=3.0.0` to align with other RAPIDS packages.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
