### PR TITLE
Remove -DNVBench_ENABLE_CUPTI=OFF.

### DIFF
--- a/conda/recipes/libcuspatial/build.sh
+++ b/conda/recipes/libcuspatial/build.sh
@@ -1,5 +1,4 @@
 # Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 # build cuspatial with verbose output
-./build.sh -v libcuspatial tests benchmarks --allgpuarch -n \
-    --cmake-args=\"-DNVBench_ENABLE_CUPTI=OFF\"
+./build.sh -v libcuspatial tests benchmarks --allgpuarch -n


### PR DESCRIPTION
## Description
The `-DNVBench_ENABLE_CUPTI=OFF` flag is no longer needed because of https://github.com/rapidsai/rapids-cmake/pull/504. NVBench CUPTI support is now disabled by default.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
