### PR TITLE
Have Cython methods accept pylibcudf.Column instead of cudf._lib.column.Column

### DIFF
--- a/python/cuspatial/cuspatial/_lib/intersection.pyx
+++ b/python/cuspatial/cuspatial/_lib/intersection.pyx
@@ -1,9 +1,10 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport make_shared, shared_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 
 from cuspatial._lib.types import CollectionType, GeometryType
 
@@ -21,7 +22,7 @@ from cuspatial._lib.types cimport (
 )
 
 
-def pairwise_linestring_intersection(Column lhs, Column rhs):
+def pairwise_linestring_intersection(plc_Column lhs, plc_Column rhs):
     """
     Compute the intersection of two (multi)linestrings.
     """
@@ -51,22 +52,34 @@ def pairwise_linestring_intersection(Column lhs, Column rhs):
             c_lhs.get()[0], c_rhs.get()[0]
         ))
 
-    geometry_collection_offset = Column.from_unique_ptr(
-        move(c_result.geometry_collection_offset)
+    geometry_collection_offset = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.geometry_collection_offset))
     )
 
-    types_buffer = Column.from_unique_ptr(move(c_result.types_buffer))
-    offset_buffer = Column.from_unique_ptr(move(c_result.offset_buffer))
-    points = Column.from_unique_ptr(move(c_result.points))
-    segments = Column.from_unique_ptr(move(c_result.segments))
-    lhs_linestring_id = Column.from_unique_ptr(
-        move(c_result.lhs_linestring_id)
+    types_buffer = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.types_buffer))
     )
-    lhs_segment_id = Column.from_unique_ptr(move(c_result.lhs_segment_id))
-    rhs_linestring_id = Column.from_unique_ptr(
-        move(c_result.rhs_linestring_id)
+    offset_buffer = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.offset_buffer))
     )
-    rhs_segment_id = Column.from_unique_ptr(move(c_result.rhs_segment_id))
+    points = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.points))
+    )
+    segments = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.segments))
+    )
+    lhs_linestring_id = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.lhs_linestring_id))
+    )
+    lhs_segment_id = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.lhs_segment_id))
+    )
+    rhs_linestring_id = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.rhs_linestring_id))
+    )
+    rhs_segment_id = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.rhs_segment_id))
+    )
 
     # Map linestring type codes from libcuspatial to cuspatial
     types_buffer[types_buffer == GeometryType.LINESTRING.value] = (

--- a/python/cuspatial/cuspatial/_lib/linestring_bounding_boxes.pyx
+++ b/python/cuspatial/cuspatial/_lib/linestring_bounding_boxes.pyx
@@ -1,10 +1,10 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
 
@@ -13,8 +13,8 @@ from cuspatial._lib.cpp.linestring_bounding_boxes cimport (
 )
 
 
-cpdef linestring_bounding_boxes(Column poly_offsets,
-                                Column x, Column y,
+cpdef linestring_bounding_boxes(plc_Column poly_offsets,
+                                plc_Column x, plc_Column y,
                                 double R):
     cdef column_view c_poly_offsets = poly_offsets.view()
     cdef column_view c_x = x.view()

--- a/python/cuspatial/cuspatial/_lib/nearest_points.pyx
+++ b/python/cuspatial/cuspatial/_lib/nearest_points.pyx
@@ -1,8 +1,9 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from cuspatial._lib.cpp.nearest_points cimport (
@@ -14,9 +15,9 @@ from cuspatial._lib.utils cimport unwrap_pyoptcol
 
 
 def pairwise_point_linestring_nearest_points(
-    Column points_xy,
-    Column linestring_part_offsets,
-    Column linestring_points_xy,
+    plc_Column points_xy,
+    plc_Column linestring_part_offsets,
+    plc_Column linestring_points_xy,
     multipoint_geometry_offset=None,
     multilinestring_geometry_offset=None,
 ):
@@ -41,17 +42,22 @@ def pairwise_point_linestring_nearest_points(
 
     multipoint_geometry_id = None
     if multipoint_geometry_offset is not None:
-        multipoint_geometry_id = Column.from_unique_ptr(
-            move(c_result.nearest_point_geometry_id.value()))
+        multipoint_geometry_id = Column.from_pylibcudf(plc_Column.from_libcudf(
+            move(c_result.nearest_point_geometry_id.value())))
 
     multilinestring_geometry_id = None
     if multilinestring_geometry_offset is not None:
-        multilinestring_geometry_id = Column.from_unique_ptr(
-            move(c_result.nearest_linestring_geometry_id.value()))
+        multilinestring_geometry_id = Column.from_pylibcudf(
+            plc_Column.from_libcudf(
+                move(c_result.nearest_linestring_geometry_id.value())
+            )
+        )
 
-    segment_id = Column.from_unique_ptr(move(c_result.nearest_segment_id))
-    point_on_linestring_xy = Column.from_unique_ptr(
-        move(c_result.nearest_point_on_linestring_xy))
+    segment_id = Column.from_pylibcudf(
+        plc_Column.from_libcudf(move(c_result.nearest_segment_id))
+    )
+    point_on_linestring_xy = Column.from_pylibcudf(plc_Column.from_libcudf(
+        move(c_result.nearest_point_on_linestring_xy)))
 
     return (
         multipoint_geometry_id,

--- a/python/cuspatial/cuspatial/_lib/pairwise_multipoint_equals_count.pyx
+++ b/python/cuspatial/cuspatial/_lib/pairwise_multipoint_equals_count.pyx
@@ -1,9 +1,10 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport make_shared, shared_ptr, unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column cimport column
 
 from cuspatial._lib.cpp.column.geometry_column_view cimport (
@@ -16,8 +17,8 @@ from cuspatial._lib.cpp.types cimport collection_type_id, geometry_type_id
 
 
 def pairwise_multipoint_equals_count(
-    Column _lhs,
-    Column _rhs,
+    plc_Column _lhs,
+    plc_Column _rhs,
 ):
     cdef shared_ptr[geometry_column_view] lhs = \
         make_shared[geometry_column_view](
@@ -41,4 +42,4 @@ def pairwise_multipoint_equals_count(
             )
         )
 
-    return Column.from_unique_ptr(move(result))
+    return Column.from_pylibcudf(plc_Column.from_libcudf(move(result)))

--- a/python/cuspatial/cuspatial/_lib/pairwise_point_in_polygon.pyx
+++ b/python/cuspatial/cuspatial/_lib/pairwise_point_in_polygon.pyx
@@ -1,9 +1,10 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
@@ -13,12 +14,12 @@ from cuspatial._lib.cpp.pairwise_point_in_polygon cimport (
 
 
 def pairwise_point_in_polygon(
-    Column test_points_x,
-    Column test_points_y,
-    Column poly_offsets,
-    Column poly_ring_offsets,
-    Column poly_points_x,
-    Column poly_points_y
+    plc_Column test_points_x,
+    plc_Column test_points_y,
+    plc_Column poly_offsets,
+    plc_Column poly_ring_offsets,
+    plc_Column poly_points_x,
+    plc_Column poly_points_y
 ):
     cdef column_view c_test_points_x = test_points_x.view()
     cdef column_view c_test_points_y = test_points_y.view()
@@ -41,4 +42,4 @@ def pairwise_point_in_polygon(
             )
         )
 
-    return Column.from_unique_ptr(move(result))
+    return Column.from_pylibcudf(plc_Column.from_libcudf(move(result)))

--- a/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
+++ b/python/cuspatial/cuspatial/_lib/point_in_polygon.pyx
@@ -1,9 +1,10 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
@@ -13,12 +14,12 @@ from cuspatial._lib.cpp.point_in_polygon cimport (
 
 
 def point_in_polygon(
-    Column test_points_x,
-    Column test_points_y,
-    Column poly_offsets,
-    Column poly_ring_offsets,
-    Column poly_points_x,
-    Column poly_points_y
+    plc_Column test_points_x,
+    plc_Column test_points_y,
+    plc_Column poly_offsets,
+    plc_Column poly_ring_offsets,
+    plc_Column poly_points_x,
+    plc_Column poly_points_y
 ):
     cdef column_view c_test_points_x = test_points_x.view()
     cdef column_view c_test_points_y = test_points_y.view()
@@ -41,4 +42,4 @@ def point_in_polygon(
             )
         )
 
-    return Column.from_unique_ptr(move(result))
+    return Column.from_pylibcudf(plc_Column.from_libcudf(move(result)))

--- a/python/cuspatial/cuspatial/_lib/points_in_range.pyx
+++ b/python/cuspatial/cuspatial/_lib/points_in_range.pyx
@@ -1,10 +1,10 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
 
@@ -18,8 +18,8 @@ cpdef points_in_range(
     double range_max_x,
     double range_min_y,
     double range_max_y,
-    Column x,
-    Column y
+    plc_Column x,
+    plc_Column y
 ):
     cdef column_view x_v = x.view()
     cdef column_view y_v = y.view()

--- a/python/cuspatial/cuspatial/_lib/polygon_bounding_boxes.pyx
+++ b/python/cuspatial/cuspatial/_lib/polygon_bounding_boxes.pyx
@@ -1,10 +1,10 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
 
@@ -13,9 +13,9 @@ from cuspatial._lib.cpp.polygon_bounding_boxes cimport (
 )
 
 
-cpdef polygon_bounding_boxes(Column poly_offsets,
-                             Column ring_offsets,
-                             Column x, Column y):
+cpdef polygon_bounding_boxes(plc_Column poly_offsets,
+                             plc_Column ring_offsets,
+                             plc_Column x, plc_Column y):
     cdef column_view c_poly_offsets = poly_offsets.view()
     cdef column_view c_ring_offsets = ring_offsets.view()
     cdef column_view c_x = x.view()

--- a/python/cuspatial/cuspatial/_lib/quadtree.pyx
+++ b/python/cuspatial/cuspatial/_lib/quadtree.pyx
@@ -1,12 +1,12 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libc.stdint cimport int8_t
 from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
@@ -17,7 +17,7 @@ from cuspatial._lib.cpp.quadtree cimport (
 )
 
 
-cpdef quadtree_on_points(Column x, Column y,
+cpdef quadtree_on_points(plc_Column x, plc_Column y,
                          double x_min, double x_max,
                          double y_min, double y_max,
                          double scale,
@@ -39,7 +39,7 @@ cpdef quadtree_on_points(Column x, Column y,
         "offset"
     ]
     return (
-        Column.from_unique_ptr(move(result.first)),
+        Column.from_pylibcudf(plc_Column.from_libcudf(move(result.first))),
         (
             {
                 name: Column.from_pylibcudf(col)

--- a/python/cuspatial/cuspatial/_lib/spatial.pyx
+++ b/python/cuspatial/cuspatial/_lib/spatial.pyx
@@ -1,10 +1,11 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
@@ -16,8 +17,8 @@ from cuspatial._lib.cpp.projection cimport (
 def sinusoidal_projection(
     double origin_lon,
     double origin_lat,
-    Column input_lon,
-    Column input_lat
+    plc_Column input_lon,
+    plc_Column input_lat
 ):
     cdef column_view c_input_lon = input_lon.view()
     cdef column_view c_input_lat = input_lat.view()
@@ -34,5 +35,7 @@ def sinusoidal_projection(
             )
         )
 
-    return (Column.from_unique_ptr(move(result.first)),
-            Column.from_unique_ptr(move(result.second)))
+    return (
+        Column.from_pylibcudf(plc_Column.from_libcudf(move(result.first))),
+        Column.from_pylibcudf(plc_Column.from_libcudf(move(result.second)))
+    )

--- a/python/cuspatial/cuspatial/_lib/spatial_join.pyx
+++ b/python/cuspatial/cuspatial/_lib/spatial_join.pyx
@@ -1,11 +1,11 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from libc.stdint cimport int8_t
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table, table_view
 
@@ -53,13 +53,13 @@ cpdef join_quadtree_and_bounding_boxes(object quadtree,
 
 cpdef quadtree_point_in_polygon(object poly_quad_pairs,
                                 object quadtree,
-                                Column point_indices,
-                                Column points_x,
-                                Column points_y,
-                                Column poly_offsets,
-                                Column ring_offsets,
-                                Column poly_points_x,
-                                Column poly_points_y):
+                                plc_Column point_indices,
+                                plc_Column points_x,
+                                plc_Column points_y,
+                                plc_Column poly_offsets,
+                                plc_Column ring_offsets,
+                                plc_Column poly_points_x,
+                                plc_Column poly_points_y):
     cdef plc_Table plc_poly_quad_pairs = plc_Table(
         [col.to_pylibcudf(mode="read") for col in poly_quad_pairs._columns]
     )
@@ -102,12 +102,12 @@ cpdef quadtree_point_in_polygon(object poly_quad_pairs,
 
 cpdef quadtree_point_to_nearest_linestring(object linestring_quad_pairs,
                                            object quadtree,
-                                           Column point_indices,
-                                           Column points_x,
-                                           Column points_y,
-                                           Column linestring_offsets,
-                                           Column linestring_points_x,
-                                           Column linestring_points_y):
+                                           plc_Column point_indices,
+                                           plc_Column points_x,
+                                           plc_Column points_y,
+                                           plc_Column linestring_offsets,
+                                           plc_Column linestring_points_x,
+                                           plc_Column linestring_points_y):
     cdef plc_Table plc_quad_pairs = plc_Table(
         [
             col.to_pylibcudf(mode="read")

--- a/python/cuspatial/cuspatial/_lib/trajectory.pyx
+++ b/python/cuspatial/cuspatial/_lib/trajectory.pyx
@@ -1,11 +1,11 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
 from libcpp.utility cimport move
 
-from cudf._lib.column cimport Column
-from pylibcudf cimport Table as plc_Table
+from cudf.core.column.column import Column
+from pylibcudf cimport Column as plc_Column, Table as plc_Table
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
@@ -18,8 +18,8 @@ from cuspatial._lib.cpp.trajectory cimport (
 )
 
 
-cpdef derive_trajectories(Column object_id, Column x,
-                          Column y, Column timestamp):
+cpdef derive_trajectories(plc_Column object_id, plc_Column x,
+                          plc_Column y, plc_Column timestamp):
     cdef column_view c_id = object_id.view()
     cdef column_view c_x = x.view()
     cdef column_view c_y = y.view()
@@ -37,11 +37,18 @@ cpdef derive_trajectories(Column object_id, Column x,
         },
         None
     )
-    return first_result, Column.from_unique_ptr(move(result.second))
+    return (
+        first_result,
+        Column.from_pylibcudf(plc_Column.from_libcudf(move(result.second)))
+    )
 
 
-cpdef trajectory_bounding_boxes(size_type num_trajectories,
-                                Column object_id, Column x, Column y):
+cpdef trajectory_bounding_boxes(
+    size_type num_trajectories,
+    plc_Column object_id,
+    plc_Column x,
+    plc_Column y,
+):
     cdef column_view c_id = object_id.view()
     cdef column_view c_x = x.view()
     cdef column_view c_y = y.view()
@@ -63,8 +70,8 @@ cpdef trajectory_bounding_boxes(size_type num_trajectories,
 
 
 cpdef trajectory_distances_and_speeds(size_type num_trajectories,
-                                      Column object_id, Column x,
-                                      Column y, Column timestamp):
+                                      plc_Column object_id, plc_Column x,
+                                      plc_Column y, plc_Column timestamp):
     cdef column_view c_id = object_id.view()
     cdef column_view c_x = x.view()
     cdef column_view c_y = y.view()

--- a/python/cuspatial/cuspatial/_lib/utils.pyx
+++ b/python/cuspatial/cuspatial/_lib/utils.pyx
@@ -1,5 +1,5 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
-from cudf._lib.column cimport Column
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+from pylibcudf cimport Column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from cuspatial._lib.cpp.optional cimport nullopt, optional

--- a/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
+++ b/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 
 import cudf
 from cudf.core.column import as_column
@@ -181,9 +181,17 @@ class DistanceDispatch:
             (self._lhs_type, self._rhs_type)
         ]
         if reverse:
-            dist = func(*collection_types, self._rhs_column, self._lhs_column)
+            dist = func(
+                *collection_types,
+                self._rhs_column.to_pylibcudf(mode="read"),
+                self._lhs_column.to_pylibcudf(mode="read"),
+            )
         else:
-            dist = func(*collection_types, self._lhs_column, self._rhs_column)
+            dist = func(
+                *collection_types,
+                self._lhs_column.to_pylibcudf(mode="read"),
+                self._rhs_column.to_pylibcudf(mode="read"),
+            )
 
         # Rows with misaligned indices contains nan. Here we scatter the
         # distance values to the correct indices.

--- a/python/cuspatial/cuspatial/core/binops/equals_count.py
+++ b/python/cuspatial/cuspatial/core/binops/equals_count.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 import cudf
 
@@ -72,8 +72,8 @@ def pairwise_multipoint_equals_count(lhs, rhs):
     if any(not contains_only_multipoints(s) for s in [lhs, rhs]):
         raise ValueError("Input GeoSeries must contain only multipoints.")
 
-    lhs_column = lhs._column.mpoints._column
-    rhs_column = rhs._column.mpoints._column
+    lhs_column = lhs._column.mpoints._column.to_pylibcudf(mode="read")
+    rhs_column = rhs._column.mpoints._column.to_pylibcudf(mode="read")
     result = c_pairwise_multipoint_equals_count(lhs_column, rhs_column)
 
     return cudf.Series._from_column(result)

--- a/python/cuspatial/cuspatial/core/binops/intersection.py
+++ b/python/cuspatial/cuspatial/core/binops/intersection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from typing import TYPE_CHECKING
 
@@ -72,7 +72,8 @@ def pairwise_linestring_intersection(
         raise ValueError("Input GeoSeries must contain only linestrings.")
 
     geoms, look_back_ids = c_pairwise_linestring_intersection(
-        linestrings1.lines.column(), linestrings2.lines.column()
+        linestrings1.lines.column().to_pylibcudf(mode="read"),
+        linestrings2.lines.column().to_pylibcudf(mode="read"),
     )
 
     (

--- a/python/cuspatial/cuspatial/core/binpreds/contains.py
+++ b/python/cuspatial/cuspatial/core/binpreds/contains.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from math import ceil, sqrt
 
@@ -97,12 +97,12 @@ def _brute_force_contains_properly(points, polygons):
         within its corresponding polygon.
     """
     pip_result = cpp_byte_point_in_polygon(
-        as_column(points.points.x),
-        as_column(points.points.y),
-        as_column(polygons.polygons.part_offset),
-        as_column(polygons.polygons.ring_offset),
-        as_column(polygons.polygons.x),
-        as_column(polygons.polygons.y),
+        as_column(points.points.x).to_pylibcudf(mode="read"),
+        as_column(points.points.y).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.part_offset).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.ring_offset).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.x).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.y).to_pylibcudf(mode="read"),
     )
     result = DataFrame(
         pip_bitmap_column_to_binary_array(
@@ -144,12 +144,12 @@ def _pairwise_contains_properly(points, polygons):
         within its corresponding polygon.
     """
     result_column = cpp_pairwise_point_in_polygon(
-        as_column(points.points.x),
-        as_column(points.points.y),
-        as_column(polygons.polygons.part_offset),
-        as_column(polygons.polygons.ring_offset),
-        as_column(polygons.polygons.x),
-        as_column(polygons.polygons.y),
+        as_column(points.points.x).to_pylibcudf(mode="read"),
+        as_column(points.points.y).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.part_offset).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.ring_offset).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.x).to_pylibcudf(mode="read"),
+        as_column(polygons.polygons.y).to_pylibcudf(mode="read"),
     )
     # Pairwise returns a boolean column with a True value for each (polygon,
     # point) pair where the point is contained properly by the polygon. We can

--- a/python/cuspatial/cuspatial/core/spatial/bounding.py
+++ b/python/cuspatial/cuspatial/core/spatial/bounding.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from cudf import DataFrame
 from cudf.core.column import as_column
@@ -67,10 +67,10 @@ def polygon_bounding_boxes(polygons: GeoSeries):
             zip(
                 column_names,
                 cpp_polygon_bounding_boxes(
-                    as_column(poly_offsets),
-                    as_column(ring_offsets),
-                    as_column(x),
-                    as_column(y),
+                    as_column(poly_offsets).to_pylibcudf(mode="read"),
+                    as_column(ring_offsets).to_pylibcudf(mode="read"),
+                    as_column(x).to_pylibcudf(mode="read"),
+                    as_column(y).to_pylibcudf(mode="read"),
                 ),
             )
         )
@@ -121,7 +121,10 @@ def linestring_bounding_boxes(linestrings: GeoSeries, expansion_radius: float):
     y = linestrings.lines.y
 
     results = cpp_linestring_bounding_boxes(
-        as_column(line_offsets), as_column(x), as_column(y), expansion_radius
+        as_column(line_offsets).to_pylibcudf(mode="read"),
+        as_column(x).to_pylibcudf(mode="read"),
+        as_column(y).to_pylibcudf(mode="read"),
+        expansion_radius,
     )
 
     return DataFrame._from_data(dict(zip(column_names, results)))

--- a/python/cuspatial/cuspatial/core/spatial/distance.py
+++ b/python/cuspatial/cuspatial/core/spatial/distance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 import cudf
 from cudf import DataFrame, Series
@@ -86,9 +86,11 @@ def directed_hausdorff_distance(multipoints: GeoSeries):
         raise ValueError("Input must be a series of multipoints.")
 
     result = cpp_directed_hausdorff_distance(
-        multipoints.multipoints.x._column,
-        multipoints.multipoints.y._column,
-        as_column(multipoints.multipoints.geometry_offset[:-1]),
+        multipoints.multipoints.x._column.to_pylibcudf(mode="read"),
+        multipoints.multipoints.y._column.to_pylibcudf(mode="read"),
+        as_column(multipoints.multipoints.geometry_offset[:-1]).to_pylibcudf(
+            mode="read"
+        ),
     )
 
     # the column label of each column in result should be its int position
@@ -151,7 +153,14 @@ def haversine_distance(p1: GeoSeries, p2: GeoSeries):
     p2_lat = p2.points.y._column
 
     return cudf.Series._from_data(
-        {"None": cpp_haversine_distance(p1_lon, p1_lat, p2_lon, p2_lat)}
+        {
+            "None": cpp_haversine_distance(
+                p1_lon.to_pylibcudf(mode="read"),
+                p1_lat.to_pylibcudf(mode="read"),
+                p2_lon.to_pylibcudf(mode="read"),
+                p2_lat.to_pylibcudf(mode="read"),
+            )
+        }
     )
 
 
@@ -221,8 +230,8 @@ def pairwise_point_distance(points1: GeoSeries, points2: GeoSeries):
         cpp_pairwise_point_distance(
             lhs_point_collection_type,
             rhs_point_collection_type,
-            lhs_column,
-            rhs_column,
+            lhs_column.to_pylibcudf(mode="read"),
+            rhs_column.to_pylibcudf(mode="read"),
         )
     )
 
@@ -293,8 +302,8 @@ def pairwise_linestring_distance(
 
     return Series._from_column(
         cpp_pairwise_linestring_distance(
-            multilinestrings1.lines.column(),
-            multilinestrings2.lines.column(),
+            multilinestrings1.lines.column().to_pylibcudf(mode="read"),
+            multilinestrings2.lines.column().to_pylibcudf(mode="read"),
         )
     )
 
@@ -413,8 +422,8 @@ def pairwise_point_linestring_distance(
         {
             None: c_pairwise_point_linestring_distance(
                 point_collection_type,
-                point_column,
-                linestrings.lines.column(),
+                point_column.to_pylibcudf(mode="read"),
+                linestrings.lines.column().to_pylibcudf(mode="read"),
             )
         }
     )
@@ -497,7 +506,9 @@ def pairwise_point_polygon_distance(points: GeoSeries, polygons: GeoSeries):
     return Series._from_data(
         {
             None: c_pairwise_point_polygon_distance(
-                point_collection_type, points_column, polygon_column
+                point_collection_type,
+                points_column.to_pylibcudf(mode="read"),
+                polygon_column.to_pylibcudf(mode="read"),
             )
         }
     )
@@ -576,8 +587,8 @@ def pairwise_linestring_polygon_distance(
     if not contains_only_polygons(polygons):
         raise ValueError("`polygon` array must contain only polygons")
 
-    linestrings_column = linestrings.lines.column()
-    polygon_column = polygons.polygons.column()
+    linestrings_column = linestrings.lines.column().to_pylibcudf(mode="read")
+    polygon_column = polygons.polygons.column().to_pylibcudf(mode="read")
 
     return Series._from_column(
         c_pairwise_line_poly_dist(linestrings_column, polygon_column)
@@ -649,8 +660,8 @@ def pairwise_polygon_distance(polygons1: GeoSeries, polygons2: GeoSeries):
     if not contains_only_polygons(polygons2):
         raise ValueError("`polygons2` array must contain only polygons")
 
-    polygon1_column = polygons1.polygons.column()
-    polygon2_column = polygons2.polygons.column()
+    polygon1_column = polygons1.polygons.column().to_pylibcudf(mode="read")
+    polygon2_column = polygons2.polygons.column().to_pylibcudf(mode="read")
 
     return Series._from_data(
         {None: c_pairwise_polygon_distance(polygon1_column, polygon2_column)}

--- a/python/cuspatial/cuspatial/core/spatial/filtering.py
+++ b/python/cuspatial/cuspatial/core/spatial/filtering.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from cudf import DataFrame
 from cudf.core.column import as_column
@@ -48,8 +48,8 @@ def points_in_spatial_window(points: GeoSeries, min_x, max_x, min_y, max_y):
     if not contains_only_points(points):
         raise ValueError("GeoSeries must contain only points.")
 
-    xs = as_column(points.points.x)
-    ys = as_column(points.points.y)
+    xs = as_column(points.points.x).to_pylibcudf(mode="read")
+    ys = as_column(points.points.y).to_pylibcudf(mode="read")
 
     res_xy = DataFrame._from_data(
         *points_in_range.points_in_range(min_x, max_x, min_y, max_y, xs, ys)

--- a/python/cuspatial/cuspatial/core/spatial/indexing.py
+++ b/python/cuspatial/cuspatial/core/spatial/indexing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 import warnings
 
@@ -159,8 +159,8 @@ def quadtree_on_points(
     if not len(points) == 0 and not contains_only_points(points):
         raise ValueError("GeoSeries must contain only points.")
 
-    xs = as_column(points.points.x)
-    ys = as_column(points.points.y)
+    xs = as_column(points.points.x).to_pylibcudf(mode="read")
+    ys = as_column(points.points.y).to_pylibcudf(mode="read")
 
     x_min, x_max, y_min, y_max = (
         min(x_min, x_max),

--- a/python/cuspatial/cuspatial/core/spatial/nearest_points.py
+++ b/python/cuspatial/cuspatial/core/spatial/nearest_points.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 import cudf
 from cudf.core.column import as_column
@@ -81,7 +81,9 @@ def pairwise_point_linestring_nearest_points(
     points_geometry_offset = (
         None
         if len(points.points.xy) > 0
-        else as_column(points.multipoints.geometry_offset)
+        else as_column(points.multipoints.geometry_offset).to_pylibcudf(
+            mode="read"
+        )
     )
 
     (
@@ -90,11 +92,11 @@ def pairwise_point_linestring_nearest_points(
         segment_id,
         point_on_linestring_xy,
     ) = nearest_points.pairwise_point_linestring_nearest_points(
-        points_xy._column,
-        as_column(linestrings.lines.part_offset),
-        linestrings.lines.xy._column,
+        points_xy._column.to_pylibcudf(mode="read"),
+        as_column(linestrings.lines.part_offset).to_pylibcudf(mode="read"),
+        linestrings.lines.xy._column.to_pylibcudf(mode="read"),
         points_geometry_offset,
-        as_column(linestrings.lines.geometry_offset),
+        as_column(linestrings.lines.geometry_offset).to_pylibcudf(mode="read"),
     )
 
     nearest_points_on_linestring = GeoColumn._from_points_xy(

--- a/python/cuspatial/cuspatial/core/spatial/projection.py
+++ b/python/cuspatial/cuspatial/core/spatial/projection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from cudf import DataFrame
 
@@ -51,8 +51,8 @@ def sinusoidal_projection(origin_lon, origin_lat, lonlat: GeoSeries):
     result = cpp_sinusoidal_projection(
         origin_lon,
         origin_lat,
-        lonlat.points.x._column,
-        lonlat.points.y._column,
+        lonlat.points.x._column.to_pylibcudf(mode="read"),
+        lonlat.points.y._column.to_pylibcudf(mode="read"),
     )
     lonlat_transformed = DataFrame(
         {"x": result[0], "y": result[1]}

--- a/python/cuspatial/cuspatial/core/trajectory.py
+++ b/python/cuspatial/cuspatial/core/trajectory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 import numpy as np
 
@@ -64,10 +64,14 @@ def derive_trajectories(object_ids, points: GeoSeries, timestamps):
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32)
-    xs = as_column(points.points.x)
-    ys = as_column(points.points.y)
-    timestamps = normalize_timestamp_column(as_column(timestamps))
+    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+        mode="read"
+    )
+    xs = as_column(points.points.x).to_pylibcudf(mode="read")
+    ys = as_column(points.points.y).to_pylibcudf(mode="read")
+    timestamps = normalize_timestamp_column(
+        as_column(timestamps)
+    ).to_pylibcudf(mode="read")
     objects, traj_offsets = cpp_derive_trajectories(
         object_ids, xs, ys, timestamps
     )
@@ -135,9 +139,11 @@ def trajectory_bounding_boxes(num_trajectories, object_ids, points: GeoSeries):
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32)
-    xs = as_column(points.points.x)
-    ys = as_column(points.points.y)
+    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+        mode="read"
+    )
+    xs = as_column(points.points.x).to_pylibcudf(mode="read")
+    ys = as_column(points.points.y).to_pylibcudf(mode="read")
     return DataFrame._from_data(
         *cpp_trajectory_bounding_boxes(num_trajectories, object_ids, xs, ys)
     )
@@ -190,10 +196,14 @@ def trajectory_distances_and_speeds(
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32)
-    xs = as_column(points.points.x)
-    ys = as_column(points.points.y)
-    timestamps = normalize_timestamp_column(as_column(timestamps))
+    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+        mode="read"
+    )
+    xs = as_column(points.points.x).to_pylibcudf(mode="read")
+    ys = as_column(points.points.y).to_pylibcudf(mode="read")
+    timestamps = normalize_timestamp_column(
+        as_column(timestamps)
+    ).to_pylibcudf(mode="read")
     df = DataFrame._from_data(
         *cpp_trajectory_distances_and_speeds(
             num_trajectories, object_ids, xs, ys, timestamps


### PR DESCRIPTION
## Description
Related to https://github.com/rapidsai/cudf/issues/17317, it appears the Cython bindings are not dependent on any methods specifically on `cudf._lib.column.Column`. It appears most routines operate on `column_view` which can be provided by a `pylibcudf.Column`.

This PR essentially makes the routines defined in Cython accept a `pylibcudf.Column` instead and return a `cudf.core.column.Column` object instead (which should help cudf transition away from its `cudf._lib.column.Column`)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
