### PR TITLE
split up CUDA-suffixed dependencies in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -398,7 +398,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &rmm_conda rmm==24.8.*,>=0.0.0a0
+          - &rmm_unsuffixed rmm==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -413,27 +413,17 @@ dependencies:
             packages:
               - rmm-cu12==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *rmm_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - rmm-cu11==24.8.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *rmm_conda
-          - {matrix: null, packages: [*rmm_conda]}
+          - {matrix: null, packages: [*rmm_unsuffixed]}
 
   depends_on_cudf:
     common:
       - output_types: conda
         packages:
-          - &cudf_conda cudf==24.8.*,>=0.0.0a0
+          - &cudf_unsuffixed cudf==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -448,27 +438,17 @@ dependencies:
             packages:
               - cudf-cu12==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - cudf-cu11==24.8.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_conda
-          - {matrix: null, packages: [*cudf_conda]}
+          - {matrix: null, packages: [*cudf_unsuffixed]}
 
   depends_on_cuml:
     common:
       - output_types: conda
         packages:
-          - &cuml_conda cuml==24.8.*,>=0.0.0a0
+          - &cuml_unsuffixed cuml==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -483,27 +463,17 @@ dependencies:
             packages:
               - cuml-cu12==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cuml_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - cuml-cu11==24.8.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cuml_conda
-          - {matrix: null, packages: [*cuml_conda]}
+          - {matrix: null, packages: [*cuml_unsuffixed]}
 
   depends_on_cuspatial:
     common:
       - output_types: conda
         packages:
-          - &cuspatial_conda cuspatial==24.8.*,>=0.0.0a0
+          - &cuspatial_unsuffixed cuspatial==24.8.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -518,21 +488,11 @@ dependencies:
             packages:
               - cuspatial-cu12==24.8.*,>=0.0.0a0
           - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cuspatial_conda
-          - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - cuspatial-cu11==24.8.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cuspatial_conda
-          - {matrix: null, packages: [*cuspatial_conda]}
+          - {matrix: null, packages: [*cuspatial_unsuffixed]}
 
   depends_on_cupy:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -407,12 +407,26 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - rmm-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
+            packages:
+              - *rmm_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
             packages:
               - rmm-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
+            packages:
+              - *rmm_conda
           - {matrix: null, packages: [*rmm_conda]}
 
   depends_on_cudf:
@@ -428,12 +442,26 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - cudf-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cudf_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
             packages:
               - cudf-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cudf_conda
           - {matrix: null, packages: [*cudf_conda]}
 
   depends_on_cuml:
@@ -449,12 +477,26 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
             packages:
               - cuml-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cuml_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
             packages:
               - cuml-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
+            packages:
+              - *cuml_conda
           - {matrix: null, packages: [*cuml_conda]}
 
   depends_on_cuspatial:
@@ -470,12 +512,26 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "false"
             packages:
               - cuspatial-cu12==24.8.*,>=0.0.0a0
-          - matrix: {cuda: "11.*"}
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - *cuspatial_conda
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "false"
             packages:
               - cuspatial-cu11==24.8.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - *cuspatial_conda
           - {matrix: null, packages: [*cuspatial_conda]}
 
   depends_on_cupy:
@@ -483,6 +539,8 @@ dependencies:
       - output_types: conda
         packages:
           - cupy>=12.0.0
+    # NOTE: cupy dependency is not broken into groups by a 'cuda_suffixed' selector like
+    #       other packages in this file because DLFW builds expect it to have a -cuda{nn}x suffix
     specific:
       - output_types: [requirements, pyproject]
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -514,22 +514,22 @@ dependencies:
         matrices:
           - matrix:
               cuda: "12.*"
-              cuda_suffixed: "false"
+              cuda_suffixed: "true"
             packages:
               - cuspatial-cu12==24.8.*,>=0.0.0a0
           - matrix:
               cuda: "12.*"
-              cuda_suffixed: "true"
+              cuda_suffixed: "false"
             packages:
               - *cuspatial_conda
           - matrix:
               cuda: "11.*"
-              cuda_suffixed: "false"
+              cuda_suffixed: "true"
             packages:
               - cuspatial-cu11==24.8.*,>=0.0.0a0
           - matrix:
               cuda: "11.*"
-              cuda_suffixed: "true"
+              cuda_suffixed: "false"
             packages:
               - *cuspatial_conda
           - {matrix: null, packages: [*cuspatial_conda]}

--- a/python/cuproj/pyproject.toml
+++ b/python/cuproj/pyproject.toml
@@ -118,6 +118,7 @@ filterwarnings = [
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
+matrix-entry = "cuda-suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",

--- a/python/cuproj/pyproject.toml
+++ b/python/cuproj/pyproject.toml
@@ -118,7 +118,7 @@ filterwarnings = [
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda-suffixed=true"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -128,6 +128,7 @@ filterwarnings = [
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
+matrix-entry = "cuda-suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cudf==24.8.*,>=0.0.0a0",

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -128,7 +128,7 @@ filterwarnings = [
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda-suffixed=true"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cudf==24.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31

In short, RAPIDS DLFW builds want to produce wheels with unsuffixed dependencies, e.g. `cudf` depending on `rmm`, not `rmm-cu12`.

This PR is part of a series across all of RAPIDS to try to support that type of build by setting up CUDA-suffixed and CUDA-unsuffixed dependency lists in `dependencies.yaml`.

For more details, see:
* https://github.com/rapidsai/build-planning/issues/31#issuecomment-2245815818
* https://github.com/rapidsai/cudf/pull/16183

## Notes for Reviewers

### Why target 24.08?

This is targeting 24.08 because:

1. it should be very low-risk
2. getting these changes into 24.08 prevents the need to carry around patches for every library in DLFW builds using RAPIDS 24.08

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
