### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/cuproj/pyproject.toml
+++ b/python/cuproj/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 description = "cuProj: GPU-Accelerated Coordinate Projection"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "NVIDIA Corporation" }]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cupy-cuda11x>=12.0.0",

--- a/python/cuspatial/pyproject.toml
+++ b/python/cuspatial/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cudf==25.4.*,>=0.0.0a0",

--- a/python/libcuspatial/pyproject.toml
+++ b/python/libcuspatial/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
