### PR TITLE
fix formatting in developer guide

### DIFF
--- a/docs/source/developer_guide/build.md
+++ b/docs/source/developer_guide/build.md
@@ -25,7 +25,7 @@ conda env create -n cuspatial --file conda/environments/all_cuda-118_arch-x86_64
 
 ### From the cuSpatial Dev Container:
 
-Execute `build-cuspatial-cpp to build `libcuspatial`. The following options may be added.
+Execute `build-cuspatial-cpp` to build `libcuspatial`. The following options may be added.
  - `-DBUILD_TESTS=ON`: build `libcuspatial` unit tests.
  - `-DBUILD_BENCHMARKS=ON`: build `libcuspatial` benchmarks.
  - `-DCMAKE_BUILD_TYPE=Debug`: Create a Debug build of `libcuspatial` (default is Release).


### PR DESCRIPTION
## Description

Reading through the docs at https://docs.rapids.ai/api/cuspatial/nightly/developer_guide/build/, I noticed what looked like a formatting mistake:

<img width="730" alt="Screenshot 2024-01-23 at 11 40 22 AM" src="https://github.com/rapidsai/cuspatial/assets/7608904/9f8bd675-c694-470d-9adc-1646e704f150">

This fixes it.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
