### PR TITLE
Change _GeoSeriesUtility._from_data(index=) default to None

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -41,6 +41,7 @@ files:
     includes:
       - cuda_version
       - depends_on_cuml
+      - test_notebooks
       - notebooks
       - py_version
       - test_cuspatial
@@ -334,6 +335,12 @@ dependencies:
       - output_types: [conda]
         packages:
           - curl
+  # TODO: Remove geopandas.dataset usage in cuspatial_api_examples.ipynb
+  test_notebooks:
+    common:
+      - output_types: [conda, requirements, pyproject]
+        packages:
+          - geopandas<1
   py_version:
     specific:
       - output_types: conda

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION
+# Copyright (c) 2020-2024, NVIDIA CORPORATION
 from typing import Dict, Tuple, TypeVar, Union
 
 import pandas as pd

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -303,7 +303,7 @@ class GeoDataFrame(cudf.DataFrame):
 
 class _GeoSeriesUtility:
     @classmethod
-    def _from_data(cls, new_data, name=None, index=False):
+    def _from_data(cls, new_data, name=None, index=None):
         new_column = new_data.columns[0]
         if is_geometry_type(new_column):
             return GeoSeries(new_column, name=name, index=index)

--- a/python/cuspatial/cuspatial/tests/spatial/distance/test_pairwise_linestring_distance.py
+++ b/python/cuspatial/cuspatial/tests/spatial/distance/test_pairwise_linestring_distance.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 from shapely.geometry import LineString
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 import cuspatial
 

--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -331,7 +331,7 @@ def test_memory_usage(gs, data_dir):
     host_dataframe = gpd.read_file(data_dir / "naturalearth_lowres.shp")
     gpu_dataframe = cuspatial.from_geopandas(host_dataframe)
     # The df size is 8kb of cudf rows and 217kb of the geometry column
-    assert gpu_dataframe.memory_usage().sum() == 216793
+    assert gpu_dataframe.memory_usage().sum() == 216789
 
 
 def test_from_dict():

--- a/python/cuspatial/cuspatial/tests/test_geoseries.py
+++ b/python/cuspatial/cuspatial/tests/test_geoseries.py
@@ -554,7 +554,7 @@ def test_memory_usage_simple(gs):
 def test_memory_usage_large(naturalearth_lowres):
     geometry = cuspatial.from_geopandas(naturalearth_lowres)["geometry"]
     # the geometry column from naturalearth_lowres is 217kb of coordinates
-    assert geometry.memory_usage() == 216793
+    assert geometry.memory_usage() == 216789
 
 
 @pytest.mark.parametrize("level", [None, 0, 1])


### PR DESCRIPTION
## Description
An upstream change in cudf uncovered a bug in `_GeoSeriesUtility._from_data` where `False` was being passed to `cudf.Series(index=)` which is an invalid value. The only valid `index` values are an actual `cudf.Index` or `None`, so setting to `None` as a more appropriate default value

Also updates the location of `assert_eq` which moved in https://github.com/rapidsai/cudf/pull/16063

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
