### PR TITLE
Ensure _from_data accepts columns objects only

### DIFF
--- a/python/cuspatial/cuspatial/core/binpreds/contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/contains.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 from math import ceil, sqrt
 
@@ -110,7 +110,7 @@ def _brute_force_contains_properly(points, polygons):
             width=len(polygons.polygons.part_offset) - 1,
         )
     )
-    final_result = DataFrame._from_data(
+    final_result = DataFrame(
         {
             name: result[name].astype("bool")
             for name in reversed(result.columns)

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -8,8 +8,7 @@ from geopandas import GeoDataFrame as gpGeoDataFrame
 from geopandas.geoseries import is_geometry_type as gp_is_geometry_type
 
 import cudf
-import cudf.core.column
-from cudf.core.column import as_column
+from cudf.core.column import ColumnBase, as_column
 from cudf.core.copy_types import BooleanMask, GatherMap
 
 from cuspatial.core._column.geocolumn import GeoColumn, GeoMeta
@@ -162,7 +161,7 @@ class GeoDataFrame(cudf.DataFrame):
 
     def _recombine_columns(
         self, geo_columns, data_columns
-    ) -> dict[Any, cudf.core.column.ColumnBase]:
+    ) -> dict[Any, ColumnBase]:
         """
         Combine a GeoDataFrame of only geometry columns with a DataFrame
         of non-geometry columns in the same order as the columns in `self`

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 import warnings
 
@@ -87,7 +87,7 @@ def point_in_polygon(points: GeoSeries, polygons: GeoSeries):
     )
 
     result.columns = polygons.index[::-1]
-    return DataFrame._from_data(
+    return DataFrame(
         {
             name: result[name].astype("bool")
             for name in reversed(result.columns)

--- a/python/cuspatial/cuspatial/core/spatial/nearest_points.py
+++ b/python/cuspatial/cuspatial/core/spatial/nearest_points.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+import cudf
 from cudf.core.column import as_column
 
 import cuspatial._lib.nearest_points as nearest_points
@@ -51,12 +52,12 @@ def pairwise_point_linestring_nearest_points(
 
     if len(points) == 0:
         data = {
-            "point_geometry_id": as_column([], dtype="i4"),
-            "linestring_geometry_id": as_column([], dtype="i4"),
-            "segment_id": as_column([], dtype="i4"),
-            "geometry": GeoColumn([]),
+            "point_geometry_id": cudf.Series([], dtype="i4"),
+            "linestring_geometry_id": cudf.Series([], dtype="i4"),
+            "segment_id": cudf.Series([], dtype="i4"),
+            "geometry": GeoSeries([]),
         }
-        return GeoDataFrame._from_data(data)
+        return GeoDataFrame(data)
 
     if not contains_only_points(points):
         raise ValueError("`points` must contain only point geometries.")

--- a/python/cuspatial/cuspatial/core/spatial/nearest_points.py
+++ b/python/cuspatial/cuspatial/core/spatial/nearest_points.py
@@ -1,6 +1,5 @@
-import cupy as cp
+# Copyright (c) 2024, NVIDIA CORPORATION.
 
-import cudf
 from cudf.core.column import as_column
 
 import cuspatial._lib.nearest_points as nearest_points
@@ -52,10 +51,10 @@ def pairwise_point_linestring_nearest_points(
 
     if len(points) == 0:
         data = {
-            "point_geometry_id": cudf.Series([], dtype="i4"),
-            "linestring_geometry_id": cudf.Series([], dtype="i4"),
-            "segment_id": cudf.Series([], dtype="i4"),
-            "geometry": GeoSeries([]),
+            "point_geometry_id": as_column([], dtype="i4"),
+            "linestring_geometry_id": as_column([], dtype="i4"),
+            "segment_id": as_column([], dtype="i4"),
+            "geometry": GeoColumn([]),
         }
         return GeoDataFrame._from_data(data)
 
@@ -97,11 +96,12 @@ def pairwise_point_linestring_nearest_points(
         as_column(linestrings.lines.geometry_offset),
     )
 
-    point_on_linestring = GeoColumn._from_points_xy(point_on_linestring_xy)
-    nearest_points_on_linestring = GeoSeries(point_on_linestring)
+    nearest_points_on_linestring = GeoColumn._from_points_xy(
+        point_on_linestring_xy
+    )
 
     if not point_geometry_id:
-        point_geometry_id = cp.zeros(len(points), dtype=cp.int32)
+        point_geometry_id = as_column(0, length=len(points), dtype="int32")
 
     data = {
         "point_geometry_id": point_geometry_id,


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/16285 makes `_from_data` explicitly requires the `data.values()` to all be a `ColumnBase`. This PR either ensures they are columns or just goes through the normal `GeoDataFrame`/`DataFrame` constructor if they are not.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
