### PR TITLE
Define cuproj before cudf to avoid conflicting dependencies.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -103,6 +103,12 @@ include(cmake/Modules/ConfigureCUDA.cmake)
 
 # add third party dependencies using CPM
 rapids_cpm_init()
+
+# Add cuProj before any dependencies, because it needs to define proj before cudf defines zstd.
+# This avoids a bug where both of those dependencies specify conflicting
+# `uninstall` targets.
+add_subdirectory(cuproj)
+
 # find or add cuDF
 include(cmake/thirdparty/get_cudf.cmake)
 # find or install GoogleTest
@@ -115,9 +121,6 @@ include (cmake/thirdparty/get_ranger.cmake)
 
 ###################################################################################################
 # - library targets -------------------------------------------------------------------------------
-
-# cuProj
-add_subdirectory(cuproj)
 
 add_library(cuspatial
     src/bounding_boxes/linestring_bounding_boxes.cu

--- a/cpp/cuproj/CMakeLists.txt
+++ b/cpp/cuproj/CMakeLists.txt
@@ -91,6 +91,7 @@ include(cmake/modules/ConfigureCUDA.cmake)
 # add third party dependencies using CPM
 rapids_cpm_init()
 
+include(cmake/thirdparty/get_nvtx.cmake)
 include(cmake/thirdparty/get_rmm.cmake)
 
 # find or install GoogleTest and Proj

--- a/cpp/cuproj/cmake/thirdparty/get_nvtx.cmake
+++ b/cpp/cuproj/cmake/thirdparty/get_nvtx.cmake
@@ -1,0 +1,25 @@
+# =============================================================================
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+# Need to call rapids_cpm_nvtx3 to get support for an installed version of nvtx3 and to support
+# installing it ourselves
+function(find_and_configure_nvtx)
+  include(${rapids-cmake-dir}/cpm/nvtx3.cmake)
+
+  # Find or install nvtx3
+  rapids_cpm_nvtx3(BUILD_EXPORT_SET cuproj-exports INSTALL_EXPORT_SET cuproj-exports)
+
+endfunction()
+
+find_and_configure_nvtx()

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -33,4 +33,9 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJ
     "${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake"
   )
 endif()
+
+# TODO: Remove this temporary branch
+set(rapids-cmake-repo KyleFromNVIDIA/rapids-cmake)
+set(rapids-cmake-branch fix-nvtx3-export)
+
 include("${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")


### PR DESCRIPTION
## Description
@isVoid observed a CMake configuration issue:

```
CMake Error at build/pip/cuda-12.8/release/_deps/proj-src/CMakeLists.txt:403 (add_custom_target):
  add_custom_target cannot create target "uninstall" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory
  "/home/coder/cuspatial/cpp/build/pip/cuda-12.8/release/_deps/zstd-src/build/cmake/lib".
  See documentation for policy CMP0002 for more details.
```

This is a conflict between the CMake code for `proj` and the CMake code for `zstd` (added as a dependency of `cudf` in https://github.com/rapidsai/cudf/pull/17935).

Both `zstd` here https://github.com/facebook/zstd/blob/eca205fc7849a61ab287492931a04960ac58e031/build/cmake/lib/CMakeLists.txt#L287 and `proj` here https://github.com/OSGeo/PROJ/blob/master/CMakeLists.txt#L492 define the same target named `uninstall`.

The `zstd` dependency comes from `cudf`, and the `proj` dependency comes from `cuproj`. However, `zstd` has `if (NOT TARGET uninstall)` guarding its creation of the target. This PR attempts to work around the problem by defining `cuproj` targets before finding `cudf`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.