### PR TITLE
Replace `thrust::optional` with `cuda::std::optional`

### DIFF
--- a/cpp/include/cuspatial/detail/distance/linestring_distance.cuh
+++ b/cpp/include/cuspatial/detail/distance/linestring_distance.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/optional>
 #include <thrust/fill.h>
-#include <thrust/optional.h>
 
 #include <limits>
 #include <type_traits>
@@ -63,7 +63,7 @@ OutputIt pairwise_linestring_distance(MultiLinestringRange1 multilinestrings1,
     (multilinestrings1.num_points() + threads_per_block - 1) / threads_per_block;
 
   detail::linestring_distance<<<num_blocks, threads_per_block, 0, stream.value()>>>(
-    multilinestrings1, multilinestrings2, thrust::nullopt, distances_first);
+    multilinestrings1, multilinestrings2, cuda::std::nullopt, distances_first);
 
   CUSPATIAL_CUDA_TRY(cudaGetLastError());
   return distances_first + multilinestrings1.size();

--- a/cpp/include/cuspatial/detail/distance/point_linestring_distance.cuh
+++ b/cpp/include/cuspatial/detail/distance/point_linestring_distance.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/optional>
 #include <thrust/fill.h>
 
 #include <limits>
@@ -62,7 +63,7 @@ OutputIt pairwise_point_linestring_distance(MultiPointRange multipoints,
   auto [threads_per_block, num_blocks] = grid_1d(multilinestrings.num_points());
 
   detail::point_linestring_distance<<<num_blocks, threads_per_block, 0, stream.value()>>>(
-    multipoints, multilinestrings, thrust::nullopt, distances_first);
+    multipoints, multilinestrings, cuda::std::nullopt, distances_first);
 
   CUSPATIAL_CUDA_TRY(cudaGetLastError());
 

--- a/cpp/include/cuspatial/detail/functors.cuh
+++ b/cpp/include/cuspatial/detail/functors.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include <cuspatial/geometry/segment.cuh>
 #include <cuspatial/traits.hpp>
 
+#include <cuda/std/utility>
 #include <thrust/binary_search.h>
 
 namespace cuspatial {
@@ -35,8 +36,8 @@ namespace detail {
  * pair of offsets: (0, 3), (3, 5), (5, 8)
  * number of elements between offsets: 3, 2, 3
  *
- * @tparam OffsetPairIterator Must be iterator type to thrust::pair of indices.
- * @param p Iterator of thrust::pair of indices.
+ * @tparam OffsetPairIterator Must be iterator type to cuda::std::pair of indices.
+ * @param p Iterator of cuda::std::pair of indices.
  */
 struct offset_pair_to_count_functor {
   template <typename OffsetPairIterator>

--- a/cpp/include/cuspatial/detail/kernel/pairwise_distance.cuh
+++ b/cpp/include/cuspatial/detail/kernel/pairwise_distance.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <thrust/optional.h>
+#include <cuda/std/optional>
 
 #include <ranger/ranger.hpp>
 
@@ -50,7 +50,7 @@ namespace detail {
 template <class MultiLinestringRange1, class MultiLinestringRange2, class OutputIt>
 CUSPATIAL_KERNEL void linestring_distance(MultiLinestringRange1 multilinestrings1,
                                           MultiLinestringRange2 multilinestrings2,
-                                          thrust::optional<uint8_t*> intersects,
+                                          cuda::std::optional<uint8_t*> intersects,
                                           OutputIt distances_first)
 {
   using T = typename MultiLinestringRange1::element_t;
@@ -93,7 +93,7 @@ CUSPATIAL_KERNEL void linestring_distance(MultiLinestringRange1 multilinestrings
 template <class MultiPointRange, class MultiLinestringRange, class OutputIterator>
 CUSPATIAL_KERNEL void point_linestring_distance(MultiPointRange multipoints,
                                                 MultiLinestringRange multilinestrings,
-                                                thrust::optional<uint8_t*> intersects,
+                                                cuda::std::optional<uint8_t*> intersects,
                                                 OutputIterator distances)
 {
   using T = typename MultiPointRange::element_t;

--- a/cpp/include/cuspatial/detail/range/enumerate_range.cuh
+++ b/cpp/include/cuspatial/detail/range/enumerate_range.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include <cuspatial/iterator_factory.cuh>
 #include <cuspatial/traits.hpp>
 
+#include <cuda/std/utility>
 #include <thrust/distance.h>
 #include <thrust/iterator/counting_iterator.h>
 
@@ -41,7 +42,7 @@ struct to_indexed_pair_functor {
   to_indexed_pair_functor(Iterator begin) : _begin(begin) {}
 
   template <typename IndexType>
-  thrust::pair<IndexType, value_type> CUSPATIAL_HOST_DEVICE operator()(IndexType i)
+  cuda::std::pair<IndexType, value_type> CUSPATIAL_HOST_DEVICE operator()(IndexType i)
   {
     return {i, _begin[i]};
   }

--- a/cpp/include/cuspatial/detail/range/multilinestring_range.cuh
+++ b/cpp/include/cuspatial/detail/range/multilinestring_range.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <cuspatial/range/multipoint_range.cuh>
 #include <cuspatial/traits.hpp>
 
+#include <cuda/std/optional>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -144,12 +145,12 @@ multilinestring_range<GeometryIterator, PartIterator, VecIterator>::part_idx_fro
 template <typename GeometryIterator, typename PartIterator, typename VecIterator>
 template <typename IndexType>
 CUSPATIAL_HOST_DEVICE
-  thrust::optional<typename thrust::iterator_traits<PartIterator>::difference_type>
+  cuda::std::optional<typename thrust::iterator_traits<PartIterator>::difference_type>
   multilinestring_range<GeometryIterator, PartIterator, VecIterator>::part_idx_from_segment_idx(
     IndexType segment_idx)
 {
   auto part_idx = thrust::distance(_part_begin, _part_iter_from_point_idx(segment_idx));
-  if (not is_valid_segment_id(segment_idx, part_idx)) return thrust::nullopt;
+  if (not is_valid_segment_id(segment_idx, part_idx)) return cuda::std::nullopt;
   return part_idx;
 }
 

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <cuspatial/geometry/segment.cuh>
 #include <cuspatial/geometry/vec_2d.hpp>
 
-#include <thrust/optional.h>
+#include <cuda/std/optional>
 #include <thrust/pair.h>
 #include <thrust/swap.h>
 #include <thrust/tuple.h>
@@ -148,7 +148,7 @@ __forceinline__ T __device__ squared_segment_distance(vec_2d<T> const& a,
 template <typename T>
 __forceinline__
 
-  thrust::pair<thrust::optional<vec_2d<T>>, thrust::optional<segment<T>>>
+  thrust::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
     __device__ collinear_or_parallel_overlapping_segments(
       vec_2d<T> a, vec_2d<T> b, vec_2d<T> c, vec_2d<T> d, vec_2d<T> center = vec_2d<T>{})
 {
@@ -156,21 +156,21 @@ __forceinline__
   auto ac = c - a;
 
   // Parallel
-  if (not float_equal(det(ab, ac), T{0})) return {thrust::nullopt, thrust::nullopt};
+  if (not float_equal(det(ab, ac), T{0})) return {cuda::std::nullopt, cuda::std::nullopt};
 
   // Must be on the same line, sort the endpoints
   if (b < a) thrust::swap(a, b);
   if (d < c) thrust::swap(c, d);
 
   // Test if not overlap
-  if (b < c || d < a) return {thrust::nullopt, thrust::nullopt};
+  if (b < c || d < a) return {cuda::std::nullopt, cuda::std::nullopt};
 
   // Compute smallest interval between the segments
   auto e0 = a > c ? a : c;
   auto e1 = b < d ? b : d;
 
-  if (e0 == e1) { return {e0 + center, thrust::nullopt}; }
-  return {thrust::nullopt, segment<T>{e0 + center, e1 + center}};
+  if (e0 == e1) { return {e0 + center, cuda::std::nullopt}; }
+  return {cuda::std::nullopt, segment<T>{e0 + center, e1 + center}};
 }
 
 /**
@@ -181,8 +181,8 @@ __forceinline__
  * @return A pair of optional intersecting point and optional overlapping segment
  */
 template <typename T>
-__forceinline__ thrust::pair<thrust::optional<vec_2d<T>>, thrust::optional<segment<T>>> __device__
-segment_intersection(segment<T> const& segment1, segment<T> const& segment2)
+__forceinline__ thrust::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
+  __device__ segment_intersection(segment<T> const& segment1, segment<T> const& segment2)
 {
   // Condition the coordinates to avoid large floating point error
   auto center = midpoint(segment1.center(), segment2.center());
@@ -207,9 +207,9 @@ segment_intersection(segment<T> const& segment1, segment<T> const& segment2)
   if (r >= 0 and r <= 1 and s >= 0 and s <= 1) {
     auto p = a + r * ab;
     // Decondition the coordinates
-    return {p + center, thrust::nullopt};
+    return {p + center, cuda::std::nullopt};
   }
-  return {thrust::nullopt, thrust::nullopt};
+  return {cuda::std::nullopt, cuda::std::nullopt};
 }
 
 /**
@@ -233,8 +233,8 @@ bool __device__ is_point_on_segment(segment<T> const& segment, vec_2d<T> const& 
  * nullopt.
  */
 template <typename T>
-thrust::optional<segment<T>> __device__ maybe_merge_segments(segment<T> const& segment1,
-                                                             segment<T> const& segment2)
+cuda::std::optional<segment<T>> __device__ maybe_merge_segments(segment<T> const& segment1,
+                                                                segment<T> const& segment2)
 {
   // Condition the coordinates to avoid large floating point error
   auto center = midpoint(segment1.center(), segment2.center());
@@ -244,16 +244,16 @@ thrust::optional<segment<T>> __device__ maybe_merge_segments(segment<T> const& s
   auto ab = b - a;
   auto cd = d - c;
 
-  if (not float_equal(det(ab, cd), T{0})) return thrust::nullopt;
+  if (not float_equal(det(ab, cd), T{0})) return cuda::std::nullopt;
   auto ac = c - a;
-  if (not float_equal(det(ab, ac), T{0})) return thrust::nullopt;
+  if (not float_equal(det(ab, ac), T{0})) return cuda::std::nullopt;
 
   // Must be on the same line, sort the endpoints
   if (b < a) thrust::swap(a, b);
   if (d < c) thrust::swap(c, d);
 
   // Test if not overlap
-  if (b < c || d < a) return thrust::nullopt;
+  if (b < c || d < a) return cuda::std::nullopt;
 
   // Compute largest interval between the segments
   auto e0 = a < c ? a : c;

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -21,7 +21,7 @@
 #include <cuspatial/geometry/vec_2d.hpp>
 
 #include <cuda/std/optional>
-#include <thrust/pair.h>
+#include <cuda/std/utility>
 #include <thrust/swap.h>
 #include <thrust/tuple.h>
 
@@ -148,7 +148,7 @@ __forceinline__ T __device__ squared_segment_distance(vec_2d<T> const& a,
 template <typename T>
 __forceinline__
 
-  thrust::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
+  cuda::std::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
     __device__ collinear_or_parallel_overlapping_segments(
       vec_2d<T> a, vec_2d<T> b, vec_2d<T> c, vec_2d<T> d, vec_2d<T> center = vec_2d<T>{})
 {
@@ -181,7 +181,7 @@ __forceinline__
  * @return A pair of optional intersecting point and optional overlapping segment
  */
 template <typename T>
-__forceinline__ thrust::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
+__forceinline__ cuda::std::pair<cuda::std::optional<vec_2d<T>>, cuda::std::optional<segment<T>>>
   __device__ segment_intersection(segment<T> const& segment1, segment<T> const& segment2)
 {
   // Condition the coordinates to avoid large floating point error

--- a/cpp/include/cuspatial/range/multilinestring_range.cuh
+++ b/cpp/include/cuspatial/range/multilinestring_range.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuda/std/optional>
 #include <thrust/pair.h>
 
 namespace cuspatial {
@@ -121,7 +122,7 @@ class multilinestring_range {
   /// If the segment id is invalid, returns nullopt.
   template <typename IndexType>
   CUSPATIAL_HOST_DEVICE
-    thrust::optional<typename thrust::iterator_traits<PartIterator>::difference_type>
+    cuda::std::optional<typename thrust::iterator_traits<PartIterator>::difference_type>
     part_idx_from_segment_idx(IndexType point_idx);
 
   /// Given the index of a part (linestring), return the geometry (multilinestring) index

--- a/cpp/include/cuspatial/traits.hpp
+++ b/cpp/include/cuspatial/traits.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 
 #include <cuspatial/geometry/vec_2d.hpp>
 #include <cuspatial/geometry/vec_3d.hpp>
-
-#include <thrust/optional.h>
 
 #include <iterator>
 #include <optional>

--- a/cpp/include/cuspatial_test/test_util.cuh
+++ b/cpp/include/cuspatial_test/test_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #include <thrust/for_each.h>
 #include <thrust/host_vector.h>
-#include <thrust/optional.h>
 
 #include <cstdio>
 #include <iomanip>

--- a/cpp/tests/operators/linestrings_test.cu
+++ b/cpp/tests/operators/linestrings_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 
 #include <rmm/device_vector.hpp>
 
+#include <cuda/std/optional>
 #include <thrust/execution_policy.h>
-#include <thrust/optional.h>
 #include <thrust/pair.h>
 
 #include <gtest/gtest.h>
@@ -38,14 +38,14 @@ using namespace cuspatial::detail;
 using namespace cuspatial::test;
 
 template <typename T>
-using optional_vec2d = thrust::optional<vec_2d<T>>;
+using optional_vec2d = cuda::std::optional<vec_2d<T>>;
 
 namespace cuspatial {
 
 // Required by gtest test suite to compile
 // Need to be defined within cuspatial namespace for ADL.
 template <typename T>
-std::ostream& operator<<(std::ostream& os, thrust::optional<vec_2d<T>> const& opt)
+std::ostream& operator<<(std::ostream& os, cuda::std::optional<vec_2d<T>> const& opt)
 {
   if (opt.has_value())
     return os << opt.value();
@@ -76,18 +76,19 @@ CUSPATIAL_KERNEL void compute_intersection(segment<T> ab,
 {
   auto [p, s]    = detail::segment_intersection(ab, cd);
   point_out[0]   = p;
-  segment_out[0] = s.has_value() ? thrust::optional(order_end_points(s.value())) : s;
+  segment_out[0] = s.has_value() ? cuda::std::optional(order_end_points(s.value())) : s;
 }
 
 template <typename T>
 struct unpack_optional_segment {
   thrust::tuple<optional_vec2d<T>, optional_vec2d<T>> CUSPATIAL_HOST_DEVICE
-  operator()(thrust::optional<segment<T>> segment)
+  operator()(cuda::std::optional<segment<T>> segment)
   {
     if (segment.has_value())
       return thrust::make_tuple(segment.value().v1, segment.value().v2);
     else
-      return thrust::tuple<optional_vec2d<T>, optional_vec2d<T>>{thrust::nullopt, thrust::nullopt};
+      return thrust::tuple<optional_vec2d<T>, optional_vec2d<T>>{cuda::std::nullopt,
+                                                                 cuda::std::nullopt};
   }
 };
 
@@ -95,23 +96,23 @@ template <typename T>
 void run_single_intersection_test(
   segment<T> const& ab,
   segment<T> const& cd,
-  std::vector<thrust::optional<vec_2d<T>>> const& points_expected,
-  std::vector<thrust::optional<segment<T>>> const& segments_expected)
+  std::vector<cuda::std::optional<vec_2d<T>>> const& points_expected,
+  std::vector<cuda::std::optional<segment<T>>> const& segments_expected)
 {
-  rmm::device_vector<thrust::optional<vec_2d<T>>> points_got(points_expected.size());
-  rmm::device_vector<thrust::optional<segment<T>>> segments_got(segments_expected.size());
+  rmm::device_vector<cuda::std::optional<vec_2d<T>>> points_got(points_expected.size());
+  rmm::device_vector<cuda::std::optional<segment<T>>> segments_got(segments_expected.size());
 
   compute_intersection<<<1, 1>>>(ab, cd, points_got.data(), segments_got.data());
 
   // Unpack the segment into two separate optional vec_2d column.
-  rmm::device_vector<thrust::optional<vec_2d<T>>> first(segments_got.size());
-  rmm::device_vector<thrust::optional<vec_2d<T>>> second(segments_got.size());
+  rmm::device_vector<cuda::std::optional<vec_2d<T>>> first(segments_got.size());
+  rmm::device_vector<cuda::std::optional<vec_2d<T>>> second(segments_got.size());
   auto outit = thrust::make_zip_iterator(first.begin(), second.begin());
 
   thrust::transform(segments_got.begin(), segments_got.end(), outit, unpack_optional_segment<T>{});
 
-  std::vector<thrust::optional<vec_2d<T>>> expected_first(segments_expected.size());
-  std::vector<thrust::optional<vec_2d<T>>> expected_second(segments_expected.size());
+  std::vector<cuda::std::optional<vec_2d<T>>> expected_first(segments_expected.size());
+  std::vector<cuda::std::optional<vec_2d<T>>> expected_second(segments_expected.size());
   auto h_outit = thrust::make_zip_iterator(expected_first.begin(), expected_second.begin());
 
   thrust::transform(thrust::host,
@@ -132,8 +133,8 @@ TYPED_TEST(SegmentIntersectionTest, SimpleIntersect)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{0.0, 1.0}, {1.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.5, 0.5}};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.5, 0.5}};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -145,8 +146,8 @@ TYPED_TEST(SegmentIntersectionTest, IntersectAtEndPoint)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{1.0, 1.0}, {1.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{vec_2d<T>{1.0, 1.0}};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{vec_2d<T>{1.0, 1.0}};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -158,8 +159,8 @@ TYPED_TEST(SegmentIntersectionTest, IntersectAtEndPoint2)
   segment<T> ab{{-1.0, 0.0}, {0.0, 0.0}};
   segment<T> cd{{0.0, 0.0}, {0.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.0, 0.0}};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.0, 0.0}};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -171,8 +172,8 @@ TYPED_TEST(SegmentIntersectionTest, IntersectAtEndPoint3)
   segment<T> ab{{-1.0, 0.0}, {0.0, 0.0}};
   segment<T> cd{{1.0, 0.0}, {0.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.0, 0.0}};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{vec_2d<T>{0.0, 0.0}};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -184,8 +185,8 @@ TYPED_TEST(SegmentIntersectionTest, UnparallelDisjoint1)
   segment<T> ab{{0.0, 0.0}, {0.4, 1.0}};
   segment<T> cd{{1.0, 0.0}, {0.6, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -197,8 +198,8 @@ TYPED_TEST(SegmentIntersectionTest, UnparallelDisjoint2)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{2.0, 0.0}, {2.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -210,8 +211,8 @@ TYPED_TEST(SegmentIntersectionTest, ParallelDisjoint1)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{1.0, 0.0}, {1.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -223,8 +224,8 @@ TYPED_TEST(SegmentIntersectionTest, ParallelDisjoint2)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{0.0, 1.0}, {1.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -236,8 +237,8 @@ TYPED_TEST(SegmentIntersectionTest, ParallelDisjoint3)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{1.0, 0.0}, {2.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -249,8 +250,8 @@ TYPED_TEST(SegmentIntersectionTest, ParallelDisjoint4)
   segment<T> ab{{0.0, 0.0}, {0.0, -1.0}};
   segment<T> cd{{1.0, 0.0}, {1.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -262,8 +263,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint1)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{2.0, 0.0}, {3.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -275,8 +276,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint2)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{-1.0, 0.0}, {-2.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -288,8 +289,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint3)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 2.0}, {0.0, 3.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -301,8 +302,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint4)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, -1.0}, {0.0, -2.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -314,8 +315,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint5)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{2.0, 2.0}, {3.0, 3.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -327,8 +328,8 @@ TYPED_TEST(SegmentIntersectionTest, CollinearDisjoint6)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{-1.0, -1.0}, {-2.0, -2.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{thrust::nullopt};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cuda::std::nullopt};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -340,8 +341,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap1)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{0.5, 0.5}, {1.5, 1.5}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.5, 0.5}, {1.0, 1.0}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.5, 0.5}, {1.0, 1.0}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -353,8 +355,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap2)
   segment<T> ab{{0.0, 0.0}, {1.0, 1.0}};
   segment<T> cd{{0.5, 0.5}, {-1.5, -1.5}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.0}, {0.5, 0.5}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.0}, {0.5, 0.5}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -366,8 +369,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap3)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{0.5, 0.0}, {2.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.5, 0.0}, {1.0, 0.0}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.5, 0.0}, {1.0, 0.0}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -379,8 +383,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap4)
   segment<T> ab{{0.0, 0.0}, {1.0, 0.0}};
   segment<T> cd{{0.5, 0.0}, {-1.0, 0.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.0}, {0.5, 0.0}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.0}, {0.5, 0.0}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -392,8 +397,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap5)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 0.5}, {0.0, 2.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.5}, {0.0, 1.0}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.5}, {0.0, 1.0}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -405,8 +411,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap6)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 0.5}, {0.0, -2.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.0}, {0.0, 0.5}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.0}, {0.0, 0.5}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -418,8 +425,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap7)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 0.0}, {0.0, 0.5}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.0}, {0.0, 0.5}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.0}, {0.0, 0.5}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -431,8 +439,9 @@ TYPED_TEST(SegmentIntersectionTest, Overlap8)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 0.5}, {0.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{segment<T>{{0.0, 0.5}, {0.0, 1.0}}};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{
+    segment<T>{{0.0, 0.5}, {0.0, 1.0}}};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -444,8 +453,8 @@ TYPED_TEST(SegmentIntersectionTest, Overlap9)
   segment<T> ab{{0.0, 0.0}, {0.0, 1.0}};
   segment<T> cd{{0.0, 0.25}, {0.0, 0.75}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{cd};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{cd};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }
@@ -457,8 +466,8 @@ TYPED_TEST(SegmentIntersectionTest, Overlap10)
   segment<T> ab{{0.0, 0.25}, {0.0, 0.75}};
   segment<T> cd{{0.0, 0.0}, {0.0, 1.0}};
 
-  std::vector<thrust::optional<vec_2d<T>>> points_expected{thrust::nullopt};
-  std::vector<thrust::optional<segment<T>>> segments_expected{ab};
+  std::vector<cuda::std::optional<vec_2d<T>>> points_expected{cuda::std::nullopt};
+  std::vector<cuda::std::optional<segment<T>>> segments_expected{ab};
 
   run_single_intersection_test(ab, cd, points_expected, segments_expected);
 }


### PR DESCRIPTION
Its deprecated and will be removed in a future CCCL release