### PR TITLE
Fix libcuproj doc example and make tests consistent.

### DIFF
--- a/cpp/cuproj/README.md
+++ b/cpp/cuproj/README.md
@@ -46,20 +46,15 @@ The C++ API also supports transforming coordinate in CUDA device code. Create a
 be passed to a kernel launch. Here's an example kernel.
 
 ```cpp
-template <typename T>
-using coordinate = typename cuproj::vec_2d<T>;
+using device_projection = cuproj::device_projection<cuproj::vec_2d<float>>;
 
-template <typename T>
-using device_projection = cuproj::device_projection<coordinate<T>>;
-
-__global__ 
-void example_kernel(device_projection const d_proj,
-                    cuproj::vec_2d<float> const* in,
-                    cuproj::vec_2d<float>* out,
-                    size_t n)
+__global__ void example_kernel(device_projection const d_proj,
+                               cuproj::vec_2d<float> const* in,
+                               cuproj::vec_2d<float>* out,
+                               size_t n)
 {
   for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; 
-       i < n; 
+       i < n;
        i += gridDim.x * blockDim.x) {
     out[i] = d_proj.transform(in[i]);
   }

--- a/cpp/cuproj/doxygen/main_page.md
+++ b/cpp/cuproj/doxygen/main_page.md
@@ -13,26 +13,10 @@ transformations are supported:
 
 - WGS84 to/from UTM
 
-## Example
-
-The C++ API is designed to be easy to use. The following example shows how to transform a point in
-Sydney, Australia from WGS84 (lat, lon) coordinates to UTM zone 56S (x, y) coordinates.
-
-```cpp
-#include <cuproj/projection_factories.cuh>
-#include <cuproj/vec_2d.hpp>
-
-// Make a projection to convert WGS84 (lat, lon) coordinates to UTM zone 56S (x, y) coordinates
-auto proj = cuproj::make_projection<cuproj::vec_2d<T>>("EPSG:4326", "EPSG:32756");
-
-cuproj::vec_2d<T> sydney{-33.858700, 151.214000};  // Sydney, NSW, Australia
-thrust::device_vector<cuproj::vec_2d<T>> d_in{1, sydney};
-thrust::device_vector<cuproj::vec_2d<T>> d_out(d_in.size());
-
-// Convert the coordinates. Works the same with a vector of many coordinates.
-proj.transform(d_in.begin(), d_in.end(), d_out.begin(), cuproj::direction::FORWARD);
-```
+There are some basic examples of using the libcuproj C++ API in the 
+[cuProj README](https://github.com/rapidsai/cuspatial/cpp/cuproj/README.md).
 
 ## Useful Links
 
  - [RAPIDS Home Page](https://rapids.ai)
+ - [cuSpatial Github](https://github.com/rapidsai/cuspatial)

--- a/cpp/cuproj/tests/wgs_to_utm_test.cu
+++ b/cpp/cuproj/tests/wgs_to_utm_test.cu
@@ -324,7 +324,9 @@ TYPED_TEST(ProjectionTest, readme_example)
   proj->transform(d_in.begin(), d_in.end(), d_out.begin(), cuproj::direction::FORWARD);
 }
 
-__global__ void example_kernel(cuproj::device_projection<cuproj::vec_2d<float>> const d_proj,
+using device_projection = cuproj::device_projection<cuproj::vec_2d<float>>;
+
+__global__ void example_kernel(device_projection const d_proj,
                                cuproj::vec_2d<float> const* in,
                                cuproj::vec_2d<float>* out,
                                size_t n)


### PR DESCRIPTION
## Description
This fixes libcuproj documentation example inconsistencies raised in #1500.

It removes the (outdated) example from the doxygen `main_page` and replaces it with a link to the readme.

It also makes the type definitions simpler in the README example and makes the Test code match the example.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
