### PR TITLE
remove unused variables in build_docs script

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -21,6 +21,8 @@ conda activate docs
 
 rapids-print-env
 
+export RAPIDS_VERSION="$(rapids-version)"
+export RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-logger "Build cuSpatial CPP docs"

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -21,7 +21,6 @@ conda activate docs
 
 rapids-print-env
 
-export RAPIDS_VERSION_NUMBER="24.12"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
 rapids-logger "Build cuSpatial CPP docs"
@@ -52,4 +51,4 @@ mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/html"
 mv _html/* "${RAPIDS_DOCS_DIR}/cuproj/html"
 popd
 
-rapids-upload-docs
+RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)" rapids-upload-docs

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -53,4 +53,4 @@ mkdir -p "${RAPIDS_DOCS_DIR}/cuproj/html"
 mv _html/* "${RAPIDS_DOCS_DIR}/cuproj/html"
 popd
 
-RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)" rapids-upload-docs
+RAPIDS_VERSION_NUMBER="${RAPIDS_VERSION_MAJOR_MINOR}" rapids-upload-docs

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -21,8 +21,6 @@ conda activate docs
 
 rapids-print-env
 
-export RAPIDS_VERSION="$(rapids-version)"
-export RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
 export RAPIDS_VERSION_NUMBER="24.12"
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -40,7 +40,6 @@ echo "${NEXT_FULL_TAG}" > VERSION
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
 
 DEPENDENCIES=(
   pylibcudf


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/106

This project doesn't need any of the changes that are being made as part of that issue across most other repos... it's already doing all of its `pip` and `conda` installs in CI in single installs (which is strict and safe) 🎉 

This small PR just makes its handling of environment variables in `ci/build_docs.sh` consistent with other RAPIDS repos, in the interest of keeping those scripts looking similar so it's easy to apply changes across all RAPIDS projects. ref: https://github.com/rapidsai/cudf/pull/17013#discussion_r1792163289

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
