### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/conda/recipes/cuproj/conda_build_config.yaml
+++ b/conda/recipes/cuproj/conda_build_config.yaml
@@ -15,3 +15,7 @@ sysroot_version:
 
 cmake_version:
   - ">=3.26.4"
+
+# Workaround until proj 9.3.1 migration completes
+proj:
+  - "9.3.0"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.