### PR TITLE
WIP: fix library-loading issues in editable installs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,4 +169,5 @@ jobs:
       build_command: |
         sccache -z;
         build-all -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON --verbose;
+        python -c "import cuspatial; print(cuspatial.__version__)";
         sccache -s;

--- a/python/libcuspatial/libcuspatial/load.py
+++ b/python/libcuspatial/libcuspatial/load.py
@@ -81,11 +81,17 @@ def load_library():
         # Prefer the libraries bundled in this package. If they aren't found
         # (which might be the case in builds where the library was prebuilt
         # before packaging the wheel), look for a system installation.
-        libcuspatial_lib = _load_wheel_installation(soname)
-        if libcuspatial_lib is None:
-            libcuspatial_lib = _load_system_installation(soname)
+        try:
+            libcuspatial_lib = _load_wheel_installation(soname)
+            if libcuspatial_lib is None:
+                libcuspatial_lib = _load_system_installation(soname)
+        except OSError:
+            # If none of the searches above succeed, just silently return None
+            # and rely on other mechanisms (like RPATHs on other DSOs) to
+            # help the loader find the library.
+            pass
 
     # The caller almost never needs to do anything with this library, but no
     # harm in offering the option since this object at least provides a handle
-    # to inspect where the libcuspatial was loaded from.
+    # to inspect where libcuspatial was loaded from.
     return libcuspatial_lib


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/118

The pattern introduced in #1483 breaks editable installs in devcontainers. In that type of build, `libcuspatial.so` is built outside of the wheel but **not installed**, so it can't be found by `ld`. Extension modules in `cuspatial` are able to find it via RPATHs instead.

This proposes:

* try-catching the entire library-loading attempt, to silently do nothing in cases like that
* adding an import of the `cuspatial` Python library in the `devcontainers` CI job, as a smoke test to catch issues like this in the future

## Notes for Reviewers

### How I tested this

Tested this approach on https://github.com/rapidsai/kvikio/pull/553

### Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
