### PR TITLE
Fix _recombine_columns when either geocolumn or non-geocolumn was empty

### DIFF
--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -169,9 +169,9 @@ class GeoDataFrame(cudf.DataFrame):
         The output is meant for GeoDataFrame._from_data.
         """
         if not (
-            geo_columns.empty or
-            data_columns.empty or
-            geo_columns.index.equals(data_columns.index)
+            geo_columns.empty
+            or data_columns.empty
+            or geo_columns.index.equals(data_columns.index)
         ):
             raise ValueError("geo_columns.index must equal data_columns.index")
 

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -168,7 +168,9 @@ class GeoDataFrame(cudf.DataFrame):
 
         The output is meant for GeoDataFrame._from_data.
         """
-        if not geo_columns.index.equals(data_columns.index):
+        if not (
+            geo_columns.empty or data_columns.empty
+        ) and not geo_columns.index.equals(data_columns.index):
             raise ValueError("geo_columns.index must equal data_columns.index")
 
         columns_mask = self.columns

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -169,8 +169,10 @@ class GeoDataFrame(cudf.DataFrame):
         The output is meant for GeoDataFrame._from_data.
         """
         if not (
-            geo_columns.empty or data_columns.empty
-        ) and not geo_columns.index.equals(data_columns.index):
+            geo_columns.empty or
+            data_columns.empty or
+            geo_columns.index.equals(data_columns.index)
+        ):
             raise ValueError("geo_columns.index must equal data_columns.index")
 
         columns_mask = self.columns


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cuspatial/issues/1437

When `GeoDataFrame._split_out_geometry_columns` is called, there may be no geometry columns to split out into 2 DataFrames; therefore, once `GeoDataFrame._recombine_columns`, it assumed the 2 DataFrames were always non-empty. Added a check to bypass this validation if either was empty.

I ran the `ZipCodes_Stops_PiP_cuSpatial` notebook locally and the (non-commented) cells no longer raise an exception.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
