### PR TITLE
Switch `pytest-xdist` algorithm to `worksteal`

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -50,7 +50,7 @@ pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuspatial.xml" \
   --numprocesses=8 \
-  --dist=loadscope \
+  --dist=worksteal \
   --cov-config=../.coveragerc \
   --cov=cuspatial \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuspatial-coverage.xml" \
@@ -65,7 +65,7 @@ pytest \
   --cache-clear \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuproj.xml" \
   --numprocesses=8 \
-  --dist=loadscope \
+  --dist=worksteal \
   --cov-config=../.coveragerc \
   --cov=cuproj \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuproj-coverage.xml" \

--- a/ci/test_wheel_cuproj.sh
+++ b/ci/test_wheel_cuproj.sh
@@ -22,5 +22,13 @@ python -m pip install $(echo ./dist/cuproj*.whl)[test]
 if [[ "$(arch)" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_cuproj.py
 else
-    python -m pytest -n 8 ./python/cuproj/cuproj/tests
+    rapids-logger "pytest cuproj"
+    pushd python/cuproj/cuproj
+    python -m pytest \
+      --cache-clear \
+      --junitxml="${RAPIDS_TESTS_DIR}/junit-cuproj.xml" \
+      --numprocesses=8 \
+      --dist=worksteal \
+      tests
+    popd
 fi

--- a/ci/test_wheel_cuproj.sh
+++ b/ci/test_wheel_cuproj.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -eou pipefail
 

--- a/ci/test_wheel_cuspatial.sh
+++ b/ci/test_wheel_cuspatial.sh
@@ -22,7 +22,7 @@ else
     pushd python/cuspatial/cuspatial
     python -m pytest \
       --cache-clear \
-      --junitxml="${RAPIDS_TESTS_DIR}/junit-cuproj.xml" \
+      --junitxml="${RAPIDS_TESTS_DIR}/junit-cuspatial.xml" \
       --numprocesses=8 \
       --dist=worksteal \
       tests

--- a/ci/test_wheel_cuspatial.sh
+++ b/ci/test_wheel_cuspatial.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -eou pipefail
 

--- a/ci/test_wheel_cuspatial.sh
+++ b/ci/test_wheel_cuspatial.sh
@@ -18,5 +18,13 @@ python -m pip install $(echo ./dist/cuspatial*.whl)[test]
 if [[ "$(arch)" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
     python ./ci/wheel_smoke_test_cuspatial.py
 else
-    python -m pytest -n 8 ./python/cuspatial/cuspatial/tests
+    rapids-logger "pytest cuspatial"
+    pushd python/cuspatial/cuspatial
+    python -m pytest \
+      --cache-clear \
+      --junitxml="${RAPIDS_TESTS_DIR}/junit-cuproj.xml" \
+      --numprocesses=8 \
+      --dist=worksteal \
+      tests
+    popd
 fi


### PR DESCRIPTION
This PR uses the `worksteal` algorithm to accelerate parallel pytests. See https://github.com/rapidsai/cudf/pull/15207.
