### PR TITLE
Restore removed `--expt-relaxed-constexpr`

### DIFF
--- a/cpp/cmake/Modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/Modules/ConfigureCUDA.cmake
@@ -22,7 +22,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-list(APPEND CUSPATIAL_CUDA_FLAGS --expt-extended-lambda)
+list(APPEND CUSPATIAL_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 
 # set warnings as errors
 if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2.0)


### PR DESCRIPTION
## Description
Fixes #1501.

Restores removed `--expt-relaxed-constexpr` for libcuspatial

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
