### PR TITLE
re-enable mixing libcuspatial wheels with libcudf conda packages

### DIFF
--- a/python/libcuspatial/libcuspatial/load.py
+++ b/python/libcuspatial/libcuspatial/load.py
@@ -16,13 +16,22 @@
 import ctypes
 import os
 
-import libcudf
-
 
 def load_library():
-    # libcudf must be loaded before libcuspatial because libcuspatial
-    # references its symbols
-    libcudf.load_library()
+    try:
+        # libcudf must be loaded before libcuspatial because libcuspatial
+        # references its symbols
+        import libcudf
+        libcudf.load_library()
+    except ModuleNotFoundError:
+        # 'libcuspatial' has a runtime dependency on 'libcudf'. However, 
+        # that dependency might be satisfied by the 'libcudf' conda package
+        # (which does not have any Python modules), instead of the
+        # 'libcudf' wheel.
+        #
+        # In that situation, assume that 'libcudf.so' is in a place where
+        # the loader can find it.
+        pass
 
     # Dynamically load libcuspatial.so. Prefer a system library if one is
     # present to avoid clobbering symbols that other packages might expect,

--- a/python/libcuspatial/libcuspatial/load.py
+++ b/python/libcuspatial/libcuspatial/load.py
@@ -24,7 +24,7 @@ def load_library():
         import libcudf
         libcudf.load_library()
     except ModuleNotFoundError:
-        # 'libcuspatial' has a runtime dependency on 'libcudf'. However, 
+        # 'libcuspatial' has a runtime dependency on 'libcudf'. However,
         # that dependency might be satisfied by the 'libcudf' conda package
         # (which does not have any Python modules), instead of the
         # 'libcudf' wheel.


### PR DESCRIPTION
## Description

Fixes #1455

devcontainer conda CI jobs are failing in this project because of the following mix of characteristics for thoes jobs:

* all build and runtime dependencies for `libcuspatial`, `cuspatial`, `cuproj` are installed via conda
* `libcuspatial`, `cuspatial`, and `cuproj` wheels are then built with `pip install -e --no-deps --no-build-isolation`
* `import libcuspatial` results in unconditionally running `import libcudf`
* `libcudf` is provided by the `libcudf` **conda** package, which does not have any Python modules, so that import fails

This fixes that, and restores the ability to mix a `pip install`'d `cuspatial` / `cuproj` with a `conda`-installed `libcudf`.

## Notes for Reviewers

### How did CI not catch this before?

When https://github.com/rapidsai/devcontainers/pull/387 was merged, I only re-ran the **pip** devcontainers CI job on #1450.

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
