### PR TITLE
xfail Python tests dependent on invalid Polygons

### DIFF
--- a/python/cuspatial/cuspatial/tests/conftest.py
+++ b/python/cuspatial/cuspatial/tests/conftest.py
@@ -29,6 +29,8 @@ def gs():
     g8 = Polygon(
         ((35, 36), (37, 38), (39, 40), (41, 42)),
     )
+    # TODO: g9, g10, g11 are invalid
+    # https://github.com/libgeos/geos/issues/1177
     g9 = MultiPolygon(
         [
             (

--- a/python/cuspatial/cuspatial/tests/test_cudf_integration.py
+++ b/python/cuspatial/cuspatial/tests/test_cudf_integration.py
@@ -1,11 +1,18 @@
-# Copyright (c) 2022 NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
 
 import cuspatial
 
+reason = (
+    "gs fixture contains invalid Polygons/MultiPolygons: "
+    "https://github.com/libgeos/geos/issues/1177"
+)
 
+
+@pytest.mark.xfail(reason=reason)
 def test_sort_index_series(gs):
     gs.index = np.random.permutation(len(gs))
     cugs = cuspatial.from_geopandas(gs)
@@ -14,6 +21,7 @@ def test_sort_index_series(gs):
     gpd.testing.assert_geoseries_equal(got, expected)
 
 
+@pytest.mark.xfail(reason=reason)
 def test_sort_index_dataframe(gpdf):
     gpdf.index = np.random.permutation(len(gpdf))
     cugpdf = cuspatial.from_geopandas(gpdf)
@@ -22,6 +30,7 @@ def test_sort_index_dataframe(gpdf):
     gpd.testing.assert_geodataframe_equal(got, expected)
 
 
+@pytest.mark.xfail(reason=reason)
 def test_sort_values(gpdf):
     cugpdf = cuspatial.from_geopandas(gpdf)
     expected = gpdf.sort_values("random")

--- a/python/cuspatial/cuspatial/tests/test_geodataframe.py
+++ b/python/cuspatial/cuspatial/tests/test_geodataframe.py
@@ -464,7 +464,13 @@ def test_cudf_dataframe_init():
     assert_eq_geo_df(gdf.to_pandas(), gpd.GeoDataFrame(df.to_pandas()))
 
 
-def test_apply_boolean_mask(gpdf, mask_factory):
+def test_apply_boolean_mask(gpdf, mask_factory, request):
+    if "MaskNone" not in request.node.callspec.id:
+        reason = (
+            "gs fixture contains invalid Polygons/MultiPolygons: "
+            "https://github.com/libgeos/geos/issues/1177"
+        )
+        request.applymarker(pytest.mark.xfail(reason=reason))
     mask = mask_factory(len(gpdf))
 
     expected = gpdf[mask]


### PR DESCRIPTION
## Description
Appears the `gs` fixture in the `conftest.py` contains invalid polygon (the holes are beyond shell), and geos 3.13 now does not consider the same invalid polygon equivalent https://github.com/libgeos/geos/issues/1177.

The `gs` fixture and the `polys` fixture (which is hard-coded) need to both be updated, but I wasn't able to get a quick-working fix (I'm not familiar with this area). This PR just xfails the effected tests.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
