### PR TITLE
Conda: Move `cmake` to `requirements/build`

### DIFF
--- a/conda/recipes/cuproj/meta.yaml
+++ b/conda/recipes/cuproj/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - {{ compiler('cuda') }}
     {% endif %}
     - cuda-version ={{ cuda_version }}
+    - cmake {{ cmake_version }}
     - ninja
     - {{ stdlib("c") }}
   host:
@@ -58,7 +59,6 @@ requirements:
     - cuda-cudart-dev
     {% endif %}
     - cuda-version ={{ cuda_version }}
-    - cmake {{ cmake_version }}
     - cython >=3.0.0
     - python
     - rapids-build-backend >=0.3.0,<0.4.0.dev0

--- a/conda/recipes/cuspatial/meta.yaml
+++ b/conda/recipes/cuspatial/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - {{ compiler('cuda') }}
     {% endif %}
     - cuda-version ={{ cuda_version }}
+    - cmake {{ cmake_version }}
     - ninja
     - {{ stdlib("c") }}
   host:
@@ -58,7 +59,6 @@ requirements:
     - cuda-cudart-dev
     {% endif %}
     - cuda-version ={{ cuda_version }}
-    - cmake {{ cmake_version }}
     - cudf ={{ minor_version }}
     - cython >=3.0.0
     - libcuspatial ={{ version }}


### PR DESCRIPTION
## Description

Previously `cmake` was added to `requirements/host`. However it is a build tool. So should be placed in `requirements/build`. This makes that change in relevant recipes.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
