### PR TITLE
Unskip taxi notebook from CI

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb nyc_taxi_years_correlation.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR


### PR DESCRIPTION
## Description
#1407 skipped the taxi dropoffs notebook due to performance regression fixed in #1418, so this PR re-enables the notebook in CI by removing it from SKIPNBS in ci/test_noteboks.sh.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
