### PR TITLE
When using CUDA 12.4+ use zstd compression

### DIFF
--- a/cpp/cmake/Modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/Modules/ConfigureCUDA.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/Modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/Modules/ConfigureCUDA.cmake
@@ -32,6 +32,10 @@ list(APPEND CUSPATIAL_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-
 
 # Produce smallest binary size
 list(APPEND CUSPATIAL_CUDA_FLAGS -Xfatbin=-compress-all)
+if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
+   CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4.0)
+  list(APPEND CUSPATIAL_CUDA_FLAGS -Xfatbin=-compress-algo=5)
+endif()
 
 if(DISABLE_DEPRECATION_WARNING)
     list(APPEND CUSPATIAL_CXX_FLAGS -Wno-deprecated-declarations)

--- a/cpp/cuproj/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cuproj/cmake/modules/ConfigureCUDA.cmake
@@ -32,6 +32,10 @@ list(APPEND CUPROJ_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-dec
 
 # Produce smallest binary size
 list(APPEND CUPROJ_CUDA_FLAGS -Xfatbin=-compress-all)
+if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
+   CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.4.0)
+  list(APPEND CUPROJ_CUDA_FLAGS -Xfatbin=-compress-algo=5)
+endif()
 
 if(DISABLE_DEPRECATION_WARNING)
     list(APPEND CUPROJ_CXX_FLAGS -Wno-deprecated-declarations)

--- a/cpp/cuproj/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cuproj/cmake/modules/ConfigureCUDA.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The zsd compression with nvcc 12.4 produces significantly ( 20-40% ) smaller
binaries with no impact on runtime or compile time performance.
