### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
                 args: ["--config pyproject.toml"]
                 additional_dependencies: ["tomli"]
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.5.1
+        rev: v1.8.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -263,8 +263,8 @@ dependencies:
               cuda: "12.*"
             packages:
               - cuda-cudart-dev
-              - cuda-nvrtc-dev
               - cuda-cupti-dev
+              - cuda-nvrtc-dev
           - matrix:
               cuda: "11.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,7 +8,8 @@ files:
     includes:
       - build_cpp
       - build_python
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - develop
       - docs
       - py_version
@@ -23,18 +24,18 @@ files:
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python_cuspatial
       - test_python_cuproj
   test_notebooks:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - depends_on_cuml
       - notebooks
       - py_version
@@ -46,7 +47,7 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
       - py_version
   py_build_cuspatial:
@@ -155,7 +156,6 @@ dependencies:
           - matrix:
               cuda: "12.0"
             packages:
-              - cuda-version=12.0
               - cuda-nvcc
   build_cpp_cuproj:
     common:
@@ -200,7 +200,6 @@ dependencies:
           - matrix:
               cuda: "12.0"
             packages:
-              - cuda-version=12.0
               - cuda-nvcc
   build_python:
     common:
@@ -232,36 +231,43 @@ dependencies:
         packages:
           - wheel
           - setuptools
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "11.2"
             packages:
-              - cuda-version=12.0
-              - cuda-cudart-dev
-              - cuda-nvrtc-dev
-              - cuda-cupti-dev
-          - matrix:
-              cuda: "11.8"
-            packages:
-              - cuda-version=11.8
-              - cudatoolkit
-          - matrix:
-              cuda: "11.5"
-            packages:
-              - cuda-version=11.5
-              - cudatoolkit
+              - cuda-version=11.2
           - matrix:
               cuda: "11.4"
             packages:
               - cuda-version=11.4
-              - cudatoolkit
           - matrix:
-              cuda: "11.2"
+              cuda: "11.5"
             packages:
-              - cuda-version=11.2
+              - cuda-version=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-version=11.8
+          - matrix:
+              cuda: "12.0"
+            packages:
+              - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-cudart-dev
+              - cuda-nvrtc-dev
+              - cuda-cupti-dev
+          - matrix:
+              cuda: "11.*"
+            packages:
               - cudatoolkit
   develop:
     common:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.