### PR TITLE
Remove text builds of documentation

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -43,14 +43,14 @@ popd
 rapids-logger "Build cuSpatial Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html -W
-mkdir -p "${RAPIDS_DOCS_DIR}/cuspatial/"html
+mkdir -p "${RAPIDS_DOCS_DIR}/cuspatial/html"
 mv _html/* "${RAPIDS_DOCS_DIR}/cuspatial/html"
 popd
 
 rapids-logger "Build cuProj Python docs"
 pushd docs/cuproj
 sphinx-build -b dirhtml source _html -W
-mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/"html
+mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/html"
 mv _html/* "${RAPIDS_DOCS_DIR}/cuproj/html"
 popd
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -43,19 +43,15 @@ popd
 rapids-logger "Build cuSpatial Python docs"
 pushd docs
 sphinx-build -b dirhtml source _html -W
-sphinx-build -b text source _text -W
-mkdir -p "${RAPIDS_DOCS_DIR}/cuspatial/"{html,txt}
+mkdir -p "${RAPIDS_DOCS_DIR}/cuspatial/"html
 mv _html/* "${RAPIDS_DOCS_DIR}/cuspatial/html"
-mv _text/* "${RAPIDS_DOCS_DIR}/cuspatial/txt"
 popd
 
 rapids-logger "Build cuProj Python docs"
 pushd docs/cuproj
 sphinx-build -b dirhtml source _html -W
-sphinx-build -b text source _text -W
-mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/"{html,txt}
+mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/"html
 mv _html/* "${RAPIDS_DOCS_DIR}/cuproj/html"
-mv _text/* "${RAPIDS_DOCS_DIR}/cuproj/txt"
 popd
 
 rapids-upload-docs


### PR DESCRIPTION
This PR removes text builds of the documentation, which we do not currently use for anything. Contributes to https://github.com/rapidsai/build-planning/issues/71.
