### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/ci/build_wheel_cuspatial.sh
+++ b/ci/build_wheel_cuspatial.sh
@@ -3,4 +3,6 @@
 
 set -euo pipefail
 
+export SKBUILD_CMAKE_ARGS="-DUSE_LIBARROW_FROM_PYARROW=ON"
+
 ci/build_wheel.sh cuspatial python/cuspatial


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.