### PR TITLE
Remove unused shuffle_order in GeoColumn

### DIFF
--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2021-2024, NVIDIA CORPORATION
+from __future__ import annotations
 
 from enum import Enum
 from functools import cached_property
-from typing import Tuple, TypeVar
+from typing import TypeVar
 
 import cupy as cp
 import pyarrow as pa
@@ -41,9 +42,8 @@ class GeoColumn(ColumnBase):
 
     def __init__(
         self,
-        data: Tuple,
+        data: tuple[cudf.Series, cudf.Series, cudf.Series, cudf.Series],
         meta: GeoMeta = None,
-        shuffle_order: cudf.Index = None,
     ):
         if (
             isinstance(data[0], cudf.Series)
@@ -61,7 +61,7 @@ class GeoColumn(ColumnBase):
             self.polygons = data[3]
             self.polygons.name = "polygons"
         else:
-            raise TypeError("All four Tuple arguments must be cudf.ListSeries")
+            raise TypeError("All four Tuple arguments must be cudf.Series")
         super().__init__(None, size=len(self), dtype="geometry")
 
     def to_arrow(self):

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -134,7 +134,6 @@ class GeoDataFrame(cudf.DataFrame):
                         other_col.polygons,
                     ),
                     other_col._meta,
-                    cudf.Index(col),
                 )
                 type_copied._data.set_by_label(name, col, validate=False)
 


### PR DESCRIPTION
## Description
With https://github.com/rapidsai/cudf/pull/16549, `cudf.Index` no longer accepts `Column` objects.

The only usage I found was that `GeoColumn` accepted `shuffle_order=cudf.Index(column)`, but `shuffle_order` appears unused (anymore?) in `GeoColumn`, so I went ahead and removed this from the constructor


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
