### PR TITLE
Fix test_intersections.py post cudf refactor

### DIFF
--- a/python/cuspatial/cuspatial/tests/basicpreds/test_intersections.py
+++ b/python/cuspatial/cuspatial/tests/basicpreds/test_intersections.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
 import geopandas as gpd
 import pandas as pd
 from geopandas.testing import assert_geoseries_equal
@@ -13,7 +15,9 @@ def run_test(s1, s2, expect_offset, expect_geom, expect_ids):
         cuspatial.from_geopandas(s1), cuspatial.from_geopandas(s2)
     )
 
-    assert_series_equal(expect_offset, offset.to_pandas(), check_dtype=False)
+    assert_series_equal(
+        expect_offset, pd.Series(offset.to_pandas()), check_dtype=False
+    )
     assert_geoseries_equal(expect_geom, geoms.to_geopandas())
     assert_frame_equal(expect_ids, ids.to_pandas())
 


### PR DESCRIPTION
## Description
closes #1395

`pairwise_linestring_intersection`, tested in this file, returns a `cudf.Column` for one of it's arguments and used `to_pandas` to test it's output. in 24.08, the output of `Column.to_pandas` was changed to a `pandas.Index` instead of a `pandas.Series` so modified the test accordingly 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
