### PR TITLE
Use CuPy array in `pip_bitmap_column_to_binary_array`

### DIFF
--- a/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
+++ b/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import numpy as np
 

--- a/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
+++ b/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
@@ -245,17 +245,17 @@ def test_pip_bitmap_column_to_binary_array():
     expected = np.array(
         [[0, 0, 0, 0], [1, 1, 0, 1], [0, 0, 1, 1], [1, 0, 0, 1]], dtype="int8"
     )
-    np.testing.assert_array_equal(got.copy_to_host(), expected)
+    np.testing.assert_array_equal(got.get(), expected)
 
     col = cudf.Series([], dtype="i8")._column
     got = pip_bitmap_column_to_binary_array(col, width=0)
     expected = np.array([], dtype="int8").reshape(0, 0)
-    np.testing.assert_array_equal(got.copy_to_host(), expected)
+    np.testing.assert_array_equal(got.get(), expected)
 
     col = cudf.Series([None, None], dtype="float64")._column
     got = pip_bitmap_column_to_binary_array(col, width=0)
     expected = np.array([], dtype="int8").reshape(2, 0)
-    np.testing.assert_array_equal(got.copy_to_host(), expected)
+    np.testing.assert_array_equal(got.get(), expected)
 
     col = cudf.Series(
         [
@@ -273,9 +273,9 @@ def test_pip_bitmap_column_to_binary_array():
         ],
         dtype="int8",
     )
-    np.testing.assert_array_equal(got.copy_to_host(), expected)
+    np.testing.assert_array_equal(got.get(), expected)
 
     col = cudf.Series([0, 0, 0])._column
     got = pip_bitmap_column_to_binary_array(col, width=3)
     expected = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]], dtype="int8")
-    np.testing.assert_array_equal(got.copy_to_host(), expected)
+    np.testing.assert_array_equal(got.get(), expected)

--- a/python/cuspatial/cuspatial/utils/join_utils.py
+++ b/python/cuspatial/cuspatial/utils/join_utils.py
@@ -28,11 +28,11 @@ def binarize(in_col, out, width):
 
 def apply_binarize(in_col, width):
     buf = rmm.DeviceBuffer(size=(in_col.size * width))
-    out = cuda.as_cuda_array(buf).view("int8").reshape((in_col.size, width))
+    out = cp.asarray(buf).view("int8").reshape((in_col.size, width))
     if out.size > 0:
         out[:] = 0
         binarize.forall(out.size)(in_col, out, width)
-    return cp.asarray(out)
+    return out
 
 
 def pip_bitmap_column_to_binary_array(polygon_bitmap_column, width):

--- a/python/cuspatial/cuspatial/utils/join_utils.py
+++ b/python/cuspatial/cuspatial/utils/join_utils.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 import operator
 
-from numba import cuda
 import cupy as cp
+from numba import cuda
 
 import rmm
 from cudf.core.buffer import acquire_spill_lock

--- a/python/cuspatial/cuspatial/utils/join_utils.py
+++ b/python/cuspatial/cuspatial/utils/join_utils.py
@@ -3,6 +3,7 @@
 import operator
 
 from numba import cuda
+import cupy as cp
 
 import rmm
 from cudf.core.buffer import acquire_spill_lock
@@ -31,7 +32,7 @@ def apply_binarize(in_col, width):
     if out.size > 0:
         out[:] = 0
         binarize.forall(out.size)(in_col, out, width)
-    return out
+    return cp.asarray(out)
 
 
 def pip_bitmap_column_to_binary_array(polygon_bitmap_column, width):


### PR DESCRIPTION
## Description
The performance regression in https://github.com/rapidsai/cuspatial/issues/1413 is due to numba's `DeviceNDArray`
is slow in slicing. Recent cudf's DataFrame construction has simplified the construction and delegated construction
to similar logic that handles __cuda_array_interface__. Since the construction involves slicing the array, we need
this operation to be fast. In that sense, we should cast the use of DeviceNDArray to cupy array to support fast
slicing.

closes #1413

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
