### PR TITLE
Update pre-commit-hooks to v0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.0.1
+        rev: v0.0.3
         hooks:
             - id: verify-copyright
 


### PR DESCRIPTION
This fixes an issue with how the `verify-copyright` hook handles multiple merge bases.
