### PR TITLE
Enable warnings-as-errors for cuproj tests

### DIFF
--- a/python/cuproj/pyproject.toml
+++ b/python/cuproj/pyproject.toml
@@ -111,3 +111,11 @@ wheel.packages = ["cuproj"]
 provider = "scikit_build_core.metadata.regex"
 input = "cuproj/VERSION"
 regex = "(?P<value>.*)"
+
+[tool.pytest.ini_options]
+xfail_strict = true
+filterwarnings = [
+    "error",
+    # https://github.com/pytest-dev/pytest-cov/issues/557
+    "ignore:The --rsyncdir command line argument:DeprecationWarning",
+]


### PR DESCRIPTION
## Description
Following https://github.com/rapidsai/build-planning/issues/26, enabled warnings-as-errors for cuproj test

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
