### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
 - c-compiler
 - clang-tools=16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-version=11.8
 - cudatoolkit
 - cudf==24.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
 - c-compiler
 - clang-tools=16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/recipes/cuproj/conda_build_config.yaml
+++ b/conda/recipes/cuproj/conda_build_config.yaml
@@ -17,7 +17,7 @@ c_stdlib_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 # Workaround until proj 9.3.1 migration completes
 proj:

--- a/conda/recipes/cuspatial/conda_build_config.yaml
+++ b/conda/recipes/cuspatial/conda_build_config.yaml
@@ -17,4 +17,4 @@ c_stdlib_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"

--- a/conda/recipes/libcuspatial/conda_build_config.yaml
+++ b/conda/recipes/libcuspatial/conda_build_config.yaml
@@ -11,7 +11,7 @@ cuda11_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.26.4"
+  - ">=3.26.4,!=3.30.0"
 
 gtest_version:
   - ">=1.13.0"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -140,7 +140,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - ninja
-          - cmake>=3.26.4
+          - cmake>=3.26.4,!=3.30.0
       - output_types: conda
         packages:
           - c-compiler
@@ -183,7 +183,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - ninja
-          - cmake>=3.26.4
+          - cmake>=3.26.4,!=3.30.0
       - output_types: conda
         packages:
           - c-compiler

--- a/python/cuproj/pyproject.toml
+++ b/python/cuproj/pyproject.toml
@@ -119,7 +119,7 @@ filterwarnings = [
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",
     "ninja",
     "rmm==24.8.*,>=0.0.0a0",

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -129,7 +129,7 @@ filterwarnings = [
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cudf==24.8.*,>=0.0.0a0",
     "cython>=3.0.0",
     "ninja",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.
