### PR TITLE
Pass dtype objects to cudf as_column calls

### DIFF
--- a/python/cuspatial/cuspatial/core/_column/geocolumn.py
+++ b/python/cuspatial/cuspatial/core/_column/geocolumn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION
+# Copyright (c) 2021-2025, NVIDIA CORPORATION
 from __future__ import annotations
 
 from enum import Enum
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import TypeVar
 
 import cupy as cp
+import numpy as np
 import pyarrow as pa
 
 import cudf
@@ -373,7 +374,9 @@ def _xy_as_variable_sized_list(xy: ColumnBase):
         raise ValueError("xy must have an even number of elements")
 
     num_points = len(xy) // 2
-    indices = as_column(range(0, num_points * 2 + 1, 2), dtype="int32")
+    indices = as_column(
+        range(0, num_points * 2 + 1, 2), dtype=np.dtype(np.int32)
+    )
     return ListColumn(
         data=None,
         dtype=cudf.ListDtype(xy.dtype),

--- a/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
+++ b/python/cuspatial/cuspatial/core/binops/distance_dispatch.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION
 
+import numpy as np
+
 import cudf
 from cudf.core.column import ColumnBase, as_column
 
@@ -198,11 +200,11 @@ class DistanceDispatch:
         result = as_column(
             float("nan"),
             length=len(self._res_index),
-            dtype="float64",
+            dtype=np.dtype(np.float64),
             nan_as_null=False,
         )
         scatter_map = as_column(
-            range(len(self._res_index)), dtype="int32"
+            range(len(self._res_index)), dtype=np.dtype(np.int32)
         ).apply_boolean_mask(self._non_null_mask)
 
         result[scatter_map] = ColumnBase.from_pylibcudf(dist)

--- a/python/cuspatial/cuspatial/core/binops/intersection.py
+++ b/python/cuspatial/cuspatial/core/binops/intersection.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 import cudf
 from cudf.core.column import ColumnBase, ListColumn, as_column
 
@@ -116,7 +118,7 @@ def pairwise_linestring_intersection(
         dtype=cudf.ListDtype(segments.dtype),
         size=segments.size,
         children=(
-            as_column(range(0, len(segments) + 1), dtype="int32"),
+            as_column(range(0, len(segments) + 1), dtype=np.dtype(np.int32)),
             segments,
         ),
     )

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION
+# Copyright (c) 2020-2025, NVIDIA CORPORATION
 
 from functools import cached_property
 from numbers import Integral
@@ -721,7 +721,7 @@ class GeoSeries(cudf.Series):
         return cls._from_column(
             GeoColumn._from_multipoints_xy(
                 as_column(multipoints_xy, dtype=coords_dtype),
-                as_column(geometry_offset, dtype="int32"),
+                as_column(geometry_offset, dtype=np.dtype(np.int32)),
             )
         )
 
@@ -767,8 +767,8 @@ class GeoSeries(cudf.Series):
         return cls._from_column(
             GeoColumn._from_linestrings_xy(
                 as_column(linestrings_xy, dtype=coords_dtype),
-                as_column(part_offset, dtype="int32"),
-                as_column(geometry_offset, dtype="int32"),
+                as_column(part_offset, dtype=np.dtype(np.int32)),
+                as_column(geometry_offset, dtype=np.dtype(np.int32)),
             )
         )
 
@@ -817,9 +817,9 @@ class GeoSeries(cudf.Series):
         return cls._from_column(
             GeoColumn._from_polygons_xy(
                 as_column(polygons_xy, dtype=coords_dtype),
-                as_column(ring_offset, dtype="int32"),
-                as_column(part_offset, dtype="int32"),
-                as_column(geometry_offset, dtype="int32"),
+                as_column(ring_offset, dtype=np.dtype(np.int32)),
+                as_column(part_offset, dtype=np.dtype(np.int32)),
+                as_column(geometry_offset, dtype=np.dtype(np.int32)),
             )
         )
 

--- a/python/cuspatial/cuspatial/core/spatial/join.py
+++ b/python/cuspatial/cuspatial/core/spatial/join.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+import numpy as np
+
 from cudf import DataFrame
 from cudf.core.column import ColumnBase, as_column
 
@@ -331,10 +333,12 @@ def quadtree_point_to_nearest_linestring(
     plc_result = spatial_join.quadtree_point_to_nearest_linestring(
         linestring_quad_pairs,
         quadtree,
-        as_column(point_indices, dtype="uint32").to_pylibcudf(mode="read"),
+        as_column(point_indices, dtype=np.dtype(np.uint32)).to_pylibcudf(
+            mode="read"
+        ),
         points_x,
         points_y,
-        as_column(linestring_offsets, dtype="uint32").to_pylibcudf(
+        as_column(linestring_offsets, dtype=np.dtype(np.uint32)).to_pylibcudf(
             mode="read"
         ),
         linestring_points_x,

--- a/python/cuspatial/cuspatial/core/spatial/nearest_points.py
+++ b/python/cuspatial/cuspatial/core/spatial/nearest_points.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
+import numpy as np
+
 import cudf
 from cudf.core.column import ColumnBase, as_column
 
@@ -104,7 +106,9 @@ def pairwise_point_linestring_nearest_points(
     )
 
     if not point_geometry_id:
-        point_geometry_id = as_column(0, length=len(points), dtype="int32")
+        point_geometry_id = as_column(
+            0, length=len(points), dtype=np.dtype(np.int32)
+        )
     else:
         point_geometry_id = ColumnBase.from_pylibcudf(point_geometry_id)
 

--- a/python/cuspatial/cuspatial/core/trajectory.py
+++ b/python/cuspatial/cuspatial/core/trajectory.py
@@ -64,7 +64,7 @@ def derive_trajectories(object_ids, points: GeoSeries, timestamps):
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+    object_ids = as_column(object_ids, dtype=np.dtype(np.int32)).to_pylibcudf(
         mode="read"
     )
     xs = as_column(points.points.x).to_pylibcudf(mode="read")
@@ -150,7 +150,7 @@ def trajectory_bounding_boxes(num_trajectories, object_ids, points: GeoSeries):
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+    object_ids = as_column(object_ids, dtype=np.dtype(np.int32)).to_pylibcudf(
         mode="read"
     )
     xs = as_column(points.points.x).to_pylibcudf(mode="read")
@@ -215,7 +215,7 @@ def trajectory_distances_and_speeds(
     if len(points) > 0 and not contains_only_points(points):
         raise ValueError("`points` must only contain point geometries.")
 
-    object_ids = as_column(object_ids, dtype=np.int32).to_pylibcudf(
+    object_ids = as_column(object_ids, dtype=np.dtype(np.int32)).to_pylibcudf(
         mode="read"
     )
     xs = as_column(points.points.x).to_pylibcudf(mode="read")

--- a/python/cuspatial/cuspatial/utils/column_utils.py
+++ b/python/cuspatial/cuspatial/utils/column_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 from typing import TypeVar
 
@@ -39,7 +39,7 @@ def normalize_point_columns(*cols):
     return (x.astype(dtype) for x in cols)
 
 
-def normalize_timestamp_column(ts, fallback_dtype="datetime64[ms]"):
+def normalize_timestamp_column(ts, fallback_dtype=np.dtype("datetime64[ms]")):
     """
     Normalize the input timestamp column to one of the cuDF timestamp dtypes.
 


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/pull/17978 required dtype objects to be passed around when converting types of cuDF column (to avoid overhead of parsing dtype strings).

This PR aligns with that change by passing dtype objects when calling `as_column`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
