### PR TITLE
Readd `nyc_taxi_years_correlation.ipynb` test

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb nyc_taxi_years_correlation.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR


### PR DESCRIPTION
## Description

Previously the notebook tests were taking a long time to complete. Specifically `nyc_taxi_years_correlation.ipynb` was skipped in PR: https://github.com/rapidsai/cuspatial/pull/1407

However the root cause was later understood to be due to this change in cuDF (causing slow downs with Numba arrays): https://github.com/rapidsai/cudf/pull/16277

Since then cuSpatial changed from Numba to CuPy arrays ( https://github.com/rapidsai/cuspatial/pull/1418 ), which resolves the issue in cuSpatial. Separately cuDF is including changes to fix the issue seen with Numba arrays ( https://github.com/rapidsai/cudf/pull/16436 )

Given all these improvements, think we can add this notebook back to the tests

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
