### PR TITLE
reduce verbosity in wheel builds

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -35,7 +35,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 cd "${package_dir}"
 
-python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
+python -m pip wheel . -w dist -v --no-deps --disable-pip-version-check
 
 mkdir -p final_dist
 python -m auditwheel repair \


### PR DESCRIPTION
## Description

Similar to https://github.com/rapidsai/cugraph/pull/4651 ... proposes switching wheels builds from `pip wheel -vvv`. to `pip wheel -v`, to make the logs a bit easier to read, to reduce the effort required to debug failing wheel build jobs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
