### PR TITLE
Verify copyright headers are up to date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 repos:
       - repo: https://github.com/PyCQA/isort
@@ -47,6 +47,10 @@ repos:
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
+      - repo: https://github.com/KyleFromNVIDIA/pre-commit-hooks
+        rev: cf900c4b9657f8f00fbd29832191f71880673525
+        hooks:
+            - id: verify-copyright
 
 default_language_version:
       python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
       - repo: https://github.com/KyleFromNVIDIA/pre-commit-hooks
-        rev: cf900c4b9657f8f00fbd29832191f71880673525
+        rev: 2011a2bbe195d97bd8d1eaccc9c8e4667e7dfc66
         hooks:
             - id: verify-copyright
 


### PR DESCRIPTION
## Description
This PR adds a pre-commit hook to verify that copyright headers are up to date.

Closes #995.

For now, I am using this draft PR to test https://github.com/rapidsai/pre-commit-hooks/pull/9.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
