### PR TITLE
Set default value for PARALLEL_LEVEL to nproc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ BUILD_DISABLE_DEPRECATION_WARNING=ON
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
 #         CONDA_PREFIX, but there is no fallback from there!
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
-PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
+PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc --all)}
 
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ BUILD_DISABLE_DEPRECATION_WARNING=ON
 #  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
 #         CONDA_PREFIX, but there is no fallback from there!
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
-PARALLEL_LEVEL=${PARALLEL_LEVEL:=""}
+PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 # cuSpatial build script
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The `PARALLEL_LEVEL` variable is used in CI to set parallel level while building. Currently this variable is set on the GHA runners to `nproc`, but as this is a RAPIDS specific variable, this variable will soon be removed from the runners, so RAPIDS projects must explicitly set this variable to `nproc`. This PR is setting the default value of `PARALLEL_LEVEL` to `nproc` to match what is done by other RAPIDS projects

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
