### PR TITLE
Replace `thrust::tuple` with `cuda::std::tuple`

### DIFF
--- a/cpp/doxygen/developer_guide/HEADER_ONLY_API_GUIDE.md
+++ b/cpp/doxygen/developer_guide/HEADER_ONLY_API_GUIDE.md
@@ -229,7 +229,7 @@ provided in `type_utils.hpp`.
 So, to refactor the libcudf-based API, we remove the following code.
 
 ```c++
-auto input_tuple = thrust::make_tuple(thrust::make_constant_iterator(static_cast<T>(radius)),
+auto input_tuple = cuda::std::make_tuple(thrust::make_constant_iterator(static_cast<T>(radius)),
                                       a_lon.begin<T>(),
                                       a_lat.begin<T>(),
                                       b_lon.begin<T>(),
@@ -242,11 +242,11 @@ thrust::transform(rmm::exec_policy(stream),
                   input_iter + result->size(),
                   result->mutable_view().begin<T>(),
                   [] __device__(auto inputs) {
-                    return calculate_haversine_distance(thrust::get<0>(inputs),
-                                                        thrust::get<1>(inputs),
-                                                        thrust::get<2>(inputs),
-                                                        thrust::get<3>(inputs),
-                                                        thrust::get<4>(inputs));
+                    return calculate_haversine_distance(cuda::std::get<0>(inputs),
+                                                        cuda::std::get<1>(inputs),
+                                                        cuda::std::get<2>(inputs),
+                                                        cuda::std::get<3>(inputs),
+                                                        cuda::std::get<4>(inputs));
                   });
 ```
 

--- a/cpp/include/cuspatial/detail/find/find_and_combine_segment.cuh
+++ b/cpp/include/cuspatial/detail/find/find_and_combine_segment.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,13 +84,13 @@ CUSPATIAL_KERNEL void simple_find_and_combine_segments_kernel(OffsetRange offset
  */
 template <typename index_t, typename T>
 struct segment_comparator {
-  bool __device__ operator()(thrust::tuple<index_t, segment<T>> const& lhs,
-                             thrust::tuple<index_t, segment<T>> const& rhs) const
+  bool __device__ operator()(cuda::std::tuple<index_t, segment<T>> const& lhs,
+                             cuda::std::tuple<index_t, segment<T>> const& rhs) const
   {
-    auto lhs_index   = thrust::get<0>(lhs);
-    auto rhs_index   = thrust::get<0>(rhs);
-    auto lhs_segment = thrust::get<1>(lhs);
-    auto rhs_segment = thrust::get<1>(rhs);
+    auto lhs_index   = cuda::std::get<0>(lhs);
+    auto rhs_index   = cuda::std::get<0>(rhs);
+    auto lhs_segment = cuda::std::get<1>(lhs);
+    auto rhs_segment = cuda::std::get<1>(rhs);
 
     // Compare space id
     if (lhs_index == rhs_index) {

--- a/cpp/include/cuspatial/detail/find/find_points_on_segments.cuh
+++ b/cpp/include/cuspatial/detail/find/find_points_on_segments.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 namespace detail {

--- a/cpp/include/cuspatial/detail/functors.cuh
+++ b/cpp/include/cuspatial/detail/functors.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ struct offset_pair_to_count_functor {
   template <typename OffsetPairIterator>
   CUSPATIAL_HOST_DEVICE auto operator()(OffsetPairIterator p)
   {
-    return thrust::get<1>(p) - thrust::get<0>(p);
+    return cuda::std::get<1>(p) - cuda::std::get<0>(p);
   }
 };
 

--- a/cpp/include/cuspatial/detail/geometry/linestring_ref.cuh
+++ b/cpp/include/cuspatial/detail/geometry/linestring_ref.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 #include <cuspatial/iterator_factory.cuh>
 #include <cuspatial/traits.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 

--- a/cpp/include/cuspatial/detail/geometry/polygon_ref.cuh
+++ b/cpp/include/cuspatial/detail/geometry/polygon_ref.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include <cuspatial/iterator_factory.cuh>
 #include <cuspatial/traits.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 

--- a/cpp/include/cuspatial/detail/index/construction/phase_1.cuh
+++ b/cpp/include/cuspatial/detail/index/construction/phase_1.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/fill.h>
@@ -38,7 +39,6 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <memory>
 #include <tuple>

--- a/cpp/include/cuspatial/detail/index/construction/phase_2.cuh
+++ b/cpp/include/cuspatial/detail/index/construction/phase_2.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/distance.h>
@@ -38,7 +39,6 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 #include <thrust/uninitialized_fill.h>
 
 #include <memory>
@@ -85,9 +85,9 @@ inline rmm::device_uvector<uint32_t> flatten_point_keys(
                     keys_and_levels + num_valid_nodes,
                     flattened_keys.begin(),
                     [last_level = max_depth - 1] __device__(auto const& val) {
-                      auto& key       = thrust::get<0>(val);
-                      auto& level     = thrust::get<1>(val);
-                      auto& is_parent = thrust::get<2>(val);
+                      auto& key       = cuda::std::get<0>(val);
+                      auto& level     = cuda::std::get<1>(val);
+                      auto& is_parent = cuda::std::get<2>(val);
                       // if this is a parent node, return max_key. otherwise
                       // compute the key for one level up the tree. Leaf nodes
                       // whose keys are zero will be removed in a subsequent

--- a/cpp/include/cuspatial/detail/index/construction/utilities.cuh
+++ b/cpp/include/cuspatial/detail/index/construction/utilities.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,18 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cuspatial {
 namespace detail {
 
 template <typename T>
 struct tuple_sum {
-  inline __device__ thrust::tuple<T, T> operator()(thrust::tuple<T, T> const& a,
-                                                   thrust::tuple<T, T> const& b)
+  inline __device__ cuda::std::tuple<T, T> operator()(cuda::std::tuple<T, T> const& a,
+                                                      cuda::std::tuple<T, T> const& b)
   {
-    return thrust::make_tuple(thrust::get<0>(a) + thrust::get<0>(b),
-                              thrust::get<1>(a) + thrust::get<1>(b));
+    return cuda::std::make_tuple(cuda::std::get<0>(a) + cuda::std::get<0>(b),
+                                 cuda::std::get<1>(a) + cuda::std::get<1>(b));
   }
 };
 

--- a/cpp/include/cuspatial/detail/intersection/linestring_intersection.cuh
+++ b/cpp/include/cuspatial/detail/intersection/linestring_intersection.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/atomic>
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -47,7 +48,6 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/tabulate.h>
-#include <thrust/tuple.h>
 #include <thrust/uninitialized_fill.h>
 #include <thrust/unique.h>
 

--- a/cpp/include/cuspatial/detail/intersection/linestring_intersection_count.cuh
+++ b/cpp/include/cuspatial/detail/intersection/linestring_intersection_count.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <ranger/ranger.hpp>
 

--- a/cpp/include/cuspatial/detail/intersection/linestring_intersection_with_duplicates.cuh
+++ b/cpp/include/cuspatial/detail/intersection/linestring_intersection_with_duplicates.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -38,7 +39,6 @@
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
 #include <thrust/scan.h>
-#include <thrust/tuple.h>
 #include <thrust/uninitialized_fill.h>
 
 #include <ranger/ranger.hpp>
@@ -162,9 +162,9 @@ struct id_ranges {
 
   /// Row-wise getter to the id arrays
   template <typename IndexType>
-  thrust::tuple<index_t, index_t, index_t, index_t> __device__ operator[](IndexType i)
+  cuda::std::tuple<index_t, index_t, index_t, index_t> __device__ operator[](IndexType i)
   {
-    return thrust::make_tuple(
+    return cuda::std::make_tuple(
       lhs_linestring_ids[i], lhs_segment_ids[i], rhs_linestring_ids[i], rhs_segment_ids[i]);
   }
 

--- a/cpp/include/cuspatial/detail/join/quadtree_point_in_polygon.cuh
+++ b/cpp/include/cuspatial/detail/join/quadtree_point_in_polygon.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,14 +58,14 @@ struct compute_poly_and_point_indices {
 
   using IndexType = iterator_value_type<QuadOffsetsIterator>;
 
-  inline thrust::tuple<IndexType, IndexType> __device__
+  inline cuda::std::tuple<IndexType, IndexType> __device__
   operator()(std::uint64_t const global_index) const
   {
     auto const [quad_poly_index, local_point_index] =
       get_quad_and_local_point_indices(global_index, point_offsets_begin, point_offsets_end);
     auto const point_idx = quad_point_offsets_begin[quad_poly_index] + local_point_index;
     auto const poly_idx  = poly_indices_begin[quad_poly_index];
-    return thrust::make_tuple(poly_idx, point_idx);
+    return cuda::std::make_tuple(poly_idx, point_idx);
   }
 };
 
@@ -82,10 +82,10 @@ struct test_poly_point_intersection {
   PointIterator points_first;
   MultiPolygonRange polygons;
 
-  inline bool __device__ operator()(thrust::tuple<IndexType, IndexType> const& poly_point_idxs)
+  inline bool __device__ operator()(cuda::std::tuple<IndexType, IndexType> const& poly_point_idxs)
   {
-    auto const poly_idx  = thrust::get<0>(poly_point_idxs);
-    auto const point_idx = thrust::get<1>(poly_point_idxs);
+    auto const poly_idx  = cuda::std::get<0>(poly_point_idxs);
+    auto const point_idx = cuda::std::get<1>(poly_point_idxs);
 
     vec_2d<T> const& point = points_first[point_idx];
 

--- a/cpp/include/cuspatial/detail/join/traversal.cuh
+++ b/cpp/include/cuspatial/detail/join/traversal.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/gather.h>
@@ -32,7 +33,6 @@
 #include <thrust/scan.h>
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/include/cuspatial/detail/pairwise_multipoint_equals_count.cuh
+++ b/cpp/include/cuspatial/detail/pairwise_multipoint_equals_count.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,8 +88,7 @@ OutputIt pairwise_multipoint_equals_count(MultiPointRangeA lhs,
   thrust::copy(
     rmm::exec_policy(stream), rhs.point_begin(), rhs.point_end(), rhs_point_sorted.begin());
 
-  auto rhs_with_keys =
-    thrust::make_zip_iterator(thrust::make_tuple(rhs_keys.begin(), rhs_point_sorted.begin()));
+  auto rhs_with_keys = thrust::make_zip_iterator(rhs_keys.begin(), rhs_point_sorted.begin());
 
   thrust::sort(rmm::exec_policy(stream), rhs_with_keys, rhs_with_keys + rhs.num_points());
 

--- a/cpp/include/cuspatial/detail/point_linestring_nearest_points.cuh
+++ b/cpp/include/cuspatial/detail/point_linestring_nearest_points.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,19 +99,19 @@ CUSPATIAL_KERNEL void pairwise_point_linestring_nearest_points_kernel(
 
           auto distance_nearest_point_pair =
             point_to_segment_distance_squared_nearest_point(c, a, b);
-          auto distance_squared = thrust::get<0>(distance_nearest_point_pair);
+          auto distance_squared = cuda::std::get<0>(distance_nearest_point_pair);
           if (distance_squared < min_distance_squared) {
             min_distance_squared = distance_squared;
             nearest_point_idx    = point_idx - point_start;
             nearest_part_idx     = part_idx - linestring_parts_start;
             nearest_segment_idx  = segment_idx - segment_start;
-            nearest_point        = thrust::get<1>(distance_nearest_point_pair);
+            nearest_point        = cuda::std::get<1>(distance_nearest_point_pair);
           }
         }
       }
     }
-    output_first[idx] =
-      thrust::make_tuple(nearest_point_idx, nearest_part_idx, nearest_segment_idx, nearest_point);
+    output_first[idx] = cuda::std::make_tuple(
+      nearest_point_idx, nearest_part_idx, nearest_segment_idx, nearest_point);
   }
 }
 

--- a/cpp/include/cuspatial/detail/point_quadtree.cuh
+++ b/cpp/include/cuspatial/detail/point_quadtree.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/tuple>
 #include <thrust/distance.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 
@@ -111,7 +111,7 @@ inline point_quadtree make_quad_tree(rmm::device_uvector<uint32_t>& keys,
                       offsets.begin(),
                       // return is_internal_node ? lhs : rhs
                       cuda::proclaim_return_type<uint32_t>([] __device__(auto const& t) {
-                        return thrust::get<0>(t) ? thrust::get<1>(t) : thrust::get<2>(t);
+                        return cuda::std::get<0>(t) ? cuda::std::get<1>(t) : cuda::std::get<2>(t);
                       }));
 
     return std::move(offsets);
@@ -129,7 +129,7 @@ inline point_quadtree make_quad_tree(rmm::device_uvector<uint32_t>& keys,
                     lengths.begin(),
                     // return bool ? lhs : rhs
                     cuda::proclaim_return_type<uint32_t>([] __device__(auto const& t) {
-                      return thrust::get<0>(t) ? thrust::get<1>(t) : thrust::get<2>(t);
+                      return cuda::std::get<0>(t) ? cuda::std::get<1>(t) : cuda::std::get<2>(t);
                     }));
 
   // Shrink keys to the number of valid nodes

--- a/cpp/include/cuspatial/detail/trajectory/derive_trajectories.cuh
+++ b/cpp/include/cuspatial/detail/trajectory/derive_trajectories.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,10 @@ template <typename Tuple>
 struct trajectory_comparator {
   __device__ bool operator()(Tuple const& lhs, Tuple const& rhs)
   {
-    auto lhs_id = thrust::get<0>(lhs);
-    auto rhs_id = thrust::get<0>(rhs);
-    auto lhs_ts = thrust::get<1>(lhs);
-    auto rhs_ts = thrust::get<1>(rhs);
+    auto lhs_id = cuda::std::get<0>(lhs);
+    auto rhs_id = cuda::std::get<0>(rhs);
+    auto lhs_ts = cuda::std::get<1>(lhs);
+    auto rhs_ts = cuda::std::get<1>(rhs);
     return (lhs_id < rhs_id) || ((lhs_id == rhs_id) && (lhs_ts < rhs_ts));
   };
 };
@@ -68,7 +68,7 @@ void order_trajectories(IdInputIt ids_first,
 {
   using id_type        = iterator_value_type<IdInputIt>;
   using timestamp_type = iterator_value_type<TimestampInputIt>;
-  using tuple_type     = thrust::tuple<id_type, timestamp_type>;
+  using tuple_type     = cuda::std::tuple<id_type, timestamp_type>;
 
   auto keys_first     = thrust::make_zip_iterator(ids_first, timestamps_first);
   auto keys_out_first = thrust::make_zip_iterator(ids_out_first, timestamps_out_first);

--- a/cpp/include/cuspatial/detail/utility/linestring.cuh
+++ b/cpp/include/cuspatial/detail/utility/linestring.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 #include <cuspatial/geometry/segment.cuh>
 #include <cuspatial/geometry/vec_2d.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/optional.h>
 #include <thrust/pair.h>
 #include <thrust/swap.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 namespace detail {
@@ -52,7 +52,7 @@ endpoint_index_of_linestring(SizeType const& linestring_idx,
  * ab
  */
 template <typename T>
-__forceinline__ thrust::tuple<T, vec_2d<T>> __device__
+__forceinline__ cuda::std::tuple<T, vec_2d<T>> __device__
 point_to_segment_distance_squared_nearest_point(vec_2d<T> const& c,
                                                 vec_2d<T> const& a,
                                                 vec_2d<T> const& b)
@@ -60,18 +60,18 @@ point_to_segment_distance_squared_nearest_point(vec_2d<T> const& c,
   auto ab        = b - a;
   auto ac        = c - a;
   auto l_squared = dot(ab, ab);
-  if (float_equal(l_squared, T{0})) { return thrust::make_tuple(dot(ac, ac), a); }
+  if (float_equal(l_squared, T{0})) { return cuda::std::make_tuple(dot(ac, ac), a); }
   auto r  = dot(ac, ab);
   auto bc = c - b;
   // If the projection of `c` is outside of segment `ab`, compute point-point distance.
   if (r <= 0 or r >= l_squared) {
     auto dac = dot(ac, ac);
     auto dbc = dot(bc, bc);
-    return dac < dbc ? thrust::make_tuple(dac, a) : thrust::make_tuple(dbc, b);
+    return dac < dbc ? cuda::std::make_tuple(dac, a) : cuda::std::make_tuple(dbc, b);
   }
   auto p  = a + (r / l_squared) * ab;
   auto pc = c - p;
-  return thrust::make_tuple(dot(pc, pc), p);
+  return cuda::std::make_tuple(dot(pc, pc), p);
 }
 
 /**

--- a/cpp/include/cuspatial/point_quadtree.cuh
+++ b/cpp/include/cuspatial/point_quadtree.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 #include <tuple>
 

--- a/cpp/include/cuspatial_test/vector_equality.hpp
+++ b/cpp/include/cuspatial_test/vector_equality.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,7 +224,7 @@ std::pair<rmm::device_vector<vec_2d<T>>, rmm::device_vector<vec_2d<T>>> unpack_v
 
   thrust::transform(pairs.begin(), pairs.end(), zipped_output, [] __device__(Pair const& pair) {
     auto [a, b] = pair;
-    return thrust::make_tuple(a, b);
+    return cuda::std::make_tuple(a, b);
   });
   return {std::move(first), std::move(second)};
 }

--- a/cpp/src/equality/pairwise_multipoint_equals_count.cu
+++ b/cpp/src/equality/pairwise_multipoint_equals_count.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 #include <utility>

--- a/cpp/src/nearest_points/point_linestring_nearest_points.cu
+++ b/cpp/src/nearest_points/point_linestring_nearest_points.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,10 +87,10 @@ struct pairwise_point_linestring_nearest_points_impl {
 
     if constexpr (!is_multi_point && !is_multi_linestring) {
       auto output_its = thrust::make_zip_iterator(
-        thrust::make_tuple(thrust::make_discard_iterator(),
-                           thrust::make_discard_iterator(),
-                           segment_idx->mutable_view().begin<cudf::size_type>(),
-                           nearest_points_it));
+        cuda::std::make_tuple(thrust::make_discard_iterator(),
+                              thrust::make_discard_iterator(),
+                              segment_idx->mutable_view().begin<cudf::size_type>(),
+                              nearest_points_it));
 
       pairwise_point_linestring_nearest_points(point_geometry_it,
                                                point_geometry_it + num_pairs + 1,
@@ -114,10 +114,10 @@ struct pairwise_point_linestring_nearest_points_impl {
                                   stream,
                                   mr);
       auto output_its = thrust::make_zip_iterator(
-        thrust::make_tuple(nearest_point_idx->mutable_view().begin<cudf::size_type>(),
-                           thrust::make_discard_iterator(),
-                           segment_idx->mutable_view().begin<cudf::size_type>(),
-                           nearest_points_it));
+        cuda::std::make_tuple(nearest_point_idx->mutable_view().begin<cudf::size_type>(),
+                              thrust::make_discard_iterator(),
+                              segment_idx->mutable_view().begin<cudf::size_type>(),
+                              nearest_points_it));
 
       pairwise_point_linestring_nearest_points(point_geometry_it,
                                                point_geometry_it + num_pairs + 1,
@@ -143,10 +143,10 @@ struct pairwise_point_linestring_nearest_points_impl {
                                   stream,
                                   mr);
       auto output_its = thrust::make_zip_iterator(
-        thrust::make_tuple(thrust::make_discard_iterator(),
-                           nearest_linestring_idx->mutable_view().begin<cudf::size_type>(),
-                           segment_idx->mutable_view().begin<cudf::size_type>(),
-                           nearest_points_it));
+        cuda::std::make_tuple(thrust::make_discard_iterator(),
+                              nearest_linestring_idx->mutable_view().begin<cudf::size_type>(),
+                              segment_idx->mutable_view().begin<cudf::size_type>(),
+                              nearest_points_it));
 
       pairwise_point_linestring_nearest_points(point_geometry_it,
                                                point_geometry_it + num_pairs + 1,
@@ -178,10 +178,10 @@ struct pairwise_point_linestring_nearest_points_impl {
                                   stream,
                                   mr);
       auto output_its = thrust::make_zip_iterator(
-        thrust::make_tuple(nearest_point_idx->mutable_view().begin<cudf::size_type>(),
-                           nearest_linestring_idx->mutable_view().begin<cudf::size_type>(),
-                           segment_idx->mutable_view().begin<cudf::size_type>(),
-                           nearest_points_it));
+        cuda::std::make_tuple(nearest_point_idx->mutable_view().begin<cudf::size_type>(),
+                              nearest_linestring_idx->mutable_view().begin<cudf::size_type>(),
+                              segment_idx->mutable_view().begin<cudf::size_type>(),
+                              nearest_points_it));
 
       pairwise_point_linestring_nearest_points(point_geometry_it,
                                                point_geometry_it + num_pairs + 1,

--- a/cpp/src/projection/sinusoidal_projection.cu
+++ b/cpp/src/projection/sinusoidal_projection.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <type_traits>
 #include <utility>

--- a/cpp/src/trajectory/trajectory_distances_and_speeds.cu
+++ b/cpp/src/trajectory/trajectory_distances_and_speeds.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/adjacent_difference.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
@@ -39,7 +40,6 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 

--- a/cpp/tests/distance/point_distance_test.cu
+++ b/cpp/tests/distance/point_distance_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/generate.h>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -36,7 +37,6 @@
 #include <thrust/random/linear_congruential_engine.h>
 #include <thrust/random/normal_distribution.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -99,11 +99,10 @@ auto compute_point_distance_host(Cart2DVec const& point1, Cart2DVec const& point
   using T      = typename Cart2D::value_type;
   thrust::host_vector<Cart2D> h_point1(point1);
   thrust::host_vector<Cart2D> h_point2(point2);
-  auto pair_iter =
-    thrust::make_zip_iterator(thrust::make_tuple(h_point1.begin(), h_point2.begin()));
+  auto pair_iter   = thrust::make_zip_iterator(h_point1.begin(), h_point2.begin());
   auto result_iter = thrust::make_transform_iterator(pair_iter, [](auto p) {
-    auto p0 = thrust::get<0>(p);
-    auto p1 = thrust::get<1>(p);
+    auto p0 = cuda::std::get<0>(p);
+    auto p1 = cuda::std::get<1>(p);
     return std::sqrt(dot(p0 - p1, p0 - p1));
   });
 

--- a/cpp/tests/intersection/intersection_test_utils.cuh
+++ b/cpp/tests/intersection/intersection_test_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@
 
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/tuple>
 #include <thrust/copy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scatter.h>
 #include <thrust/sort.h>
-#include <thrust/tuple.h>
 
 namespace cuspatial {
 namespace test {
@@ -55,13 +55,13 @@ bool CUSPATIAL_HOST_DEVICE operator<(segment<T> lhs, segment<T> rhs)
  */
 template <typename KeyType, typename GeomType>
 struct order_key_value_pairs {
-  using key_value_t = thrust::tuple<KeyType, GeomType>;
+  using key_value_t = cuda::std::tuple<KeyType, GeomType>;
 
   bool CUSPATIAL_HOST_DEVICE operator()(key_value_t lhs, key_value_t rhs)
   {
-    return thrust::get<0>(lhs) < thrust::get<0>(rhs) ||
-           (thrust::get<0>(lhs) == thrust::get<0>(rhs) &&
-            thrust::get<1>(lhs) < thrust::get<1>(rhs));
+    return cuda::std::get<0>(lhs) < cuda::std::get<0>(rhs) ||
+           (cuda::std::get<0>(lhs) == cuda::std::get<0>(rhs) &&
+            cuda::std::get<1>(lhs) < cuda::std::get<1>(rhs));
   }
 };
 
@@ -133,7 +133,7 @@ linestring_intersection_result<T, IndexType> segment_sort_intersection_result(
                       keys_points_begin,
                       keys_points_begin + num_points,
                       scatter_map.begin(),
-                      order_key_value_pairs<thrust::tuple<IndexType, IndexType>, vec_2d<T>>{});
+                      order_key_value_pairs<cuda::std::tuple<IndexType, IndexType>, vec_2d<T>>{});
 
   // Segment-sort the segment array
   auto keys_segment_begin =
@@ -143,7 +143,7 @@ linestring_intersection_result<T, IndexType> segment_sort_intersection_result(
                       keys_segment_begin,
                       keys_segment_begin + num_segments,
                       scatter_map.begin() + num_points,
-                      order_key_value_pairs<thrust::tuple<IndexType, IndexType>, segment<T>>{});
+                      order_key_value_pairs<cuda::std::tuple<IndexType, IndexType>, segment<T>>{});
 
   // Restore the order of indices
   auto lhs_linestring_id = std::make_unique<rmm::device_uvector<IndexType>>(num_geoms, stream, mr);

--- a/cpp/tests/nearest_points/point_linestring_nearest_points_test.cu
+++ b/cpp/tests/nearest_points/point_linestring_nearest_points_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,11 +58,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, Empty)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(0);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(0);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(nearest_point_id.begin(),
-                                                 nearest_linestring_parts_id.begin(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(nearest_point_id.begin(),
+                                             nearest_linestring_parts_id.begin(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -98,11 +97,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, OnePairSingleComponent)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -137,11 +135,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, NearestAtLeftEndPoint)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -176,11 +173,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, NearestAtRightEndPoint)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -216,11 +212,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, PointAtEndPoints)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -256,11 +251,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, PointOnLineString)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -296,11 +290,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, TwoPairsSingleComponent)
   auto nearest_linestring_segment_id = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate     = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(thrust::make_discard_iterator(),
-                                                 thrust::make_discard_iterator(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(thrust::make_discard_iterator(),
+                                             thrust::make_discard_iterator(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_it,
                                                       points_geometry_it + num_pairs + 1,
@@ -338,11 +331,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, OnePairMultiComponent)
   auto nearest_linestring_segment_id    = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate        = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it =
-    thrust::make_zip_iterator(thrust::make_tuple(nearest_point_id.begin(),
-                                                 nearest_linestring_linestring_id.begin(),
-                                                 nearest_linestring_segment_id.begin(),
-                                                 neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(nearest_point_id.begin(),
+                                             nearest_linestring_linestring_id.begin(),
+                                             nearest_linestring_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_offsets.begin(),
                                                       points_geometry_offsets.end(),
@@ -395,10 +387,10 @@ TYPED_TEST(PairwisePointLinestringNearestPointsTest, ThreePairMultiComponent)
   auto nearest_segment_id        = rmm::device_vector<int32_t>(num_pairs);
   auto neartest_point_coordinate = rmm::device_vector<vec_2d<T>>(num_pairs);
 
-  auto output_it = thrust::make_zip_iterator(thrust::make_tuple(nearest_point_id.begin(),
-                                                                nearest_linestring_id.begin(),
-                                                                nearest_segment_id.begin(),
-                                                                neartest_point_coordinate.begin()));
+  auto output_it = thrust::make_zip_iterator(nearest_point_id.begin(),
+                                             nearest_linestring_id.begin(),
+                                             nearest_segment_id.begin(),
+                                             neartest_point_coordinate.begin());
 
   auto ret = pairwise_point_linestring_nearest_points(points_geometry_offsets.begin(),
                                                       points_geometry_offsets.end(),

--- a/cpp/tests/operators/linestrings_test.cu
+++ b/cpp/tests/operators/linestrings_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,13 +81,14 @@ CUSPATIAL_KERNEL void compute_intersection(segment<T> ab,
 
 template <typename T>
 struct unpack_optional_segment {
-  thrust::tuple<optional_vec2d<T>, optional_vec2d<T>> CUSPATIAL_HOST_DEVICE
+  cuda::std::tuple<optional_vec2d<T>, optional_vec2d<T>> CUSPATIAL_HOST_DEVICE
   operator()(thrust::optional<segment<T>> segment)
   {
     if (segment.has_value())
-      return thrust::make_tuple(segment.value().v1, segment.value().v2);
+      return cuda::std::make_tuple(segment.value().v1, segment.value().v2);
     else
-      return thrust::tuple<optional_vec2d<T>, optional_vec2d<T>>{thrust::nullopt, thrust::nullopt};
+      return cuda::std::tuple<optional_vec2d<T>, optional_vec2d<T>>{thrust::nullopt,
+                                                                    thrust::nullopt};
   }
 };
 

--- a/cpp/tests/trajectory/trajectory_test_utils.cuh
+++ b/cpp/tests/trajectory/trajectory_test_utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,15 +227,15 @@ struct trajectory_test_data {
   }
 
   struct duration_functor {
-    using id_and_timestamp = thrust::tuple<std::int32_t, time_point>;
+    using id_and_timestamp = cuda::std::tuple<std::int32_t, time_point>;
 
     __host__ __device__ time_point::rep operator()(id_and_timestamp const& p0,
                                                    id_and_timestamp const& p1)
     {
-      auto const id0 = thrust::get<0>(p0);
-      auto const id1 = thrust::get<0>(p1);
-      auto const t0  = thrust::get<1>(p0);
-      auto const t1  = thrust::get<1>(p1);
+      auto const id0 = cuda::std::get<0>(p0);
+      auto const id1 = cuda::std::get<0>(p1);
+      auto const t0  = cuda::std::get<1>(p0);
+      auto const t1  = cuda::std::get<1>(p1);
 
       if (id0 == id1) { return (t1 - t0).count(); }
       return 0;
@@ -243,14 +243,14 @@ struct trajectory_test_data {
   };
 
   struct distance_functor {
-    using id_and_position = thrust::tuple<std::int32_t, cuspatial::vec_2d<T>>;
+    using id_and_position = cuda::std::tuple<std::int32_t, cuspatial::vec_2d<T>>;
     __host__ __device__ T operator()(id_and_position const& p0, id_and_position const& p1)
     {
-      auto const id0 = thrust::get<0>(p0);
-      auto const id1 = thrust::get<0>(p1);
+      auto const id0 = cuda::std::get<0>(p0);
+      auto const id1 = cuda::std::get<0>(p1);
       if (id0 == id1) {
-        auto const pos0 = thrust::get<1>(p0);
-        auto const pos1 = thrust::get<1>(p1);
+        auto const pos0 = cuda::std::get<1>(p0);
+        auto const pos1 = cuda::std::get<1>(p1);
         auto const vec  = pos1 - pos0;
         return sqrt(dot(vec, vec));
       }
@@ -259,7 +259,7 @@ struct trajectory_test_data {
   };
 
   struct average_distance_speed_functor {
-    using duration_distance = thrust::tuple<time_point::rep, T, T, T>;
+    using duration_distance = cuda::std::tuple<time_point::rep, T, T, T>;
     using Sec               = typename cuda::std::chrono::seconds;
     using Period =
       typename cuda::std::ratio_divide<typename time_point::period, typename Sec::period>::type;
@@ -268,10 +268,10 @@ struct trajectory_test_data {
                                                      duration_distance const& b)
     {
       auto time_d =
-        time_point::duration(thrust::get<0>(a)) + time_point::duration(thrust::get<0>(b));
+        time_point::duration(cuda::std::get<0>(a)) + time_point::duration(cuda::std::get<0>(b));
       auto time_s =
         static_cast<T>(time_d.count()) * static_cast<T>(Period::num) / static_cast<T>(Period::den);
-      T dist_km   = thrust::get<1>(a) + thrust::get<1>(b);
+      T dist_km   = cuda::std::get<1>(a) + cuda::std::get<1>(b);
       T dist_m    = dist_km * T{1000.0};  // km to m
       T speed_m_s = dist_m / time_s;      // m/ms to m/s
       return {time_d.count(), dist_km, dist_m, speed_m_s};


### PR DESCRIPTION
The former is effectively just an alias and we want to get rid of it
