### PR TITLE
Vendor RAPIDS.cmake

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -94,7 +94,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.06
     with:
       enable_check_generated_files: false
-      ignored_pr_jobs: telemetry-summarize
+      ignored_pr_jobs: telemetry-summarize check-nightly-ci
   conda-cpp-build:
     needs: checks
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   pr-builder:
     needs:
-      - check-nightly-ci
       - changed-files
       - checks
       - conda-cpp-build

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb ZipCodes_Stops_PiP_cuSpatial.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -29,7 +29,7 @@ NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 
 # Add notebooks that should be skipped here
 # (space-separated list of filenames without paths)
-SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb ZipCodes_Stops_PiP_cuSpatial.ipynb"
+SKIPNBS="binary_predicates.ipynb cuproj_benchmark.ipynb trajectory_clustering.ipynb ZipCodes_Stops_PiP_cuSpatial.ipynb"
 
 EXITCODE=0
 trap "EXITCODE=1" ERR

--- a/cmake/RAPIDS.cmake
+++ b/cmake/RAPIDS.cmake
@@ -1,0 +1,90 @@
+# =============================================================================
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+#
+# This is the preferred entry point for projects using rapids-cmake
+#
+# Enforce the minimum required CMake version for all users
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+
+# Allow users to control which version is used
+if(NOT rapids-cmake-version OR NOT rapids-cmake-version MATCHES [[^([0-9][0-9])\.([0-9][0-9])$]])
+  message(
+    FATAL_ERROR "The CMake variable rapids-cmake-version must be defined in the format MAJOR.MINOR."
+  )
+endif()
+
+# Allow users to control which GitHub repo is fetched
+if(NOT rapids-cmake-repo)
+  # Define a default repo if the user doesn't set one
+  set(rapids-cmake-repo rapidsai/rapids-cmake)
+endif()
+
+# Allow users to control which branch is fetched
+if(NOT rapids-cmake-branch)
+  # Define a default branch if the user doesn't set one
+  set(rapids-cmake-branch "branch-${rapids-cmake-version}")
+endif()
+
+# Allow users to control the exact URL passed to FetchContent
+if(NOT rapids-cmake-url)
+  # Construct a default URL if the user doesn't set one
+  set(rapids-cmake-url "https://github.com/${rapids-cmake-repo}/")
+
+  # In order of specificity
+  if(rapids-cmake-fetch-via-git)
+    if(rapids-cmake-sha)
+      # An exact git SHA takes precedence over anything
+      set(rapids-cmake-value-to-clone "${rapids-cmake-sha}")
+    elseif(rapids-cmake-tag)
+      # Followed by a git tag name
+      set(rapids-cmake-value-to-clone "${rapids-cmake-tag}")
+    else()
+      # Or if neither of the above two were defined, use a branch
+      set(rapids-cmake-value-to-clone "${rapids-cmake-branch}")
+    endif()
+  else()
+    if(rapids-cmake-sha)
+      # An exact git SHA takes precedence over anything
+      set(rapids-cmake-value-to-clone "archive/${rapids-cmake-sha}.zip")
+    elseif(rapids-cmake-tag)
+      # Followed by a git tag name
+      set(rapids-cmake-value-to-clone "archive/refs/tags/${rapids-cmake-tag}.zip")
+    else()
+      # Or if neither of the above two were defined, use a branch
+      set(rapids-cmake-value-to-clone "archive/refs/heads/${rapids-cmake-branch}.zip")
+    endif()
+  endif()
+endif()
+
+include(FetchContent)
+if(rapids-cmake-fetch-via-git)
+  FetchContent_Declare(
+    rapids-cmake
+    GIT_REPOSITORY "${rapids-cmake-url}"
+    GIT_TAG "${rapids-cmake-value-to-clone}"
+  )
+else()
+  string(APPEND rapids-cmake-url "${rapids-cmake-value-to-clone}")
+  FetchContent_Declare(rapids-cmake URL "${rapids-cmake-url}")
+endif()
+FetchContent_GetProperties(rapids-cmake)
+if(rapids-cmake_POPULATED)
+  # Something else has already populated rapids-cmake, only thing we need to do is setup the
+  # CMAKE_MODULE_PATH
+  if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)
+    list(APPEND CMAKE_MODULE_PATH "${rapids-cmake-dir}")
+  endif()
+else()
+  FetchContent_MakeAvailable(rapids-cmake)
+endif()

--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _rapids_version)
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")
   set(RAPIDS_VERSION_MINOR "${CMAKE_MATCH_2}")
@@ -26,11 +26,5 @@ else()
   )
 endif()
 
-if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
-  file(
-    DOWNLOAD
-    "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_MAJOR_MINOR}/RAPIDS.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake"
-  )
-endif()
-include("${CMAKE_CURRENT_BINARY_DIR}/CUSPATIAL_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
+set(rapids-cmake-version "${RAPIDS_VERSION_MAJOR_MINOR}")
+include("${CMAKE_CURRENT_LIST_DIR}/RAPIDS.cmake")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../rapids_config.cmake)
+include(../cmake/rapids_config.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -202,6 +202,10 @@ endif()
 # Define spdlog level
 target_compile_definitions(cuspatial PUBLIC "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")
 
+# Remove this after upgrading to a CCCL that has a proper CMake option. See
+# https://github.com/NVIDIA/cccl/pull/2844
+target_compile_definitions(cuspatial PRIVATE THRUST_FORCE_32_BIT_OFFSET_TYPE=1 CCCL_AVOID_SORT_UNROLL=1)
+
 # Specify the target module library dependencies
 target_link_libraries(cuspatial PUBLIC cudf::cudf)
 target_link_libraries(cuspatial PRIVATE ranger::ranger)

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ target_link_libraries(cuspatial_benchmark_common
     PUBLIC benchmark::benchmark
            cudf::cudftestutil
            ranger::ranger
-           cuspatial GTest::gtest GTest::gmock 
+           cuspatial GTest::gtest GTest::gmock
            PRIVATE cudf::cudftestutil_impl)
 
 target_compile_options(cuspatial_benchmark_common
@@ -55,6 +55,9 @@ target_include_directories(cuspatial_benchmark_common
 
 function(ConfigureBench CMAKE_BENCH_NAME)
     add_executable(${CMAKE_BENCH_NAME} ${ARGN})
+    target_compile_definitions(
+      ${CMAKE_BENCH_NAME} PRIVATE THRUST_FORCE_32_BIT_OFFSET_TYPE=1 CCCL_AVOID_SORT_UNROLL=1
+    )
     set_target_properties(${CMAKE_BENCH_NAME}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUSPATIAL_BINARY_DIR}/benchmarks>"
                    INSTALL_RPATH "\$ORIGIN/../../../lib"

--- a/cpp/cuproj/CMakeLists.txt
+++ b/cpp/cuproj/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../rapids_config.cmake)
+include(../../cmake/rapids_config.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ﻿#=============================================================================
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
-# cudftestutil_impl is an interface source library, this empty object 
-# library is used to speed-up compilation and linking against it, 
+# cudftestutil_impl is an interface source library, this empty object
+# library is used to speed-up compilation and linking against it,
 # otherwise we pay the non-trivial compilation cost repeatedly for each
 # test executable
 add_library(cuspatial_test_common OBJECT test_common.cpp)
@@ -37,7 +37,7 @@ set_target_properties(cuspatial_test_common
 )
 
 target_link_libraries(cuspatial_test_common
-    PUBLIC cudf::cudftestutil GTest::gtest GTest::gmock 
+    PUBLIC cudf::cudftestutil GTest::gtest GTest::gmock
     PRIVATE cudf::cudftestutil_impl)
 
 target_compile_options(cuspatial_test_common PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUSPATIAL_CXX_FLAGS}>"
@@ -45,6 +45,9 @@ target_compile_options(cuspatial_test_common PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:$
 
 function(ConfigureTest CMAKE_TEST_NAME)
     add_executable(${CMAKE_TEST_NAME} ${ARGN})
+    target_compile_definitions(
+      ${CMAKE_TEST_NAME} PRIVATE THRUST_FORCE_32_BIT_OFFSET_TYPE=1 CCCL_AVOID_SORT_UNROLL=1
+    )
     target_compile_options(${CMAKE_TEST_NAME}
                 PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUSPATIAL_CXX_FLAGS}>"
                         "$<$<COMPILE_LANGUAGE:CUDA>:${CUSPATIAL_CUDA_FLAGS}>")

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../../../rapids_config.cmake)
+include(../../../../cmake/rapids_config.cmake)
 
 # TODO: The logic for setting the architectures was previously not here. Was
 # that just an oversight, or is there a reason not to include this here?

--- a/python/cuproj/CMakeLists.txt
+++ b/python/cuproj/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../rapids_config.cmake)
+include(../../cmake/rapids_config.cmake)
 include(rapids-cuda)
 rapids_cuda_init_architectures(cuproj-python)
 

--- a/python/cuproj/cuproj/cuprojshim/CMakeLists.txt
+++ b/python/cuproj/cuproj/cuprojshim/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../../../rapids_config.cmake)
+include(../../../../cmake/rapids_config.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)

--- a/python/cuspatial/CMakeLists.txt
+++ b/python/cuspatial/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../rapids_config.cmake)
+include(../../cmake/rapids_config.cmake)
 include(rapids-cuda)
 rapids_cuda_init_architectures(cuspatial-python)
 

--- a/python/cuspatial/cuspatial/core/geodataframe.py
+++ b/python/cuspatial/cuspatial/core/geodataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION
+# Copyright (c) 2020-2025, NVIDIA CORPORATION
 from __future__ import annotations
 
 from typing import Any, Dict, TypeVar, Union
@@ -51,8 +51,8 @@ class GeoDataFrame(cudf.DataFrame):
                     data[key] = GeoSeries(data[key])
                 except TypeError:
                     pass
-            super()._init_from_dict_like(
-                data, index=self.index if len(self.index) > 0 else None
+            super().__init__(
+                data=data, index=self.index if len(self.index) > 0 else None
             )
         elif data is None:
             pass

--- a/python/cuspatial/cuspatial/core/geoseries.py
+++ b/python/cuspatial/cuspatial/core/geoseries.py
@@ -355,14 +355,14 @@ class GeoSeries(cudf.Series):
             self._sr = _sr
 
         def __getitem__(self, item):
-            booltest = cudf.Series(item)
-            if booltest.dtype in (bool, np.bool_):
+            series = cudf.Series(item)
+            if series.dtype in (bool, np.bool_):
                 return self._sr.iloc[item]
 
             map_df = cudf.DataFrame(
                 {"map": self._sr.index, "idx": cp.arange(len(self._sr.index))}
             )
-            index_df = cudf.DataFrame({"map": item}).reset_index()
+            index_df = cudf.DataFrame({"map": series}).reset_index()
             new_index = index_df.merge(
                 map_df, how="left", sort=False
             ).sort_values("index")

--- a/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
+++ b/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 import numpy as np
 

--- a/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
+++ b/python/cuspatial/cuspatial/tests/spatial/join/test_point_in_polygon.py
@@ -27,7 +27,7 @@ def test_one_point_in():
             cudf.Series([0, 1]),
         ),
     )
-    expected = cudf.DataFrame({0: True})
+    expected = cudf.DataFrame({0: [True]})
     cudf.testing.assert_frame_equal(expected, result)
 
 
@@ -41,7 +41,7 @@ def test_one_point_out():
             cudf.Series([0, 1]),
         ),
     )
-    expected = cudf.DataFrame({0: False})
+    expected = cudf.DataFrame({0: [False]})
     cudf.testing.assert_frame_equal(expected, result)
 
 
@@ -60,7 +60,7 @@ def test_one_point_in_two_rings():
         ),
     )
 
-    expected = cudf.DataFrame({0: True})
+    expected = cudf.DataFrame({0: [True]})
     cudf.testing.assert_frame_equal(expected, result)
 
 
@@ -80,7 +80,7 @@ def test_one_point_in_two_unclosed_rings():
             cudf.Series([0, 1]),
         ),
     )
-    expected = cudf.DataFrame({0: True})
+    expected = cudf.DataFrame({0: [True]})
     cudf.testing.assert_frame_equal(expected, result)
 
 
@@ -97,7 +97,7 @@ def test_one_point_out_two_rings():
             cudf.Series([0, 1]),
         ),
     )
-    expected = cudf.DataFrame({0: False})
+    expected = cudf.DataFrame({0: [False]})
     cudf.testing.assert_frame_equal(expected, result)
 
 
@@ -117,7 +117,7 @@ def test_one_point_out_two_unclosed_rings():
             cudf.Series([0, 1]),
         ),
     )
-    expected = cudf.DataFrame({0: False})
+    expected = cudf.DataFrame({0: [False]})
     cudf.testing.assert_frame_equal(expected, result)
 
 

--- a/python/libcuspatial/CMakeLists.txt
+++ b/python/libcuspatial/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
-include(../../rapids_config.cmake)
+include(../../cmake/rapids_config.cmake)
 
 project(
   libcuspatial-python


### PR DESCRIPTION
This works around a problem where GitHub is rejecting requests to the `githubusercontent.com` CDN. We vendor the contents of `RAPIDS.cmake` from `rapidsai/rapids-cmake` to avoid a network call.

xref: https://github.com/rapidsai/rapids-cmake/pull/809
xref: https://github.com/rapidsai/build-infra/issues/206
