### PR TITLE
Forward-merge branch-24.04 to branch-24.06

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.0.1
+        rev: v0.0.3
         hooks:
             - id: verify-copyright
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.04` that creates a PR to keep `branch-24.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.