### PR TITLE
handle more RAPIDS version formats in update-version.sh, refactor dependencies.yaml

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -77,10 +77,10 @@ DEPENDENCIES=(
 
 for DEP in "${DEPENDENCIES[@]}"; do
   for FILE in dependencies.yaml conda/environments/*.yaml; do
-    sed_runner "/-.* ${DEP}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" ${FILE}
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" "${FILE}"
   done
-  sed_runner "s/${DEP}==.*\",/${DEP}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/cuspatial/pyproject.toml
-  sed_runner "s/${DEP}==.*\",/${DEP}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/cuproj/pyproject.toml
+  sed_runner "s/${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==.*\",/${DEP}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/cuspatial/pyproject.toml
+  sed_runner "s/${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==.*\",/${DEP}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/cuproj/pyproject.toml
 done
 
 # Dependency versions in dependencies.yaml

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,7 +154,7 @@ dependencies:
             packages:
               - nvcc_linux-aarch64=11.8
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - cuda-nvcc
   build_cpp_cuproj:
@@ -198,7 +198,7 @@ dependencies:
             packages:
               - nvcc_linux-aarch64=11.8
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - cuda-nvcc
   build_python:
@@ -359,17 +359,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &rmm_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - rmm-cu12==24.4.*
-          - {matrix: {cuda: "12.1"}, packages: *rmm_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *rmm_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &rmm_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - rmm-cu11==24.4.*
-          - {matrix: {cuda: "11.5"}, packages: *rmm_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *rmm_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *rmm_packages_pip_cu11}
           - {matrix: null, packages: [*rmm_conda]}
 
   depends_on_cudf:
@@ -385,17 +380,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &cudf_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cudf-cu12==24.4.*
-          - {matrix: {cuda: "12.1"}, packages: *cudf_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cudf_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &cudf_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cudf-cu11==24.4.*
-          - {matrix: {cuda: "11.5"}, packages: *cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cudf_packages_pip_cu11}
           - {matrix: null, packages: [*cudf_conda]}
 
   depends_on_cuml:
@@ -411,17 +401,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &cuml_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cuml-cu12==24.4.*
-          - {matrix: {cuda: "12.1"}, packages: *cuml_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cuml_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &cuml_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cuml-cu11==24.4.*
-          - {matrix: {cuda: "11.5"}, packages: *cuml_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cuml_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cuml_packages_pip_cu11}
           - {matrix: null, packages: [*cuml_conda]}
 
   depends_on_cuspatial:
@@ -437,17 +422,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &cuspatial_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cuspatial-cu12==24.4.*
-          - {matrix: {cuda: "12.1"}, packages: *cuspatial_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cuspatial_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &cuspatial_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cuspatial-cu11==24.4.*
-          - {matrix: {cuda: "11.5"}, packages: *cuspatial_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cuspatial_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cuspatial_packages_pip_cu11}
           - {matrix: null, packages: [*cuspatial_conda]}
 
   depends_on_cupy:
@@ -458,33 +438,10 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          # All CUDA 12 + x86_64 versions
-          - matrix: {cuda: "12.2", arch: x86_64}
-            packages: &cupy_packages_cu12_x86_64
+          - matrix: {cuda: "12.*"}
+            packages:
               - cupy-cuda12x>=12.0.0
-          - {matrix: {cuda: "12.1", arch: x86_64}, packages: *cupy_packages_cu12_x86_64}
-          - {matrix: {cuda: "12.0", arch: x86_64}, packages: *cupy_packages_cu12_x86_64}
-
-          # All CUDA 12 + aarch64 versions
-          - matrix: {cuda: "12.2", arch: aarch64}
-            packages: &cupy_packages_cu12_aarch64
-              - cupy-cuda12x -f https://pip.cupy.dev/aarch64 # TODO: Verify that this works.
-          - {matrix: {cuda: "12.1", arch: aarch64}, packages: *cupy_packages_cu12_aarch64}
-          - {matrix: {cuda: "12.0", arch: aarch64}, packages: *cupy_packages_cu12_aarch64}
-
-          # All CUDA 11 + x86_64 versions
-          - matrix: {cuda: "11.8", arch: x86_64}
-            packages: &cupy_packages_cu11_x86_64
+          - matrix: {cuda: "11.*"}
+            packages:
               - cupy-cuda11x>=12.0.0
-          - {matrix: {cuda: "11.5", arch: x86_64}, packages: *cupy_packages_cu11_x86_64}
-          - {matrix: {cuda: "11.4", arch: x86_64}, packages: *cupy_packages_cu11_x86_64}
-          - {matrix: {cuda: "11.2", arch: x86_64}, packages: *cupy_packages_cu11_x86_64}
-
-          # All CUDA 11 + aarch64 versions
-          - matrix: {cuda: "11.8", arch: aarch64}
-            packages: &cupy_packages_cu11_aarch64
-              - cupy-cuda11x -f https://pip.cupy.dev/aarch64 # TODO: Verify that this works.
-          - {matrix: {cuda: "11.5", arch: aarch64}, packages: *cupy_packages_cu11_aarch64}
-          - {matrix: {cuda: "11.4", arch: aarch64}, packages: *cupy_packages_cu11_aarch64}
-          - {matrix: {cuda: "11.2", arch: aarch64}, packages: *cupy_packages_cu11_aarch64}
           - {matrix: null, packages: [cupy-cuda11x>=12.0.0]}


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/13.

Updates `update-version.sh` to correctly handle RAPIDS dependencies like `cudf-cu12==24.2.*`.

This also pulls in some dependency refactoring originally added in #1320, which allows greater use of dependencies.yaml globs (and therefore less maintenance effort to support new CUDA versions).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

### How I tested this

The portability of this updated `sed` command was tested here: https://github.com/rapidsai/cudf/pull/14825#issuecomment-1904735849.

In this repo, I ran the following:

```shell
./ci/release/update-version.sh '23.12.00'
git diff

./ci/release/update-version.sh '24.04.00'
git diff
```

Confirmed that that first `git diff` changed all the things I expected, and that second one showed 0 changes.
