### PR TITLE
fix(proj): update patch to version 9.6.0

### DIFF
--- a/cpp/cuproj/cmake/patches/proj.patch
+++ b/cpp/cuproj/cmake/patches/proj.patch
@@ -1,7 +1,7 @@
 From 4f83ac5a1abdd7833faaae0a8d36bafd3560b55e Mon Sep 17 00:00:00 2001
 From: Gil Forsyth <gforsyth@nvidia.com>
 Date: Tue, 8 Apr 2025 14:19:05 -0400
-Subject: [PATCH] [PATCH] remove uninstall target
+Subject: [PATCH] remove uninstall target
 
 ---
  CMakeLists.txt | 1 -

--- a/cpp/cuproj/cmake/patches/proj.patch
+++ b/cpp/cuproj/cmake/patches/proj.patch
@@ -1,23 +1,22 @@
-From 420df6db01107cf7ec5735a9763de719e60b0f38 Mon Sep 17 00:00:00 2001
-From: Kyle Edwards <kyedwards@nvidia.com>
-Date: Tue, 25 Mar 2025 12:42:19 -0400
-Subject: [PATCH] Remove uninstall target
+From 4f83ac5a1abdd7833faaae0a8d36bafd3560b55e Mon Sep 17 00:00:00 2001
+From: Gil Forsyth <gforsyth@nvidia.com>
+Date: Tue, 8 Apr 2025 14:19:05 -0400
+Subject: [PATCH] [PATCH] remove uninstall target
 
-This is interfering with other projects that also have an uninstall
-target.
 ---
  CMakeLists.txt | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ed7e5bc8..cdd05256 100644
+index af13b63d..7fa4494b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -400,4 +400,3 @@ if(NOT _is_multi_config_generator)
+@@ -489,6 +489,5 @@ if(NOT _is_multi_config_generator)
  endif()
- 
+
  configure_file(cmake/uninstall.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/proj_uninstall.cmake @ONLY)
 -add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/proj_uninstall.cmake)
--- 
-2.34.1
 
+ message(STATUS "EMBED_RESOURCE_FILES=${EMBED_RESOURCE_FILES}")
+--
+2.47.0

--- a/cpp/cuproj/cmake/patches/proj_override.json
+++ b/cpp/cuproj/cmake/patches/proj_override.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     "PROJ": {
-      "version": "9.2.0",
+      "version": "9.6.0",
       "git_url": "https://github.com/osgeo/proj.git",
       "git_tag": "${version}",
       "patches": [

--- a/cpp/cuproj/cmake/thirdparty/get_proj.cmake
+++ b/cpp/cuproj/cmake/thirdparty/get_proj.cmake
@@ -58,4 +58,4 @@ function(find_and_configure_proj)
 
 endfunction()
 
-find_and_configure_proj(9.2.0)
+find_and_configure_proj(9.6.0)


### PR DESCRIPTION
## Description

The `conda` devcontainer is building fine with `proj` 9.6.0, but the `pip` one
is failing because of cmake version restrictions on 9.2.0 -- this bumps the
version of `proj` we pull down via `cpm` and updates the patch to remove the
uninstall target.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cuspatial/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
