### PR TITLE
fix wheel tests on Rocky Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ There are two ways to fix this:
     sudo -y add-apt-repository ppa:ubuntugis/ppa
     sudo apt install libgdal-dev
     ```
+  * Rocky Linux users can install a newer GDAL as follows
+    ```shell
+    yum update -y
+    yum config-manager --set-enabled powertools
+    yum update -y
+    yum install -y gdal-devel
+    ```
 2. Pin fiona's version to a range that's compatible with your version of `libgdal-dev`
   * For Ubuntu20.04 ([GDAL v3.0.4](https://packages.ubuntu.com/focal/libgdal-dev)):
     ```shell

--- a/ci/test_wheel_cuproj.sh
+++ b/ci/test_wheel_cuproj.sh
@@ -7,8 +7,16 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # install build dependencies for fiona
-apt update
-DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libgdal-dev
+if type -f yum > /dev/null 2>&1; then
+  yum update -y
+  # some of gdal-devel's dependencies, like 'libdap', come from the powertools repo
+  yum config-manager --set-enabled powertools
+  yum update -y
+  yum install -y gdal-devel
+else
+  apt update
+  DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libgdal-dev
+fi
 
 # Download the cuproj and cuspatial built in the previous step
 RAPIDS_PY_WHEEL_NAME="cuproj_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist

--- a/ci/test_wheel_cuspatial.sh
+++ b/ci/test_wheel_cuspatial.sh
@@ -7,8 +7,16 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # install build dependencies for fiona
-apt update
-DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libgdal-dev
+if type -f yum > /dev/null 2>&1; then
+  yum update -y
+  # some of gdal-devel's dependencies, like 'libdap', come from the powertools repo
+  yum config-manager --set-enabled powertools
+  yum update -y
+  yum install -y gdal-devel
+else
+  apt update
+  DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libgdal-dev
+fi
 
 # Download the cuspatial built in the previous step
 RAPIDS_PY_WHEEL_NAME="cuspatial_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist


### PR DESCRIPTION
## Description

RAPIDS libraries recently started running nightly wheel tests on Rocky Linux 8: https://github.com/rapidsai/shared-workflows/pull/236/files#r1725947245

That distribution's system package manager is `yum`, not `apt`, and as a result `cuspatial`'s nightly runs are failing like this:

```text
ci/test_wheel_cuspatial.sh: line 10: apt: command not found
Error: Process completed with exit code 127.
```

([build link](https://github.com/rapidsai/cuspatial/actions/runs/10678284262/job/29595047179))

This fixes that.

## Notes for Reviewers

### How I tested this

```shell
docker run \
    --rm \
    --gpus 1 \
    -v $(pwd):/opt/work \
    -w /opt/work \
    -it rapidsai/citestwheel:cuda12.5.1-rockylinux8-py3.11 \
    bash

yum update -y
yum config-manager --set-enabled powertools
yum update -y
yum install -y gdal-devel

python -m pip install \
    --no-binary fiona \
    'cuproj-cu12[test]==24.10.*,>=0.0.0a0' \
    'cuspatial-cu12[test]==24.10.*,>=0.0.0a0' \
    'fiona>=1.8.19,<1.9'

pushd python/cuproj/cuproj
python -m pytest \
  --cache-clear \
  --numprocesses=8 \
  --dist=worksteal \
  tests
popd

pushd python/cuspatial/cuspatial
python -m pytest \
  --cache-clear \
  --numprocesses=8 \
  --dist=worksteal \
  tests
popd
```

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.