### PR TITLE
remove versioneer and setup.cfg references in docs, update rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
             - id: verify-copyright
             - id: verify-alpha-spec
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.16.0
+        rev: v1.17.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,18 +13,18 @@ files:
       - develop
       - docs
       - py_version
-      - depends_on_rmm
       - depends_on_cudf
       - depends_on_cuml
       - depends_on_cupy
       - depends_on_libcudf
       - depends_on_librmm
+      - depends_on_rmm
+      - notebooks
       - rapids_build_skbuild
       - run_python_cuspatial
       - test_notebooks
-      - test_python_cuspatial
       - test_python_cuproj
-      - notebooks
+      - test_python_cuspatial
   test_cpp:
     output: none
     includes:
@@ -38,8 +38,8 @@ files:
       - depends_on_cuproj
       - depends_on_cuspatial
       - py_version
-      - test_python_cuspatial
       - test_python_cuproj
+      - test_python_cuspatial
   test_notebooks:
     output: none
     includes:
@@ -47,9 +47,9 @@ files:
       - depends_on_cuml
       - depends_on_cuproj
       - depends_on_cuspatial
-      - test_notebooks
       - notebooks
       - py_version
+      - test_notebooks
   checks:
     output: none
     includes:
@@ -59,8 +59,8 @@ files:
     output: none
     includes:
       - cuda_version
-      - depends_on_cuspatial
       - depends_on_cuproj
+      - depends_on_cuspatial
       - docs
       - py_version
   py_build_libcuspatial:
@@ -102,11 +102,11 @@ files:
       table: tool.rapids-build-backend
       key: requires
     includes:
-      - depends_on_rmm
-      - depends_on_cudf
       - build_cpp
       - build_python
       - build_wheels
+      - depends_on_rmm
+      - depends_on_cudf
       - depends_on_libcudf
       - depends_on_libcuspatial
       - depends_on_librmm
@@ -161,8 +161,8 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
-      - test_python_cuproj
       - depends_on_cuspatial
+      - test_python_cuproj
 
 channels:
   - rapidsai
@@ -279,7 +279,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &rapids_build_backend rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.3.0,<0.4.0.dev0
       - output_types: conda
         packages:
           - scikit-build-core>=0.10.0

--- a/docs/source/developer_guide/contributing_guide.md
+++ b/docs/source/developer_guide/contributing_guide.md
@@ -72,15 +72,11 @@ Specifically, cuSpatial uses the following tools:
 - [`isort`](https://pycqa.github.io/isort/) ensures imports are sorted consistently.
 
 Linter config data is stored in a number of files. cuSpatial generally uses `pyproject.toml` over
-`setup.cfg` and avoids project-specific files (e.g. `setup.cfg` > `python/cudf/setup.cfg`). However,
-differences between tools and the different packages in the repo result in the following caveats:
+`setup.cfg` and prefers root-level files to project-specific files.
+However, differences between tools and the different packages in the repo result in the following caveats:
 
-- `flake8` has no plans to support `pyproject.toml`, so it must live in `setup.cfg`.
+- `flake8` has no plans to support `pyproject.toml`, so it must live in `.flake8`.
 - `isort` must be configured per project to set which project is the "first party" project.
-
-Additionally, cuSpatial's use of `versioneer` means that each project must have a `setup.cfg`.
-As a result, cuSpatial currently maintains both root and project-level `pyproject.toml` and
-`setup.cfg` files.
 
 ## Writing tests
 

--- a/docs/source/developer_guide/contributing_guide.md
+++ b/docs/source/developer_guide/contributing_guide.md
@@ -71,8 +71,8 @@ Specifically, cuSpatial uses the following tools:
 - [`black`](https://github.com/psf/black) is an automatic code formatter.
 - [`isort`](https://pycqa.github.io/isort/) ensures imports are sorted consistently.
 
-Linter config data is stored in a number of files. cuSpatial generally uses `pyproject.toml` over
-`setup.cfg` and prefers root-level files to project-specific files.
+Linter config data is stored in a number of files. cuSpatial generally uses `pyproject.toml` and
+prefers root-level files to project-specific files.
 However, differences between tools and the different packages in the repo result in the following caveats:
 
 - `flake8` has no plans to support `pyproject.toml`, so it must live in `.flake8`.


### PR DESCRIPTION
## Description

Removes references to `setup.cfg` and `versioneer` in the contributing docs... `cuspatial` no longer uses either of these.

Also updates `rapids-dependency-file-generator` to its latest version (v1.17.0) and removes an unused YAML anchor in `dependencies.yaml`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
