### PR TITLE
Fix multipolygon geometry iterator.

### DIFF
--- a/cpp/include/cuspatial/range/multipolygon_range.cuh
+++ b/cpp/include/cuspatial/range/multipolygon_range.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,10 +115,10 @@ class multipolygon_range {
   CUSPATIAL_HOST_DEVICE auto point_end();
 
   /// Return the iterator to the first geometry offset in the range.
-  CUSPATIAL_HOST_DEVICE auto geometry_offset_begin() { return _part_begin; }
+  CUSPATIAL_HOST_DEVICE auto geometry_offset_begin() { return _geometry_begin; }
 
   /// Return the iterator to the one past the last geometry offset in the range.
-  CUSPATIAL_HOST_DEVICE auto geometry_offset_end() { return _part_end; }
+  CUSPATIAL_HOST_DEVICE auto geometry_offset_end() { return _geometry_end; }
 
   /// Return the iterator to the first part offset in the range.
   CUSPATIAL_HOST_DEVICE auto part_offset_begin() { return _part_begin; }

--- a/cpp/include/cuspatial_test/vector_factories.cuh
+++ b/cpp/include/cuspatial_test/vector_factories.cuh
@@ -164,10 +164,26 @@ class multipolygon_array {
   {
     auto [geometry_offsets, part_offsets, ring_offsets, coordinates] = arr.to_host();
 
-    return os << "Geometry Offsets:\n\t{" << geometry_offsets << "}\n"
-              << "Part Offsets:\n\t{" << part_offsets << "}\n"
-              << "Ring Offsets: \n\t{" << ring_offsets << "}\n"
-              << "Coordinates: \n\t{" << coordinates << "}\n";
+    auto print_vector = [&](auto const& vec) {
+      for (auto it = vec.begin(); it != vec.end(); it++) {
+        os << *it;
+        if (std::next(it) != vec.end()) { os << ", "; }
+      }
+    };
+
+    os << "Geometry Offsets:\n\t{";
+    print_vector(geometry_offsets);
+    os << "}\n";
+    os << "Part Offsets:\n\t{";
+    print_vector(part_offsets);
+    os << "}\n";
+    os << "Ring Offsets: \n\t{";
+    print_vector(ring_offsets);
+    os << "}\n";
+    os << "Coordinates: \n\t{";
+    print_vector(coordinates);
+    os << "}\n";
+    return os;
   }
 
  protected:

--- a/cpp/tests/range/multipolygon_range_test.cu
+++ b/cpp/tests/range/multipolygon_range_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1069,7 +1069,7 @@ class MultipolygonRangeOneTest : public MultipolygonRangeTestBase<T> {
   void test_geometry_offsets_it()
   {
     rmm::device_uvector<std::size_t> d_offsets = this->copy_geometry_offsets();
-    auto expected                              = make_device_vector<std::size_t>({0, 1});
+    auto expected                              = make_device_vector<std::size_t>({0, 2});
 
     CUSPATIAL_EXPECT_VECTORS_EQUIVALENT(d_offsets, expected);
   }


### PR DESCRIPTION
## Description
This PR fixes a bug in the multipolygon geometry iterator. The geometry iterator was returning part iterators by mistake, which masked an issue that we were patching out in rapids-cmake's CCCL. See https://github.com/rapidsai/rapids-cmake/pull/511.

With this fix, we can remove that patch from rapids-cmake's CCCL: https://github.com/rapidsai/rapids-cmake/pull/640

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
