### PR TITLE
Update to CCCL 2.8.2-rc0.

### DIFF
--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -11,6 +11,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch cccl-2.8.0)
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")


### PR DESCRIPTION
This PR updates to CCCL 2.8.2-rc0. Do not merge until all of RAPIDS is ready to update.

Part of https://github.com/rapidsai/build-planning/issues/157.
