### PR TITLE
Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_libcuspatial.sh
+      package-type: cpp
+      wheel-name: libcuspatial
   wheel-publish-libcuspatial:
     needs: wheel-build-libcuspatial
     secrets: inherit
@@ -98,6 +100,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cuspatial.sh
+      package-type: python
+      wheel-name: cuspatial
   wheel-publish-cuspatial:
     needs: wheel-build-cuspatial
     secrets: inherit
@@ -118,6 +122,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cuproj.sh
+      package-type: python
+      wheel-name: cuproj
   wheel-publish-cuproj:
     needs: wheel-build-cuproj
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -159,6 +159,8 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: pull-request
       script: ci/build_wheel_libcuspatial.sh
+      package-type: cpp
+      wheel-name: libcuspatial
   wheel-build-cuspatial:
     needs: [checks, wheel-build-libcuspatial]
     secrets: inherit
@@ -166,6 +168,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_cuspatial.sh
+      package-type: python
+      wheel-name: cuspatial
   wheel-tests-cuspatial:
     needs: [wheel-build-cuspatial, changed-files]
     secrets: inherit
@@ -181,6 +185,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_cuproj.sh
+      package-type: python
+      wheel-name: cuproj
   wheel-tests-cuproj:
     needs: [wheel-build-cuspatial, wheel-build-cuproj, changed-files]
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,7 +7,6 @@ package_name=$1
 package_dir=$2
 package_type=$3
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
 # The 'libcuspatial' wheel should package 'libcuspatial.so', and all others
 # should exclude it (they dynamically load it if they need it).
 #
@@ -48,9 +47,10 @@ rapids-pip-retry wheel \
 
 sccache --show-adv-stats
 
+# repair wheels and write to the location that artifact-uploading code expects to find them
 python -m auditwheel repair \
     "${EXCLUDE_ARGS[@]}" \
-    -w "${wheel_dir}" \
+    -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     dist/*
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 "${package_type}" "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 "${package_type}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,6 +7,7 @@ package_name=$1
 package_dir=$2
 package_type=$3
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
 # The 'libcuspatial' wheel should package 'libcuspatial.so', and all others
 # should exclude it (they dynamically load it if they need it).
 #
@@ -47,10 +48,9 @@ rapids-pip-retry wheel \
 
 sccache --show-adv-stats
 
-mkdir -p final_dist
 python -m auditwheel repair \
     "${EXCLUDE_ARGS[@]}" \
-    -w final_dist \
+    -w "${wheel_dir}" \
     dist/*
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 "${package_type}" final_dist
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 "${package_type}" "${wheel_dir}"

--- a/ci/build_wheel_cuproj.sh
+++ b/ci/build_wheel_cuproj.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_wheel_cuproj.sh
+++ b/ci/build_wheel_cuproj.sh
@@ -5,5 +5,7 @@ set -euo pipefail
 
 package_dir="python/cuproj"
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 ci/build_wheel.sh cuproj ${package_dir} python
-ci/validate_wheel.sh ${package_dir} final_dist
+ci/validate_wheel.sh ${package_dir} "${wheel_dir}"

--- a/ci/build_wheel_cuproj.sh
+++ b/ci/build_wheel_cuproj.sh
@@ -5,7 +5,5 @@ set -euo pipefail
 
 package_dir="python/cuproj"
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 ci/build_wheel.sh cuproj ${package_dir} python
-ci/validate_wheel.sh ${package_dir} "${wheel_dir}"
+ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_cuspatial.sh
+++ b/ci/build_wheel_cuspatial.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 package_dir="python/cuspatial"
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Downloads libcuspatial wheel from this current build,
@@ -19,4 +17,4 @@ echo "libcuspatial-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo /tmp/libcuspatial_di
 export PIP_CONSTRAINT="/tmp/constraints.txt"
 
 ci/build_wheel.sh cuspatial ${package_dir} python
-ci/validate_wheel.sh ${package_dir} "${wheel_dir}"
+ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_cuspatial.sh
+++ b/ci/build_wheel_cuspatial.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 package_dir="python/cuspatial"
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # Downloads libcuspatial wheel from this current build,
@@ -17,4 +19,4 @@ echo "libcuspatial-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo /tmp/libcuspatial_di
 export PIP_CONSTRAINT="/tmp/constraints.txt"
 
 ci/build_wheel.sh cuspatial ${package_dir} python
-ci/validate_wheel.sh ${package_dir} final_dist
+ci/validate_wheel.sh ${package_dir} "${wheel_dir}"

--- a/ci/build_wheel_libcuspatial.sh
+++ b/ci/build_wheel_libcuspatial.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 package_dir="python/libcuspatial"
 package_name="libcuspatial"
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 rapids-logger "Generating build requirements"
 matrix_selectors="cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true"
 
@@ -29,4 +27,4 @@ rapids-pip-retry install \
 export PIP_NO_BUILD_ISOLATION=0
 
 ci/build_wheel.sh "${package_name}" ${package_dir} cpp
-ci/validate_wheel.sh ${package_dir} "${wheel_dir}"
+ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_libcuspatial.sh
+++ b/ci/build_wheel_libcuspatial.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 package_dir="python/libcuspatial"
 package_name="libcuspatial"
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 rapids-logger "Generating build requirements"
 matrix_selectors="cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};cuda_suffixed=true"
 
@@ -27,4 +29,4 @@ rapids-pip-retry install \
 export PIP_NO_BUILD_ISOLATION=0
 
 ci/build_wheel.sh "${package_name}" ${package_dir} cpp
-ci/validate_wheel.sh ${package_dir} final_dist
+ci/validate_wheel.sh ${package_dir} "${wheel_dir}"


### PR DESCRIPTION
This work is towards moving build artifacts from downloads.rapids.ai to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

As part of these changes, all wheel builds need to be in a specified temporary directory indicated by the environment variable `RAPIDS_WHEEL_BLD_OUTPUT_DIR` set on the `ci-wheel` Docker image used for building wheels. This lets us upload all wheel artifacts seamlessly to Github Artifacts.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
