### PR TITLE
test notebooks in 'docs/', make cuspatial_api_examples self-contained, skip long-running notebook, fix some docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,10 +148,13 @@ ENV/
 .mypy_cache/
 
 # notebook/example generated files
+docs/source/user_guide/cache/
+docs/source/user_guide/*.csv
 notebooks/taxi2016.csv
 notebooks/taxi2017.csv
 notebooks/tzones_lonlat.json
 notebooks/cu_taxi.zones.*
+*.parquet
 
 # clang tooling
 compile_commands.json

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -45,7 +45,7 @@ test_notebooks() {
             echo "--------------------------------------------------------------------------------"
         else
             nvidia-smi
-            ${NBTEST} ${nbBasename}
+            ${NBTEST} "${nb}"
         fi
     done
 }

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -26,7 +26,6 @@ set -u
 rapids-print-env
 
 NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
-pushd notebooks
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
@@ -36,17 +35,30 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 
 set +e
-for nb in $(find . -name "*.ipynb"); do
-    nbBasename=$(basename ${nb})
-    if (echo " ${SKIPNBS} " | grep -q " ${nbBasename} "); then
-        echo "--------------------------------------------------------------------------------"
-        echo "SKIPPING: ${nb} (listed in skip list)"
-        echo "--------------------------------------------------------------------------------"
-    else
-        nvidia-smi
-        ${NBTEST} ${nbBasename}
-    fi
-done
+
+test_notebooks() {
+    for nb in $(find . -name "*.ipynb"); do
+        nbBasename=$(basename ${nb})
+        if (echo " ${SKIPNBS} " | grep -q " ${nbBasename} "); then
+            echo "--------------------------------------------------------------------------------"
+            echo "SKIPPING: ${nb} (listed in skip list)"
+            echo "--------------------------------------------------------------------------------"
+        else
+            nvidia-smi
+            ${NBTEST} ${nbBasename}
+        fi
+    done
+}
+
+# test notebooks in notebooks/
+pushd notebooks
+test_notebooks
+popd
+
+# test notebooks in docs/
+pushd docs
+test_notebooks
+popd
 
 rapids-logger "Notebook test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb nyc_taxi_years_correlation.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR

--- a/ci/utils/nbtest.sh
+++ b/ci/utils/nbtest.sh
@@ -24,8 +24,7 @@ get_ipython().run_cell_magic=my_run_cell_magic
 "
 
 NO_COLORS=--colors=NoColor
-NBTMPDIR="$WORKSPACE/tmp"
-mkdir -p ${NBTMPDIR}
+NBTMPDIR="$(mktemp -d)"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR

--- a/ci/utils/nbtest.sh
+++ b/ci/utils/nbtest.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Copyright (c) 2023, NVIDIA CORPORATION.
 
+set -e -u -o pipefail
+
 MAGIC_OVERRIDE_CODE="
 def my_run_line_magic(*args, **kwargs):
     g=globals()

--- a/ci/utils/nbtest.sh
+++ b/ci/utils/nbtest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -e -u -o pipefail
 

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -19,6 +19,7 @@ dependencies:
 - cython>=3.0.0
 - doxygen
 - gcc_linux-64=11.*
+- geopandas<1
 - geopandas>=0.11.0
 - ipython
 - ipywidgets
@@ -33,6 +34,7 @@ dependencies:
 - numpy>=1.23,<2.0a0
 - numpydoc
 - nvcc_linux-64=11.8
+- osmnx>=1.9.3
 - pre-commit
 - proj
 - pydata-sphinx-theme!=0.14.2

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -22,6 +22,7 @@ dependencies:
 - cython>=3.0.0
 - doxygen
 - gcc_linux-64=11.*
+- geopandas<1
 - geopandas>=0.11.0
 - ipython
 - ipywidgets
@@ -35,6 +36,7 @@ dependencies:
 - notebook
 - numpy>=1.23,<2.0a0
 - numpydoc
+- osmnx>=1.9.3
 - pre-commit
 - proj
 - pydata-sphinx-theme!=0.14.2

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,6 +20,7 @@ files:
       - rapids_build_skbuild
       - run_python_cuspatial
       - test_libcuspatial
+      - test_notebooks
       - test_python_cuspatial
       - test_python_cuproj
       - notebooks
@@ -341,6 +342,9 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - geopandas<1
+      - output_types: conda
+        packages:
+          - osmnx>=1.9.3
   py_version:
     specific:
       - output_types: conda

--- a/docs/source/user_guide/cuspatial_api_examples.ipynb
+++ b/docs/source/user_guide/cuspatial_api_examples.ipynb
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "88d05bb9-c924-4d0b-8736-cd5183602d76",
    "metadata": {
     "tags": []
@@ -108,6 +108,7 @@
     "import cudf\n",
     "import cupy\n",
     "import geopandas\n",
+    "import os\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from shapely.geometry import *\n",
@@ -116,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "4937d4aa-4e32-49ab-a22e-96dfb0098d07",
    "metadata": {
     "tags": []
@@ -156,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "255fbfbe-8be1-498c-9a26-f4a3f31bdded",
    "metadata": {
     "tags": []
@@ -239,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "956451e2-a520-441d-a939-575ed179917b",
    "metadata": {
     "tags": []
@@ -305,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "cd8d1c39-b44f-4d06-9e11-04c2dca4cf15",
    "metadata": {
     "tags": []
@@ -320,7 +321,7 @@
        "<POLYGON ((66.519 37.363, 67.076 37.356, 67.83 37.145, 68.136 37.023, 68.859...>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -350,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "cb5acdad-53aa-418f-9948-8445515bd2b2",
    "metadata": {
     "tags": []
@@ -415,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "03b75847-090d-40f8-8147-cb10b900d6ec",
    "metadata": {
     "tags": []
@@ -480,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "452f60cb-28cc-4ad8-8aa2-9d73e3d56ec6",
    "metadata": {
     "tags": []
@@ -491,11 +492,11 @@
      "output_type": "stream",
      "text": [
       "      x_min     y_min     x_max     y_max\n",
-      "0  0.000098  0.000243  0.999422  0.999068\n",
-      "1  0.000663  0.000414  0.999813  0.998456\n",
-      "2  0.000049  0.000220  0.999748  0.999220\n",
-      "3  0.000006  0.000303  0.999729  0.999762\n",
-      "4  0.001190  0.000074  0.999299  0.999858\n"
+      "0  0.000361  0.000170  0.999582  0.999485\n",
+      "1  0.000184  0.000647  0.999939  0.999884\n",
+      "2  0.000461  0.001395  0.999938  0.999297\n",
+      "3  0.000093  0.000073  0.999819  0.999544\n",
+      "4  0.000105  0.000112  0.999952  0.999013\n"
      ]
     }
    ],
@@ -523,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "9266aac4-f925-4fb7-b287-5f0b795d5756",
    "metadata": {
     "tags": []
@@ -566,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "15b5bb38-702f-4360-b48c-2e49ffd650d7",
    "metadata": {
     "tags": []
@@ -577,11 +578,11 @@
      "output_type": "stream",
      "text": [
       "       minx      miny      maxx      maxy\n",
-      "0 -0.000002  0.000143  0.999522  0.999168\n",
-      "1  0.000563  0.000314  0.999913  0.998556\n",
-      "2 -0.000051  0.000120  0.999848  0.999320\n",
-      "3 -0.000094  0.000203  0.999829  0.999862\n",
-      "4  0.001090 -0.000026  0.999399  0.999958\n"
+      "0  0.000261  0.000070  0.999682  0.999585\n",
+      "1  0.000084  0.000547  1.000039  0.999984\n",
+      "2  0.000361  0.001295  1.000038  0.999397\n",
+      "3 -0.000007 -0.000027  0.999919  0.999644\n",
+      "4  0.000005  0.000012  1.000052  0.999113\n"
      ]
     }
    ],
@@ -614,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "a7a870dd-c0ae-41c1-a66c-cff4bd2db0ec",
    "metadata": {
     "tags": []
@@ -675,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "e75b0352-0f80-404d-a113-f301601cd5a3",
    "metadata": {
     "tags": []
@@ -738,7 +739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "70f66319-c4d2-4a93-ab98-0debcce4a719",
    "metadata": {
     "tags": []
@@ -755,7 +756,7 @@
        "Name: None, dtype: float64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -789,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "c32741b0-c550-4d0f-b494-45191f5b60fd",
    "metadata": {},
    "outputs": [
@@ -850,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "35dfb7c9-1914-488a-b22e-8d0067ea7a8b",
    "metadata": {
     "tags": []
@@ -907,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "40e9a41e-21af-47cc-a142-b19a67941f7f",
    "metadata": {
     "tags": []
@@ -991,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "258c9a8c-7fe3-4047-80b7-00878d9fb2f1",
    "metadata": {
     "tags": []
@@ -1023,18 +1024,18 @@
       "4          None       None      None          None       None      None   \n",
       "\n",
       "  FCLASS_UA                                           geometry distance_from  \\\n",
-      "0      None  MULTIPOLYGON (((20037508.343 -1812498.413, 200...  Vatican City   \n",
-      "1      None  POLYGON ((3774143.866 -105758.362, 3792946.708...    San Marino   \n",
-      "2      None  POLYGON ((-964649.018 3205725.605, -964597.245...         Vaduz   \n",
-      "3      None  MULTIPOLYGON (((-13674486.249 6274861.394, -13...       Lobamba   \n",
-      "4      None  MULTIPOLYGON (((-13674486.249 6274861.394, -13...    Luxembourg   \n",
+      "0      None  MULTIPOLYGON (((180 -16.06713, 180 -16.55522, ...  Vatican City   \n",
+      "1      None  POLYGON ((33.90371 -0.95, 34.07262 -1.05982, 3...    San Marino   \n",
+      "2      None  POLYGON ((-8.66559 27.65643, -8.66512 27.58948...         Vaduz   \n",
+      "3      None  MULTIPOLYGON (((-122.84 49, -122.97421 49.0025...       Lobamba   \n",
+      "4      None  MULTIPOLYGON (((-122.84 49, -120 49, -117.0312...    Luxembourg   \n",
       "\n",
       "       distance  \n",
-      "0  1.969350e+07  \n",
-      "1  5.929777e+06  \n",
-      "2  3.421172e+06  \n",
-      "3  1.296059e+07  \n",
-      "4  8.174897e+06  \n",
+      "0  5.329915e+06  \n",
+      "1  5.628613e+06  \n",
+      "2  6.057264e+06  \n",
+      "3  4.626961e+06  \n",
+      "4  6.415631e+06  \n",
       "\n",
       "[5 rows x 171 columns]\n",
       "(GPU)\n",
@@ -1073,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
    "id": "5863871e",
    "metadata": {},
    "outputs": [
@@ -1126,7 +1127,7 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>West 80th Street</td>\n",
-       "      <td>LINESTRING (-8235369.475 4980617.398, -8235349...</td>\n",
+       "      <td>LINESTRING (-8235369.475 4980617.398, -8235347...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1143,11 +1144,11 @@
        "0       Columbus Avenue  LINESTRING (-8234860.077 4980333.535, -8234863...\n",
        "1      West 80th Street  LINESTRING (-8235173.854 4980508.442, -8235160...\n",
        "2      Amsterdam Avenue  LINESTRING (-8235173.854 4980508.442, -8235168...\n",
-       "3      West 80th Street  LINESTRING (-8235369.475 4980617.398, -8235349...\n",
+       "3      West 80th Street  LINESTRING (-8235369.475 4980617.398, -8235347...\n",
        "4              Broadway  LINESTRING (-8235369.475 4980617.398, -8235373..."
       ]
      },
-     "execution_count": 22,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1155,14 +1156,14 @@
    "source": [
     "# all driveways within 2km range of central park, nyc\n",
     "\n",
-    "# The dataset is downloaded and processed as follows:\n",
-    "# import osmnx as ox\n",
-    "# graph = ox.graph_from_point((40.769361, -73.977655), dist=2000, network_type=\"drive\")\n",
-    "# nodes, streets = ox.graph_to_gdfs(graph)\n",
-    "# streets = streets.to_crs(3857)\n",
-    "# streets = streets.reset_index(drop=True)\n",
-    "# streets.index.name = \"index\"\n",
-    "# streets[[\"name\", \"geometry\"]].to_csv(\"streets_3857.csv\")\n",
+    "if not os.path.exists(\"./streets_3857.csv\"):\n",
+    "    import osmnx as ox\n",
+    "    graph = ox.graph_from_point((40.769361, -73.977655), dist=2000, network_type=\"drive\")\n",
+    "    nodes, streets = ox.graph_to_gdfs(graph)\n",
+    "    streets = streets.to_crs(3857)\n",
+    "    streets = streets.reset_index(drop=True)\n",
+    "    streets.index.name = \"index\"\n",
+    "    streets[[\"name\", \"geometry\"]].to_csv(\"streets_3857.csv\")\n",
     "\n",
     "# The data is under notebooks/streets_3857.csv\n",
     "streets = pd.read_csv(\"./streets_3857.csv\", index_col=\"index\")\n",
@@ -1173,10 +1174,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "id": "f4c67464",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/raid/jlamb/miniforge/envs/cuspatial-dev/lib/python3.11/site-packages/osmnx/features.py:294: DeprecationWarning: The 'unary_union' attribute is deprecated, use the 'union_all()' method instead.\n",
+      "  polygon = gdf_place[\"geometry\"].unary_union\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -1240,7 +1249,7 @@
        "0      POLYGON ((-8236139.639 4975314.625, -8235990.3..."
       ]
      },
-     "execution_count": 24,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1248,12 +1257,13 @@
    "source": [
     "# The polygon of the Empire State Building\n",
     "\n",
-    "# The dataset is downloaded and processed as follows:\n",
-    "# esb = ox.geometries.geometries_from_place('Empire State Building, New York', tags={\"building\": True})\n",
-    "# esb = esb.to_crs(3857)\n",
-    "# esb = esb.geometry.reset_index(drop=True)\n",
-    "# esb.index.name = \"index\"\n",
-    "# esb.to_csv(\"esb_3857.csv\")\n",
+    "if not os.path.exists(\"./esb_3857.csv\"):\n",
+    "    import osmnx as ox\n",
+    "    esb = ox.features.features_from_place('Empire State Building, New York', tags={\"building\": True})\n",
+    "    esb = esb.to_crs(3857)\n",
+    "    esb = esb.geometry.reset_index(drop=True)\n",
+    "    esb.index.name = \"index\"\n",
+    "    esb.to_csv(\"esb_3857.csv\")\n",
     "\n",
     "# The data is under notebooks/esb_3857.csv\n",
     "esb = pd.read_csv(\"./esb_3857.csv\", index_col=\"index\")\n",
@@ -1265,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 20,
    "id": "d4e68e87",
    "metadata": {},
    "outputs": [
@@ -1313,7 +1323,7 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>West 80th Street</td>\n",
-       "      <td>5276.886560</td>\n",
+       "      <td>5275.851781</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1326,33 +1336,33 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1859</th>\n",
-       "      <td>East 70th Street</td>\n",
-       "      <td>4193.471831</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1860</th>\n",
-       "      <td>West 65th Street</td>\n",
-       "      <td>3999.118604</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1861</th>\n",
-       "      <td>Dyer Avenue</td>\n",
-       "      <td>1470.617115</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>1862</th>\n",
-       "      <td>Dyer Avenue</td>\n",
-       "      <td>1468.714127</td>\n",
+       "      <td>West 82nd Street</td>\n",
+       "      <td>5411.762092</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1863</th>\n",
-       "      <td>Dyer Avenue</td>\n",
-       "      <td>1548.205363</td>\n",
+       "      <td>Broadway</td>\n",
+       "      <td>5476.345847</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1864</th>\n",
+       "      <td>West 84th Street</td>\n",
+       "      <td>5613.403002</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1865</th>\n",
+       "      <td>West 75th Street</td>\n",
+       "      <td>4750.092380</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1866</th>\n",
+       "      <td>Broadway</td>\n",
+       "      <td>4638.894939</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1864 rows × 2 columns</p>\n",
+       "<p>1867 rows × 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1360,19 +1370,19 @@
        "0      Columbus Avenue  4993.583717\n",
        "1     West 80th Street  5103.472213\n",
        "2     Amsterdam Avenue  5208.373183\n",
-       "3     West 80th Street  5276.886560\n",
+       "3     West 80th Street  5275.851781\n",
        "4             Broadway  5178.999774\n",
        "...                ...          ...\n",
-       "1859  East 70th Street  4193.471831\n",
-       "1860  West 65th Street  3999.118604\n",
-       "1861       Dyer Avenue  1470.617115\n",
-       "1862       Dyer Avenue  1468.714127\n",
-       "1863       Dyer Avenue  1548.205363\n",
+       "1862  West 82nd Street  5411.762092\n",
+       "1863          Broadway  5476.345847\n",
+       "1864  West 84th Street  5613.403002\n",
+       "1865  West 75th Street  4750.092380\n",
+       "1866          Broadway  4638.894939\n",
        "\n",
-       "[1864 rows x 2 columns]"
+       "[1867 rows x 2 columns]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1399,7 +1409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "id": "951625da",
    "metadata": {},
    "outputs": [],
@@ -1410,7 +1420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 22,
    "id": "2f0e1118",
    "metadata": {},
    "outputs": [
@@ -1445,81 +1455,81 @@
        "      <th>0</th>\n",
        "      <td>Nigeria</td>\n",
        "      <td>China</td>\n",
-       "      <td>7.383366e+06</td>\n",
+       "      <td>64.966620</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Ethiopia</td>\n",
        "      <td>India</td>\n",
-       "      <td>2.883313e+06</td>\n",
+       "      <td>25.598868</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Egypt</td>\n",
        "      <td>Indonesia</td>\n",
-       "      <td>6.776043e+06</td>\n",
+       "      <td>60.717434</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>Dem. Rep. Congo</td>\n",
        "      <td>Pakistan</td>\n",
-       "      <td>4.227767e+06</td>\n",
+       "      <td>37.489668</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>South Africa</td>\n",
        "      <td>Bangladesh</td>\n",
-       "      <td>8.189086e+06</td>\n",
+       "      <td>72.860545</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>Tanzania</td>\n",
        "      <td>Japan</td>\n",
-       "      <td>1.096947e+07</td>\n",
+       "      <td>97.872886</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>Kenya</td>\n",
        "      <td>Philippines</td>\n",
-       "      <td>8.399282e+06</td>\n",
+       "      <td>75.450451</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>Uganda</td>\n",
        "      <td>Vietnam</td>\n",
-       "      <td>7.773975e+06</td>\n",
+       "      <td>69.827567</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>Algeria</td>\n",
        "      <td>Turkey</td>\n",
-       "      <td>2.000180e+06</td>\n",
+       "      <td>17.927419</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>Sudan</td>\n",
        "      <td>Iran</td>\n",
-       "      <td>1.625828e+06</td>\n",
+       "      <td>13.990335</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "            Africa         Asia          dist\n",
-       "0          Nigeria        China  7.383366e+06\n",
-       "1         Ethiopia        India  2.883313e+06\n",
-       "2            Egypt    Indonesia  6.776043e+06\n",
-       "3  Dem. Rep. Congo     Pakistan  4.227767e+06\n",
-       "4     South Africa   Bangladesh  8.189086e+06\n",
-       "5         Tanzania        Japan  1.096947e+07\n",
-       "6            Kenya  Philippines  8.399282e+06\n",
-       "7           Uganda      Vietnam  7.773975e+06\n",
-       "8          Algeria       Turkey  2.000180e+06\n",
-       "9            Sudan         Iran  1.625828e+06"
+       "            Africa         Asia       dist\n",
+       "0          Nigeria        China  64.966620\n",
+       "1         Ethiopia        India  25.598868\n",
+       "2            Egypt    Indonesia  60.717434\n",
+       "3  Dem. Rep. Congo     Pakistan  37.489668\n",
+       "4     South Africa   Bangladesh  72.860545\n",
+       "5         Tanzania        Japan  97.872886\n",
+       "6            Kenya  Philippines  75.450451\n",
+       "7           Uganda      Vietnam  69.827567\n",
+       "8          Algeria       Turkey  17.927419\n",
+       "9            Sudan         Iran  13.990335"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1555,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 23,
    "id": "d1ade9da-c9e2-45c4-9685-dffeda3fd358",
    "metadata": {
     "tags": []
@@ -1622,7 +1632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 24,
    "id": "cc72a44d-a9bf-4432-9898-de899ac45869",
    "metadata": {
     "tags": []
@@ -1639,7 +1649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 25,
    "id": "1125fd17-afe1-4b9c-b48d-8842dd3700b3",
    "metadata": {
     "tags": []
@@ -1648,7 +1658,7 @@
     {
      "data": {
       "text/plain": [
-       "<cudf.core.column.numerical.NumericalColumn object at 0x7f3c9f514290>\n",
+       "<cudf.core.column.numerical.NumericalColumn object at 0x7f525c27a570>\n",
        "[\n",
        "  0,\n",
        "  142\n",
@@ -1656,7 +1666,7 @@
        "dtype: int32"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1704,7 +1714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 26,
    "id": "e19873b9-2614-4242-ad67-caa47f807d04",
    "metadata": {
     "tags": []
@@ -1741,9 +1751,9 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>[8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, ...</td>\n",
-       "      <td>[18, 16, 18, 15, 17, 14, 16, 137, 13, 15, 14, ...</td>\n",
+       "      <td>[18, 16, 18, 15, 17, 137, 14, 16, 13, 15, 14, ...</td>\n",
        "      <td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...</td>\n",
-       "      <td>[9, 10, 10, 11, 11, 12, 12, 28, 13, 13, 14, 15...</td>\n",
+       "      <td>[9, 10, 10, 11, 11, 28, 12, 12, 13, 13, 14, 15...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1754,16 +1764,16 @@
        "0  [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, ...   \n",
        "\n",
        "                                      lhs_segment_id  \\\n",
-       "0  [18, 16, 18, 15, 17, 14, 16, 137, 13, 15, 14, ...   \n",
+       "0  [18, 16, 18, 15, 17, 137, 14, 16, 13, 15, 14, ...   \n",
        "\n",
        "                                   rhs_linestring_id  \\\n",
        "0  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...   \n",
        "\n",
        "                                      rhs_segment_id  \n",
-       "0  [9, 10, 10, 11, 11, 12, 12, 28, 13, 13, 14, 15...  "
+       "0  [9, 10, 10, 11, 11, 28, 12, 12, 13, 13, 14, 15...  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1797,7 +1807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 27,
    "id": "bf7b2256",
    "metadata": {
     "tags": []
@@ -1814,7 +1824,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1900,7 +1910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 28,
    "id": "e3a0a9a3-0bdd-4f05-bcb5-7db4b99a44a3",
    "metadata": {
     "tags": []
@@ -1965,7 +1975,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 29,
    "id": "023bd25a-35be-435d-ab0b-ecbd7a47e147",
    "metadata": {
     "tags": []
@@ -2025,7 +2035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 30,
    "id": "784aff8e-c9ed-4a81-aa87-bf301b3b90af",
    "metadata": {
     "tags": []
@@ -2038,7 +2048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 31,
    "id": "fea24c78-cf5c-45c6-b860-338238e61323",
    "metadata": {
     "tags": []
@@ -2048,22 +2058,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   point_index  linestring_index      distance\n",
-      "0            0                19  1.362153e+06\n",
-      "1            1                21  1.352434e+06\n",
-      "2            2                19  6.406228e+04\n",
-      "3            3                19  6.750845e+03\n",
-      "4            4                21  3.473671e+05\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/coder/cuspatial/python/cuspatial/cuspatial/core/spatial/indexing.py:174: UserWarning: scale 5 is less than required minimum scale 243402.43980382645. Clamping to minimum scale\n",
-      "  warnings.warn(\n",
-      "/home/coder/cuspatial/python/cuspatial/cuspatial/core/spatial/join.py:146: UserWarning: scale 5 is less than required minimum scale 243402.43980382645. Clamping to minimum scale\n",
-      "  warnings.warn(\n"
+      "Empty DataFrame\n",
+      "Columns: [point_index, linestring_index, distance]\n",
+      "Index: []\n"
      ]
     }
    ],

--- a/notebooks/nyc_taxi_years_correlation.ipynb
+++ b/notebooks/nyc_taxi_years_correlation.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "!if [ ! -f \"tzones_lonlat.json\" ]; then curl \"https://data.cityofnewyork.us/api/geospatial/d3c5-ddgc?method=export&format=GeoJSON\" -o tzones_lonlat.json; else echo \"tzones_lonlat.json found\"; fi\n",
     "!if [ ! -f \"taxi2016.csv\" ]; then curl https://storage.googleapis.com/anaconda-public-data/nyc-taxi/csv/2016/yellow_tripdata_2016-01.csv -o taxi2016.csv; else echo \"taxi2016.csv found\"; fi   \n",
-    "!if [ ! -f \"taxi2017.csv\" ]; then curl https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2017-01.parquet -o taxi2017.parquet; else echo \"taxi2017.csv found\"; fi"
+    "!if [ ! -f \"taxi2017.parquet\" ]; then curl https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2017-01.parquet -o taxi2017.parquet; else echo \"taxi2017.csv found\"; fi"
    ]
   },
   {
@@ -128,9 +128,10 @@
     "tzones = gpd.GeoDataFrame.from_file('tzones_lonlat.json')\n",
     "taxi_zones = cuspatial.from_geopandas(tzones).geometry\n",
     "taxi_zone_rings = cuspatial.GeoSeries.from_polygons_xy(\n",
-    "    taxi_zones.polygons.xy, taxi_zones.polygons.ring_offset,\n",
-    "    taxi_zones.polygons.part_offset,\n",
-    "    cudf.Series(range(len(taxi_zones.polygons.part_offset)))\n",
+    "    polygons_xy=taxi_zones.polygons.xy,\n",
+    "    ring_offset=taxi_zones.polygons.ring_offset,\n",
+    "    part_offsets=taxi_zones.polygons.part_offset,\n",
+    "    geometry_offsets=cudf.Series(range(len(taxi_zones.polygons.part_offset)))\n",
     ")"
    ]
   },
@@ -507,7 +508,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -800,16 +800,16 @@ class GeoSeries(cudf.Series):
         ----------
         polygons_xy : array-like
             Coordinates of the points, interpreted as interleaved x-y coords.
+        ring_offset : array-like
+            Offsets into the part array indicating the beginning of each ring.
+            The length of this array is the number of rings.
+        part_offset : array-like
+            Offsets into the coordinates array indicating the beginning of
+            each part. The length of this array is the number of parts.
         geometry_offset : array-like
             Offsets of the first coordinate of each geometry. The length of
             this array is the number of geometries.  Offsets with a difference
             greater than 1 indicate a MultiLinestring.
-        part_offset : array-like
-            Offsets into the coordinates array indicating the beginning of
-            each part. The length of this array is the number of parts.
-        rint_offset : array-like
-            Offsets into the part array indicating the beginning of each ring.
-            The length of this array is the number of rings.
 
         Returns
         -------


### PR DESCRIPTION
## Description

Contributes to #1406.

Unblocks CI.

CI in https://github.com/rapidsai/docker has been failing because of errors in the `cuspatial_api_examples.ipynb` notebook. Specifically, that notebook refers unconditionally to local files that are not guaranteed to exist.

To fix this, that proposes the following:

* in the notebook, conditionally recreate those files if they don't yet exist
* always test the notebooks in `docs/` in CI here

CI **here** is failing because the `nyc_taxi_years_correlation` notebook recently started taking a prohibitively long time to run. This proposes:

* skipping `nyc_taxi_years_correlation` notebook in CI

And some other small things noticed while doing all this:

* fixing typo (`rint -> ring`) and argument ordering in `GeoSeries.from_polygons_xy()` docs

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Notes for Reviewers

I ran these notebooks on a system with CUDA 12.2, using the latest `24.8.*` nightlies of RAPIDS conda packages.