### PR TITLE
Skip nyc_taxi_years_correlation.ipynb due to missing taxi geo dataset

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -eEuo pipefail
 
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb nyc_taxi_years_correlation.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR


### PR DESCRIPTION
## Description
It appears https://data.cityofnewyork.us/api/geospatial/d3c5-ddgc?method=export&format=GeoJSON does not return usable data anymore so `nyc_taxi_years_correlation.ipynb` is unable to run currently. Skipping for now until a new dataset can be found

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
