### PR TITLE
Address cudf.DataFrame.insert API change

### DIFF
--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -270,7 +270,7 @@ class GeoDataFrame(cudf.DataFrame):
         if not drop:
             if not isinstance(cudf_data.index, cudf.MultiIndex):
                 recombiner.insert(
-                    loc=0, name="index", value=cudf_reindexed["index"]
+                    loc=0, column="index", value=cudf_reindexed["index"]
                 )
             # If the index is a MultiIndex, we need to insert the
             # individual levels into the GeoDataFrame.

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -288,7 +288,7 @@ class GeoDataFrame(cudf.DataFrame):
                 for n, name in enumerate(levels):
                     recombiner.insert(
                         loc=n,
-                        name=name,
+                        column=name,
                         value=cudf_reindexed[name].reset_index(drop=True),
                     )
                 recombiner.index = cudf_reindexed.index


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cuspatial/issues/1427

The API of `cudf.DataFrame.insert` will change in 24.10 to better align with pandas, so adjusting the usage here

xref https://github.com/rapidsai/cudf/pull/16402

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
