### PR TITLE
add note about the repo being archived [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]  
+> The final release of this project was `v25.04`.
+> See https://docs.rapids.ai/notices/rsn0045/ for details.
+
 # <div align="left"><img src="https://rapids.ai/assets/images/rapids_logo.png" width="90px"/>&nbsp;cuSpatial - GPU-Accelerated Vector Geospatial Data Analysis</div>
 
 > **Note**


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/197

Proposes adding a note to the README explaining that the project is no longer under active development.

## Notes for Reviewers

Targeting this at `branch-25.04` because that is the default branch in the repo (the final one we released from).

I'll ask for an admin merge of this, so used `[skip ci]` to save resources.

Here is how this notice renders in GitHub:

<img width="937" height="628" alt="Screenshot 2025-07-28 at 4 21 37 PM" src="https://github.com/user-attachments/assets/875df97d-b74c-4c4d-b384-2d2cead1ac4c" />

ref: https://github.com/jameslamb/cuspatial/tree/docs/archive