### PR TITLE
Use verify-alpha-spec hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,15 +42,16 @@ repos:
             - id: codespell
               args: ["--config pyproject.toml"]
               additional_dependencies: ["tomli"]
+      - repo: https://github.com/rapidsai/pre-commit-hooks
+        rev: v0.2.0
+        hooks:
+            - id: verify-copyright
+            - id: verify-alpha-spec
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.13.11
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]
-      - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.0.3
-        hooks:
-            - id: verify-copyright
 
 
 default_language_version:

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -22,10 +22,10 @@ dependencies:
 - geopandas>=0.11.0
 - ipython
 - ipywidgets
-- libcudf==24.8.*
+- libcudf==24.8.*,>=0.0.0a0
 - libcuspatial-tests==24.8.*
 - libcuspatial==24.8.*
-- librmm==24.8.*
+- librmm==24.8.*,>=0.0.0a0
 - myst-parser
 - nbsphinx
 - ninja

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -25,10 +25,10 @@ dependencies:
 - geopandas>=0.11.0
 - ipython
 - ipywidgets
-- libcudf==24.8.*
+- libcudf==24.8.*,>=0.0.0a0
 - libcuspatial-tests==24.8.*
 - libcuspatial==24.8.*
-- librmm==24.8.*
+- librmm==24.8.*,>=0.0.0a0
 - myst-parser
 - nbsphinx
 - ninja

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -145,8 +145,8 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - libcudf==24.8.*
-          - librmm==24.8.*
+          - libcudf==24.8.*,>=0.0.0a0
+          - librmm==24.8.*,>=0.0.0a0
           - proj
           - sqlite
     specific:
@@ -489,5 +489,5 @@ dependencies:
       - output_types: conda
         packages:
           - libcuspatial==24.8.*
-          - cuspatial==24.8.*
-          - cuproj==24.8.*
+          - cuspatial==24.8.*,>=0.0.0a0
+          - cuproj==24.8.*,>=0.0.0a0


### PR DESCRIPTION
With the deployment of rapids-build-backend, we need to make sure our dependencies have alpha specs.

Contributes to https://github.com/rapidsai/build-planning/issues/31

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
