### PR TITLE
Enable import tests

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -27,19 +27,13 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-logger "Begin py build cuSpatial"
 
-# TODO: Remove `--no-test` flag once importing on a CPU
-# node works correctly
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
-  --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cuspatial
 
 rapids-logger "Begin py build cuProj"
 
-# TODO: Remove `--no-test` flag once importing on a CPU
-# node works correctly
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
-  --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cuproj
 

--- a/conda/recipes/cuproj/meta.yaml
+++ b/conda/recipes/cuproj/meta.yaml
@@ -84,8 +84,6 @@ test:            # [linux64]
     - cupy>=12.0.0
     - cuspatial ={{ minor_version }}
     - rmm ={{ minor_version }}
-  env:
-    - RAPIDS_NO_INITIALIZE=1
 
 
 about:

--- a/conda/recipes/cuproj/meta.yaml
+++ b/conda/recipes/cuproj/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
@@ -84,6 +84,8 @@ test:            # [linux64]
     - cupy>=12.0.0
     - cuspatial ={{ minor_version }}
     - rmm ={{ minor_version }}
+  env:
+    - RAPIDS_NO_INITIALIZE=1
 
 
 about:

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -82,6 +82,8 @@ requirements:
 test:            # [linux64]
   imports:       # [linux64]
     - cuspatial  # [linux64]
+  env:
+    - RAPIDS_NO_INITIALIZE=1
 
 about:
   home: https://rapids.ai/

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -82,8 +82,6 @@ requirements:
 test:            # [linux64]
   imports:       # [linux64]
     - cuspatial  # [linux64]
-  env:
-    - RAPIDS_NO_INITIALIZE=1
 
 about:
   home: https://rapids.ai/


### PR DESCRIPTION
Removes the `--no-test` flag currently set in conda build command and enables testing imports.