### PR TITLE
WIP: Prevent path conflict in builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -16,6 +16,7 @@ rapids-print-env
 version=$(rapids-generate-version)
 
 rapids-logger "Begin cpp build"
+conda config --set path_conflict prevent
 
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
     conda/recipes/libcuspatial

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -27,6 +27,7 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-logger "Begin py build cuSpatial"
 
+conda config --set path_conflict prevent
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/54

This will make builds fail when there are path conflicts
